### PR TITLE
feat: add Recently Completed section to home page

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -97,6 +97,17 @@ export async function fetchJobs(params?: { category?: string; status?: string; l
 }
 
 /**
+ * Fetches the most recently completed jobs for social proof on the home page.
+ *
+ * @param limit Number of completed jobs to fetch (default 3).
+ * @returns Array of completed jobs, newest first.
+ */
+export async function fetchRecentlyCompletedJobs(limit = 3): Promise<Job[]> {
+  const { jobs } = await fetchJobs({ status: "completed", limit });
+  return jobs;
+}
+
+/**
  * Fetches a single job by its identifier.
  *
  * @param id Job identifier.

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -4,11 +4,30 @@
  */
 import Link from "next/link";
 import { useState } from "react";
+import type { GetStaticProps } from "next";
 import WalletConnect from "@/components/WalletConnect";
+import { fetchRecentlyCompletedJobs } from "@/lib/api";
+import { formatXLM } from "@/utils/format";
+import type { Job } from "@/utils/types";
+
+// Category → emoji icon mapping for compact cards
+const CATEGORY_ICONS: Record<string, string> = {
+  "Smart Contracts": "📜",
+  "Frontend Development": "🖥️",
+  "Backend Development": "⚙️",
+  "UI/UX Design": "🎨",
+  "Technical Writing": "✍️",
+  "DevOps": "🚀",
+  "Security Audit": "🔐",
+  "Data Analysis": "📊",
+  "Mobile Development": "📱",
+  "Other": "💼",
+};
 
 interface HomeProps {
   publicKey: string | null;
   onConnect: (pk: string) => void;
+  completedJobs: Job[];
 }
 
 const STEPS = [
@@ -30,7 +49,7 @@ const CATEGORIES = [
   "DevOps", "Data Analysis",
 ];
 
-export default function Home({ publicKey, onConnect }: HomeProps) {
+export default function Home({ publicKey, onConnect, completedJobs }: HomeProps) {
   const [showConnect, setShowConnect] = useState(false);
 
   return (
@@ -118,6 +137,52 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
           </div>
         </div>
 
+        {/* ── Recently Completed ──────────────────────────────────────────── */}
+        <div className="mb-20">
+          <div className="flex items-center justify-between mb-8">
+            <div>
+              <h2 className="font-display text-3xl font-bold text-amber-100 mb-1">Recently Completed</h2>
+              <p className="text-amber-800 text-sm font-body">Real work, real payments — settled on Stellar.</p>
+            </div>
+            <Link href="/jobs?status=completed"
+              className="text-sm text-market-400 hover:text-market-300 transition-colors font-body whitespace-nowrap">
+              View all completed work →
+            </Link>
+          </div>
+
+          {completedJobs.length === 0 ? (
+            <div className="card text-center py-12">
+              <p className="text-3xl mb-3">🏁</p>
+              <p className="text-amber-700 font-body text-sm">No completed jobs yet — be the first to finish one.</p>
+            </div>
+          ) : (
+            <div className="grid sm:grid-cols-3 gap-4">
+              {completedJobs.map((job) => (
+                <Link key={job.id} href={`/jobs/${job.id}`}>
+                  <div className="card group hover:border-market-500/25 transition-all h-full flex flex-col">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-xl" aria-hidden="true">
+                        {CATEGORY_ICONS[job.category] ?? "💼"}
+                      </span>
+                      <span className="text-xs text-amber-800 font-body truncate">{job.category}</span>
+                      <span className="ml-auto flex-shrink-0 inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2 py-0.5 rounded-full">
+                        ✓ Done
+                      </span>
+                    </div>
+                    <h3 className="font-display font-semibold text-amber-200 text-sm leading-snug group-hover:text-market-300 transition-colors line-clamp-2 mb-3 flex-1">
+                      {job.title}
+                    </h3>
+                    <div className="pt-2 border-t border-[rgba(251,191,36,0.07)]">
+                      <p className="text-xs text-amber-800 mb-0.5">Budget</p>
+                      <p className="font-mono font-semibold text-market-400 text-sm">{formatXLM(job.budget)}</p>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+
         {/* ── Why Stellar ─────────────────────────────────────────────────── */}
         <div className="card mb-20 bg-gradient-to-br from-ink-800 to-ink-900 border-market-500/18">
           <div className="max-w-3xl mx-auto text-center">
@@ -165,3 +230,16 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
     </div>
   );
 }
+
+export const getStaticProps: GetStaticProps = async () => {
+  let completedJobs: Job[] = [];
+  try {
+    completedJobs = await fetchRecentlyCompletedJobs(3);
+  } catch {
+    // Backend may be unavailable at build time — render empty state gracefully
+  }
+  return {
+    props: { completedJobs },
+    revalidate: 60, // ISR: refresh every 60 seconds
+  };
+};


### PR DESCRIPTION
- Add fetchRecentlyCompletedJobs() helper to api.ts
- Fetch last 3 completed jobs via GET /api/jobs?status=completed&limit=3
- Display compact 3-column cards with category icon, title, and budget
- Add View all completed work link to /jobs?status=completed
- Handle empty state gracefully
- Use getStaticProps with ISR (revalidate: 60s) for server-side fetch

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #79

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
