### PR TITLE
Add application success rate and response time stats to freelancer pr…

### DIFF
--- a/backend/src/routes/profiles.js
+++ b/backend/src/routes/profiles.js
@@ -9,10 +9,20 @@ const { createRateLimiter } = require("../middleware/rateLimiter");
 const profileUpdateRateLimiter = createRateLimiter(5, 1); // 5 profile updates per minute
 const generalProfileRateLimiter = createRateLimiter(30, 1); // 100 requests per minute for getting profiles
 
-const { getProfile, upsertProfile, updateAvailability } = require("../services/profileService");
+const { getProfile, upsertProfile, updateAvailability, getProfileStats, getResponseTime } = require("../services/profileService");
 
 router.get("/:publicKey", generalProfileRateLimiter ,async (req, res, next) => {
   try { res.json({ success: true, data: await getProfile(req.params.publicKey) }); }
+  catch (e) { next(e); }
+});
+
+router.get("/:publicKey/stats", generalProfileRateLimiter, async (req, res, next) => {
+  try { res.json({ success: true, data: await getProfileStats(req.params.publicKey) }); }
+  catch (e) { next(e); }
+});
+
+router.get("/:publicKey/response-time", generalProfileRateLimiter, async (req, res, next) => {
+  try { res.json({ success: true, data: await getResponseTime(req.params.publicKey) }); }
   catch (e) { next(e); }
 });
 

--- a/backend/src/services/profileService.js
+++ b/backend/src/services/profileService.js
@@ -256,10 +256,59 @@ async function updateAvailability(publicKey, availability) {
   return rowToProfile(rows[0]);
 }
 
+async function getProfileStats(publicKey) {
+  validatePublicKey(publicKey);
+
+  const { rows } = await pool.query(
+    `SELECT 
+       COUNT(*)::int AS total_applications,
+       COUNT(CASE WHEN status = 'accepted' THEN 1 END)::int AS accepted_applications
+     FROM applications
+     WHERE freelancer_address = $1`,
+    [publicKey]
+  );
+
+  const stats = rows[0];
+  const total = stats.total_applications || 0;
+  const accepted = stats.accepted_applications || 0;
+  const successRate = total > 0 ? Math.round((accepted / total) * 100) : 0;
+
+  return {
+    totalApplications: total,
+    acceptedApplications: accepted,
+    successRate
+  };
+}
+
+async function getResponseTime(publicKey) {
+  validatePublicKey(publicKey);
+
+  const { rows } = await pool.query(
+    `SELECT 
+       AVG(EXTRACT(EPOCH FROM (e.released_at - a.accepted_at)) / 86400)::numeric AS avg_days
+     FROM applications a
+     JOIN escrows e ON a.job_id = e.job_id
+     WHERE a.freelancer_address = $1 
+       AND a.status = 'accepted' 
+       AND a.accepted_at IS NOT NULL 
+       AND e.status = 'released' 
+       AND e.released_at IS NOT NULL`,
+    [publicKey]
+  );
+
+  const avgDays = rows[0].avg_days ? parseFloat(rows[0].avg_days) : null;
+
+  return {
+    averageDays: avgDays !== null ? parseFloat(avgDays.toFixed(1)) : null
+  };
+}
+
 module.exports = {
   getProfile,
   upsertProfile,
   updateAvailability,
+  getProfileStats,
+  getResponseTime,
   VALID_PORTFOLIO_TYPES,
   VALID_AVAILABILITY_STATUSES,
   MAX_PORTFOLIO_ITEMS,

--- a/backend/src/services/profileService.test.js
+++ b/backend/src/services/profileService.test.js
@@ -7,6 +7,8 @@ const {
   getProfile,
   upsertProfile,
   updateAvailability,
+  getProfileStats,
+  getResponseTime,
   MAX_PORTFOLIO_ITEMS,
 } = require("./profileService");
 
@@ -199,6 +201,50 @@ describe("profileService", () => {
         availableFrom: "2026-07-01T00:00:00.000Z",
         availableUntil: "2026-07-10T00:00:00.000Z",
       });
+    });
+  });
+
+  describe("getProfileStats", () => {
+    it("returns zero stats when no applications exist", async () => {
+      pool.query.mockResolvedValueOnce({
+        rows: [{ total_applications: 0, accepted_applications: 0 }],
+      });
+
+      const stats = await getProfileStats(publicKey);
+      expect(stats).toEqual({
+        totalApplications: 0,
+        acceptedApplications: 0,
+        successRate: 0,
+      });
+    });
+
+    it("calculates success rate correctly", async () => {
+      pool.query.mockResolvedValueOnce({
+        rows: [{ total_applications: 4, accepted_applications: 3 }],
+      });
+
+      const stats = await getProfileStats(publicKey);
+      expect(stats.successRate).toBe(75);
+    });
+  });
+
+  describe("getResponseTime", () => {
+    it("returns null when no data is available", async () => {
+      pool.query.mockResolvedValueOnce({
+        rows: [{ avg_days: null }],
+      });
+
+      const result = await getResponseTime(publicKey);
+      expect(result.averageDays).toBeNull();
+    });
+
+    it("returns formatted average days", async () => {
+      pool.query.mockResolvedValueOnce({
+        rows: [{ avg_days: "2.4567" }],
+      });
+
+      const result = await getResponseTime(publicKey);
+      expect(result.averageDays).toBe(2.5);
     });
   });
 });

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -18,7 +18,7 @@
  */
 
 import axios from "axios";
