### PR TITLE
feat(frontend): add 500ms hover preview for job cards (#78)

### DIFF
--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -3,6 +3,7 @@
  * Displays a single job listing in the browse grid.
  */
 import Link from "next/link";
+import { useState, useRef, useEffect } from "react"; // Added for hover logic
 import {
   formatDeadline,
   formatXLM,
@@ -21,15 +22,53 @@ export default function JobCard({ job }: JobCardProps) {
   const { xlmPriceUsd } = usePriceContext();
   const usdEquivalent = formatUSDEquivalent(job.budget, xlmPriceUsd);
 
+  // ── ISSUE #78: Hover Card State & Logic ──────────────────────────────────────────
+  const [showPreview, setShowPreview] = useState(false);
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleMouseEnter = () => {
+    // Check if device has a mouse/pointer (Acceptance Criteria: No popover on touch)
+    if (window.matchMedia("(pointer: fine)").matches) {
+      hoverTimeoutRef.current = setTimeout(() => {
+        setShowPreview(true);
+      }, 500); // 500ms delay requirement
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+    }
+    setShowPreview(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+    };
+  }, []);
+  // ──────────────────────────────────────────────────────────────────────────────────
+
   const hasValidDeadline = Boolean(job.deadline && formatDeadline(job.deadline));
   const formattedDeadline = job.deadline ? formatDeadline(job.deadline) : "";
   const deadlineState = getDeadlineState(job.deadline);
   const isStatusClosed = job.status === "cancelled" || job.status === "completed";
   const showClosedBadge = isStatusClosed || deadlineState === "closed";
   const showClosingSoonBadge = !showClosedBadge && deadlineState === "closing_soon";
+
+  // Helper to get monthly estimate (keeping original logic intact)
+  const getMonthlyEstimate = (budget: string, price: number | null) => {
+    return "Estimated monthly: " + formatUSDEquivalent(budget, price);
+  };
+
   return (
     <Link href={`/jobs/${job.id}`}>
-      <div className="card-hover group animate-fade-in">
+      {/* ── ISSUE #78: Added relative positioning and hover handlers ── */}
+      <div 
+        className="card-hover group animate-fade-in relative cursor-pointer" 
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
         {/* Header row */}
         <div className="flex items-start justify-between gap-3 mb-3">
           <h3 className="font-display font-semibold text-amber-100 text-base leading-snug group-hover:text-market-300 transition-colors line-clamp-2">
@@ -99,11 +138,42 @@ export default function JobCard({ job }: JobCardProps) {
             {job.category}
           </span>
         </div>
+
+        {/* ── ISSUE #78: Floating Hover Preview Card ── */}
+        {showPreview && (
+          <div className="absolute z-50 left-0 top-full mt-2 w-full md:left-full md:top-0 md:mt-0 md:ml-4 md:w-80 animate-in fade-in zoom-in duration-200">
+            <div className="bg-ink-900 border border-market-500/40 p-4 rounded-xl shadow-2xl backdrop-blur-lg">
+              <h4 className="text-market-300 font-semibold text-sm mb-2">Job Preview</h4>
+              <p className="text-amber-100/90 text-xs leading-relaxed mb-3">
+                {job.description.substring(0, 300)}
+                {job.description.length > 300 ? "..." : ""}
+              </p>
+              
+              <div className="mb-3">
+                <p className="text-[10px] text-amber-800 uppercase font-bold mb-1">Required Skills</p>
+                <div className="flex flex-wrap gap-1">
+                  {job.skills.map((s) => (
+                    <span key={s} className="text-[10px] bg-market-500/10 text-market-400 border border-market-500/20 px-1.5 py-0.5 rounded">
+                      {s}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              <div className="pt-2 border-t border-market-500/20">
+                <p className="text-[10px] text-amber-800 mb-0.5 font-bold uppercase">Client Address</p>
+                <p className="text-[10px] font-mono text-amber-100/70 truncate">{job.clientAddress || "Not specified"}</p>
+              </div>
+            </div>
+          </div>
+        )}
+        {/* ───────────────────────────────────────────── */}
       </div>
     </Link>
   );
 }
 
+// ... JobCardSkeleton remains exactly as you shared it below ...
 export function JobCardSkeleton() {
   return (
     <div className="card">


### PR DESCRIPTION
## Description
Implemented a hover-to-preview feature for job listings to reduce unnecessary navigation. Users can now see a detailed preview of a job by hovering over a card for 500ms.

## Key Changes
- **Delayed Hover Logic**: Added a `setTimeout` (500ms) to `onMouseEnter` to prevent accidental triggers while scrolling.
- **Preview Content**: Shows full description (clamped at 300 characters), all required skills, and the client's wallet address.
- **Responsive Positioning**: 
  - **Desktop**: Preview floats to the right of the card.
  - **Mobile**: Preview appears directly below the card.
- **Accessibility**: Logic only triggers on devices with a mouse (`pointer: fine`) to avoid interfering with touch interactions.
- **UI Enhancements**: Added `cursor-pointer` to indicate the card is both hoverable and clickable.

## Verification Checklist
- [x] 500ms delay works as expected.
- [x] Preview dismisses immediately on mouse leave.
- [x] Content is accurately truncated at 300 chars.
- [x] Layout is responsive across breakpoints.

Closes #78