-import type { Availability, Job, Application, UserProfile, Rating } from "@/utils/types";
+import type { Availability, Job, Application, UserProfile, Rating, ProfileStats, ResponseTimeStats } from "@/utils/types";
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000",
@@ -323,6 +323,32 @@ export async function updateProfileAvailability(
   const { data } = await api.post<{ success: boolean; data: UserProfile }>(
     `/api/profiles/${encodeURIComponent(publicKey)}/availability`,
     payload
+  );
+  return data.data;
+}
+
+/**
+ * Fetches application statistics for a freelancer profile.
+ *
+ * @param publicKey Freelancer Stellar public key.
+ * @returns Statistics including total applications, accepted count, and success rate.
+ */
+export async function fetchProfileStats(publicKey: string) {
+  const { data } = await api.get<{ success: boolean; data: ProfileStats }>(
+    `/api/profiles/${encodeURIComponent(publicKey)}/stats`
+  );
+  return data.data;
+}
+
+/**
+ * Fetches the average response time (acceptance to completion) for a freelancer.
+ *
+ * @param publicKey Freelancer Stellar public key.
+ * @returns Average response time in days.
+ */
+export async function fetchResponseTime(publicKey: string) {
+  const { data } = await api.get<{ success: boolean; data: ResponseTimeStats }>(
+    `/api/profiles/${encodeURIComponent(publicKey)}/response-time`
   );
   return data.data;
 }

--- a/frontend/pages/freelancers/[publicKey].tsx
+++ b/frontend/pages/freelancers/[publicKey].tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 import FreelancerTierBadge from "@/components/FreelancerTierBadge";
-import { fetchPublicProfile } from "@/lib/api";
+import { fetchPublicProfile, fetchProfileStats, fetchResponseTime } from "@/lib/api";
 import {
   availabilityStatusLabel,
   availabilitySummary,
@@ -15,7 +15,7 @@ import {
   shortenAddress,
 } from "@/utils/format";
 import { accountUrl, isValidStellarAddress } from "@/lib/stellar";
-import type { AvailabilityStatus, PortfolioItem, UserProfile } from "@/utils/types";
+import type { AvailabilityStatus, PortfolioItem, UserProfile, ProfileStats, ResponseTimeStats } from "@/utils/types";
 
 type LoadState =
   | { status: "loading" }
@@ -54,8 +54,9 @@ function getAvailabilityBadgeClass(status?: AvailabilityStatus | null) {
 export default function PublicFreelancerProfilePage() {
   const router = useRouter();
   const rawKey = typeof router.query.publicKey === "string" ? router.query.publicKey : "";
-
   const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [stats, setStats] = useState<ProfileStats | null>(null);
+  const [responseTime, setResponseTime] = useState<ResponseTimeStats | null>(null);
 
   const titleBase = useMemo(() => {
     if (state.status === "ok" && state.profile.displayName?.trim()) {
@@ -93,10 +94,21 @@ export default function PublicFreelancerProfilePage() {
 
     (async () => {
       try {
-        const profile = await fetchPublicProfile(rawKey);
+        const [profile, profileStats, profileResponseTime] = await Promise.all([
+          fetchPublicProfile(rawKey),
+          fetchProfileStats(rawKey),
+          fetchResponseTime(rawKey)
+        ]);
+
         if (cancelled) return;
-        if (profile === null) setState({ status: "not_found" });
-        else setState({ status: "ok", profile });
+        
+        if (profile === null) {
+          setState({ status: "not_found" });
+        } else {
+          setState({ status: "ok", profile });
+          setStats(profileStats);
+          setResponseTime(profileResponseTime);
+        }
       } catch (error: unknown) {
         if (cancelled) return;
         const message = error instanceof Error ? error.message : "Could not load profile.";
@@ -175,8 +187,13 @@ export default function PublicFreelancerProfilePage() {
                 <h1 className="font-display text-2xl sm:text-3xl font-bold text-amber-100 break-words">
                   {state.profile.displayName?.trim() || shortenAddress(state.profile.publicKey)}
                 </h1>
-                <div className="mt-3">
+                <div className="mt-3 flex flex-wrap gap-2">
                   <FreelancerTierBadge tier={state.profile.tier} className="text-sm" />
+                  {responseTime?.averageDays !== null && responseTime.averageDays <= 3 && (
+                    <span className="inline-flex items-center gap-1 text-xs font-semibold px-2.5 py-0.5 rounded-full bg-market-500/10 text-market-400 border border-market-500/20">
+                      ⚡ Fast Responder
+                    </span>
+                  )}
                 </div>
                 <p className="text-xs sm:text-sm text-amber-800 mt-2 font-mono break-all">
                   {state.profile.publicKey}
@@ -242,6 +259,24 @@ export default function PublicFreelancerProfilePage() {
                 <p className="label mb-1">Average rating</p>
                 <p className="font-display text-2xl sm:text-3xl font-bold text-market-400">
                   {state.profile.rating?.toFixed(2) ?? "New"}
+                </p>
+              </div>
+              <div className="rounded-xl bg-ink-900/50 border border-market-500/10 p-4">
+                <p className="label mb-1">Success rate</p>
+                <p className="font-display text-2xl sm:text-3xl font-bold text-market-400">
+                  {stats ? `${stats.successRate}%` : "—"}
+                </p>
+                <p className="text-[10px] uppercase tracking-wider text-amber-800 mt-1">
+                  {stats?.acceptedApplications || 0} / {stats?.totalApplications || 0} accepted
+                </p>
+              </div>
+              <div className="rounded-xl bg-ink-900/50 border border-market-500/10 p-4">
+                <p className="label mb-1">Avg. completion</p>
+                <p className="font-display text-2xl sm:text-3xl font-bold text-market-400">
+                  {responseTime?.averageDays !== null ? `${responseTime?.averageDays}d` : "—"}
+                </p>
+                <p className="text-[10px] uppercase tracking-wider text-amber-800 mt-1">
+                  Acceptance to release
                 </p>
               </div>
             </div>

--- a/frontend/utils/types.ts
+++ b/frontend/utils/types.ts
@@ -57,6 +57,16 @@ export interface Application {
   createdAt: string;
 }
 
+export interface ProfileStats {
+  totalApplications: number;
+  acceptedApplications: number;
+  successRate: number;
+}
+
+export interface ResponseTimeStats {
+  averageDays: number | null;
+}
+
 export interface UserProfile {
   publicKey: string;
   displayName?: string;


### PR DESCRIPTION
PR #74  Add Freelancer Performance Stats and Fast Responder Badge

## Description
This PR implements new performance metrics for freelancer profiles to give clients better insight into freelancer responsiveness and reliability. It adds on-the-fly computation for application success rates and average turnaround times, along with a visual "Fast Responder" badge for top-performing freelancers.

## Key Changes

### Backend
- **New Service Functions**: Added `getProfileStats` and `getResponseTime` to `profileService.js` to calculate metrics using real-time application and escrow data.
- **New API Endpoints**:
  - `GET /api/profiles/:publicKey/stats`: Returns total applications, accepted count, and success rate.
  - `GET /api/profiles/:publicKey/response-time`: Returns the average days from application acceptance to escrow release.
- **Unit Tests**: Added comprehensive tests in `profileService.test.js` to ensure accurate calculations and graceful handling of empty data sets.

### Frontend
- **Enhanced Type Safety**: Added `ProfileStats` and `ResponseTimeStats` interfaces to the shared type definitions.
- **API Client**: Updated `lib/api.ts` with new methods to fetch the performance data.
- **Profile UI**:
  - Integrated a new statistics section in the freelancer profile grid.
  - Implemented the **"⚡ Fast Responder"** badge for freelancers with an average completion time of ≤ 3 days.
  - Ensured "zero-state" profiles (new freelancers) display clear placeholders instead of errors.

## Verification
- Verified backend logic with new unit tests.
- Confirmed frontend state management correctly handles concurrent API fetches via `Promise.all`.
- Manually checked UI responsiveness and badge logic.

Close PR #74