### PR TITLE
feat: post-quality, share link, proposal-min, backend JSDoc (#148, #149, #152, #157)

### DIFF
--- a/backend/src/routes/escrow.js
+++ b/backend/src/routes/escrow.js
@@ -21,10 +21,10 @@ const { getJob, updateJobStatus } = require("../services/jobService");
  * In v1.2 this will call the Soroban contract's release_escrow() function.
  * See ROADMAP.md v1.2 — Escrow Contract (Live).
  */
-router.post("/:jobId/release", (req, res, next) => {
+router.post("/:jobId/release", async (req, res, next) => {
   try {
     const { jobId } = req.params;
-    const { clientAddress, contractTxHash } = req.body;
+    const { clientAddress } = req.body;
 
     if (!clientAddress || !/^G[A-Z0-9]{55}$/.test(clientAddress)) {
       const e = new Error("Invalid client address"); e.status = 400; throw e;

--- a/backend/src/services/applicationService.js
+++ b/backend/src/services/applicationService.js
@@ -1,6 +1,12 @@
 /**
  * src/services/applicationService.js
- * All data persisted in the `applications` PostgreSQL table.
+ *
+ * Applications service — owns all reads and writes against the `applications`
+ * PostgreSQL table. Handles freelancer proposal submission, validation of
+ * screening-question answers, listing applications by job or freelancer, and
+ * the atomic "accept one + reject the rest" transition that hires a freelancer.
+ *
+ * @module services/applicationService
  */
 "use strict";
 
@@ -8,6 +14,42 @@ const pool = require("../db/pool");
 const { getJob, assignFreelancer } = require("./jobService");
 const { calculateFreelancerTier } = require("./profileService");
 
+/**
+ * Camel-cased application record returned by this service.
+ *
+ * @typedef {Object} Application
+ * @property {string} id                 UUID of the application.
+ * @property {string} jobId              UUID of the parent job.
+ * @property {string} freelancerAddress  Stellar G-address of the applicant.
+ * @property {string} freelancerTier     Computed tier label (see `calculateFreelancerTier`).
+ * @property {string} proposal           Cover letter / proposal text (≥50 chars).
+ * @property {string} bidAmount          Bid as a fixed-point string (e.g. "450.0000000").
+ * @property {("XLM"|"USDC")} currency   Bid currency.
+ * @property {("pending"|"accepted"|"rejected")} status
+ * @property {Object<string,string>} screeningAnswers  Map of question → answer.
+ * @property {string} createdAt          ISO timestamp.
+ */
+
+/**
+ * Input shape accepted by {@link submitApplication}.
+ *
+ * @typedef {Object} SubmitApplicationInput
+ * @property {string} jobId
+ * @property {string} freelancerAddress
+ * @property {string} proposal
+ * @property {string|number} bidAmount
+ * @property {("XLM"|"USDC")} [currency="XLM"]
+ * @property {Object<string,string>} [screeningAnswers]  Required only when the parent
+ *                                                       job has screening questions.
+ */
+
+/**
+ * Throws a 400 Error when `key` is not a valid Stellar G-address.
+ *
+ * @param {string} key  Stellar account public key.
+ * @returns {void}
+ * @throws {Error}      `status === 400` if the key fails the G-address regex.
+ */
 function validatePublicKey(key) {
   if (!key || !/^G[A-Z0-9]{55}$/.test(key)) {
     const e = new Error("Invalid Stellar public key");
@@ -16,6 +58,13 @@ function validatePublicKey(key) {
   }
 }
 
+/**
+ * Convert a snake_case `applications` row (joined with profile/rating
+ * aggregates) into the camelCase API object.
+ *
+ * @param {Object} row  Raw DB row.
+ * @returns {Application}
+ */
 function rowToApp(row) {
   const completedJobs = row.completed_jobs ?? 0;
   const freelancerRating =
@@ -35,6 +84,30 @@ function rowToApp(row) {
   };
 }
 
+/**
+ * Submit a freelancer's proposal to a job. Inserts a row in `applications`
+ * and increments the parent job's `applicant_count`. Returns the new
+ * application as a camel-cased {@link Application}.
+ *
+ * @param {SubmitApplicationInput} input
+ * @returns {Promise<Application>}
+ * @throws {Error} 400 — invalid public key, proposal too short, bid not positive,
+ *                       or screening answers missing/incomplete.
+ * @throws {Error} 400 — job is not `open`.
+ * @throws {Error} 400 — applicant is the job's own client.
+ * @throws {Error} 404 — job not found.
+ * @throws {Error} 409 — duplicate application from the same freelancer.
+ *
+ * @example
+ * const application = await submitApplication({
+ *   jobId: "f4d3...e1",
+ *   freelancerAddress: "GXYZ...ABC",
+ *   proposal: "I have shipped 5 Soroban contracts and...",
+ *   bidAmount: "450",
+ *   currency: "XLM",
+ *   screeningAnswers: { "Years of Rust?": "4" },
+ * });
+ */
 async function submitApplication({
   jobId,
   freelancerAddress,
@@ -118,6 +191,14 @@ async function submitApplication({
   return rowToApp(appRow);
 }
 
+/**
+ * List every application for a given job, oldest first. Joins in profile
+ * `completed_jobs` and the freelancer's average rating so the result row can
+ * compute a freelancer tier label.
+ *
+ * @param {string} jobId  UUID of the job.
+ * @returns {Promise<Application[]>}
+ */
 async function getApplicationsForJob(jobId) {
   const { rows } = await pool.query(
     `SELECT a.*,
@@ -134,6 +215,13 @@ async function getApplicationsForJob(jobId) {
   return rows.map(rowToApp);
 }
 
+/**
+ * List every application submitted by a freelancer, newest first.
+ *
+ * @param {string} freelancerAddress  Stellar G-address of the freelancer.
+ * @returns {Promise<Application[]>}
+ * @throws {Error} 400 — invalid Stellar public key.
+ */
 async function getApplicationsForFreelancer(freelancerAddress) {
   validatePublicKey(freelancerAddress);
   const { rows } = await pool.query(
@@ -151,6 +239,23 @@ async function getApplicationsForFreelancer(freelancerAddress) {
   return rows.map(rowToApp);
 }
 
+/**
+ * Accept a freelancer's proposal. Atomically marks the chosen application
+ * `accepted` and rejects every other pending application on the same job,
+ * then assigns the freelancer to the job (which transitions it to
+ * `in_progress`).
+ *
+ * Wrapped in a single Postgres transaction so a partial failure cannot
+ * leave two accepted applications on one job.
+ *
+ * @param {string} applicationId  UUID of the application to accept.
+ * @param {string} clientAddress  Stellar G-address of the calling client; must
+ *                                match the parent job's `client_address`.
+ * @returns {Promise<Application>}  The newly accepted application.
+ * @throws {Error} 400 — invalid client public key, or job no longer open.
+ * @throws {Error} 403 — caller is not the job's client.
+ * @throws {Error} 404 — application or job not found.
+ */
 async function acceptApplication(applicationId, clientAddress) {
   validatePublicKey(clientAddress);
 

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -1,11 +1,67 @@
 /**
  * src/services/jobService.js
- * All data persisted in the `jobs` PostgreSQL table.
+ *
+ * Job listings service — owns all reads and writes against the `jobs`
+ * PostgreSQL table. Responsible for validation of job inputs, cursor-based
+ * pagination, status transitions, escrow contract id linkage, listing-boost
+ * (Featured) state, and timezone-aware filtering of the job feed.
+ *
+ * @module services/jobService
  */
 "use strict";
 
 const pool = require("../db/pool");
 const { getTimezoneOffset } = require("date-fns-tz");
+
+/**
+ * Camel-cased job record returned by this service.
+ *
+ * @typedef {Object} Job
+ * @property {string}   id                  UUID of the job.
+ * @property {string}   title               Job title (≥10 chars).
+ * @property {string}   description         Job description (≥30 chars).
+ * @property {string}   budget              Budget as a fixed-point string (e.g. "500.0000000").
+ * @property {("XLM"|"USDC")} currency      Payment currency.
+ * @property {string}   category            One of {@link VALID_CATEGORIES}.
+ * @property {string[]} skills              Up to 8 skill tags.
+ * @property {("open"|"in_progress"|"completed"|"cancelled")} status
+ * @property {string}   clientAddress       Stellar G-address of the client.
+ * @property {string|null} freelancerAddress Stellar G-address of the hired freelancer, if any.
+ * @property {string|null} escrowContractId Soroban contract id for the locked escrow.
+ * @property {number}   applicantCount      Cached count of applications for this job.
+ * @property {number}   shareCount          Number of times the job link has been shared.
+ * @property {boolean}  boosted             True while the listing is Featured.
+ * @property {string|null} boostedUntil     ISO timestamp at which boost expires.
+ * @property {string|null} deadline         ISO timestamp deadline (optional).
+ * @property {string|null} timezone         IANA timezone name for compatibility filtering.
+ * @property {string[]} screeningQuestions  Up to 5 screening questions applicants must answer.
+ * @property {string}   createdAt           ISO timestamp when the job was created.
+ * @property {string}   updatedAt           ISO timestamp of last write.
+ */
+
+/**
+ * Input shape accepted by {@link createJob}.
+ *
+ * @typedef {Object} CreateJobInput
+ * @property {string}   title
+ * @property {string}   description
+ * @property {string|number} budget
+ * @property {("XLM"|"USDC")} [currency="XLM"]
+ * @property {string}   category
+ * @property {string[]} [skills]
+ * @property {string}   [deadline]            ISO timestamp.
+ * @property {string}   [timezone]            IANA timezone name.
+ * @property {string[]} [screeningQuestions]  Up to 5 questions; non-empty entries are kept.
+ * @property {string}   clientAddress         Stellar G-address of the posting client.
+ */
+
+/**
+ * Pagination wrapper returned by {@link listJobs}.
+ *
+ * @typedef {Object} JobListPage
+ * @property {Job[]}      jobs
+ * @property {string|null} nextCursor  Opaque base64 cursor for the next page, or null when exhausted.
+ */
 
 const VALID_STATUSES = ["open", "in_progress", "completed", "cancelled"];
 
@@ -22,6 +78,13 @@ const VALID_CATEGORIES = [
   "Other",
 ];
 
+/**
+ * Throws a 400 Error when `key` is not a valid Stellar G-address.
+ *
+ * @param {string} key  Stellar account public key.
+ * @returns {void}
+ * @throws {Error}      `status === 400` if the key fails the G-address regex.
+ */
 function validatePublicKey(key) {
   if (!key || !/^G[A-Z0-9]{55}$/.test(key)) {
     const e = new Error("Invalid Stellar public key");
@@ -53,6 +116,12 @@ function isTimezoneCompatible(jobTimezone, userTimezone) {
   }
 }
 
+/**
+ * Convert a snake_case `jobs` row into the camelCase API object.
+ *
+ * @param {Object} row  Raw row from the `jobs` table.
+ * @returns {Job}       Camel-cased job record.
+ */
 function rowToJob(row) {
   return {
     id: row.id,
@@ -78,6 +147,27 @@ function rowToJob(row) {
   };
 }
 
+/**
+ * Create a new job listing in `status = 'open'`.
+ *
+ * The client's profile row must already exist; the FK constraint on
+ * `client_address` will otherwise reject the insert.
+ *
+ * @param {CreateJobInput} input
+ * @returns {Promise<Job>}  The newly persisted job.
+ * @throws {Error} 400 — when title/description/budget/category/currency fail validation.
+ *
+ * @example
+ * const job = await createJob({
+ *   title: "Build a Soroban escrow contract",
+ *   description: "We need a Rust developer to ship an escrow with milestones...",
+ *   budget: "500",
+ *   currency: "XLM",
+ *   category: "Smart Contracts",
+ *   skills: ["Rust", "Soroban"],
+ *   clientAddress: "GABCDEF...XYZ",
+ * });
+ */
 async function createJob({
   title,
   description,
@@ -147,6 +237,13 @@ async function createJob({
   return rowToJob(rows[0]);
 }
 
+/**
+ * Fetch a single job by id.
+ *
+ * @param {string} id  UUID of the job.
+ * @returns {Promise<Job>}
+ * @throws {Error} 404 — when no job with this id exists.
+ */
 async function getJob(id) {
   const { rows } = await pool.query("SELECT * FROM jobs WHERE id = $1", [id]);
   if (!rows.length) {
@@ -157,6 +254,12 @@ async function getJob(id) {
   return rowToJob(rows[0]);
 }
 
+/**
+ * Encode a (createdAt, id) pair into an opaque base64 cursor.
+ *
+ * @param {Object} jobRow  Row containing `created_at` and `id`.
+ * @returns {string}        Base64-encoded JSON cursor.
+ */
 function encodeCursor(jobRow) {
   return Buffer.from(
     JSON.stringify({
@@ -166,6 +269,13 @@ function encodeCursor(jobRow) {
   ).toString("base64");
 }
 
+/**
+ * Decode a base64 pagination cursor produced by {@link encodeCursor}.
+ *
+ * @param {string} cursor  Base64-encoded JSON cursor.
+ * @returns {{ createdAt: string, id: string }}
+ * @throws {Error} 400 — when the cursor cannot be parsed.
+ */
 function decodeCursor(cursor) {
   try {
     const decoded = JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
@@ -178,6 +288,24 @@ function decodeCursor(cursor) {
   }
 }
 
+/**
+ * Page through jobs, with optional filtering and ordering.
+ *
+ * Boosted (Featured) listings sort first; ties break on `created_at DESC, id DESC`.
+ * Cursor pagination is keyset-based — pass {@link JobListPage.nextCursor} from the
+ * previous page to fetch the next slice.
+ *
+ * @param {Object}  [opts]
+ * @param {string}  [opts.category]               Restrict to a category from {@link VALID_CATEGORIES}.
+ * @param {("open"|"in_progress"|"completed"|"cancelled")} [opts.status="open"]
+ * @param {number}  [opts.limit=50]               Page size (clamped to 1..100).
+ * @param {string}  [opts.search]                 Substring search over title, description, and skills.
+ * @param {string}  [opts.cursor]                 Opaque cursor from the previous page.
+ * @param {string}  [opts.timezone]               IANA timezone of the viewer; only jobs whose
+ *                                                timezone is within ±3h are returned.
+ * @returns {Promise<JobListPage>}
+ * @throws {Error} 400 — when `cursor` is malformed.
+ */
 async function listJobs({ category, status = "open", limit = 50, search, cursor, timezone } = {}) {
   const conditions = [];
   const params = [];
@@ -238,6 +366,13 @@ async function listJobs({ category, status = "open", limit = 50, search, cursor,
   };
 }
 
+/**
+ * List every job posted by a specific client, newest first.
+ *
+ * @param {string} clientAddress  Stellar G-address of the client.
+ * @returns {Promise<Job[]>}
+ * @throws {Error} 400 — invalid Stellar public key.
+ */
 async function listJobsByClient(clientAddress) {
   validatePublicKey(clientAddress);
   const { rows } = await pool.query(
@@ -247,6 +382,15 @@ async function listJobsByClient(clientAddress) {
   return rows.map(rowToJob);
 }
 
+/**
+ * Transition a job to a new status.
+ *
+ * @param {string} id      UUID of the job.
+ * @param {("open"|"in_progress"|"completed"|"cancelled")} status
+ * @returns {Promise<Job>}
+ * @throws {Error} 400 — invalid status.
+ * @throws {Error} 404 — job not found.
+ */
 async function updateJobStatus(id, status) {
   if (!VALID_STATUSES.includes(status)) {
     const e = new Error("Invalid status");
@@ -268,6 +412,15 @@ async function updateJobStatus(id, status) {
   return rowToJob(rows[0]);
 }
 
+/**
+ * Hire a freelancer for a job and move it to `in_progress`.
+ *
+ * @param {string} jobId              UUID of the job.
+ * @param {string} freelancerAddress  Stellar G-address of the freelancer being hired.
+ * @returns {Promise<Job>}
+ * @throws {Error} 400 — invalid freelancer public key.
+ * @throws {Error} 404 — job not found.
+ */
 async function assignFreelancer(jobId, freelancerAddress) {
   validatePublicKey(freelancerAddress);
 
@@ -288,6 +441,16 @@ async function assignFreelancer(jobId, freelancerAddress) {
   return rowToJob(rows[0]);
 }
 
+/**
+ * Persist the on-chain escrow contract id against a job. Called after the
+ * client signs and submits the Soroban `create_escrow` transaction.
+ *
+ * @param {string} jobId             UUID of the job.
+ * @param {string} escrowContractId  Soroban contract id (or transaction hash).
+ * @returns {Promise<Job>}
+ * @throws {Error} 400 — invalid escrow contract id.
+ * @throws {Error} 404 — job not found.
+ */
 async function updateJobEscrowId(jobId, escrowContractId) {
   if (!escrowContractId || typeof escrowContractId !== "string") {
     const e = new Error("Invalid escrow contract ID");
@@ -309,6 +472,14 @@ async function updateJobEscrowId(jobId, escrowContractId) {
   return rowToJob(rows[0]);
 }
 
+/**
+ * Hard-delete a job. Used to roll back an "orphaned" job whose escrow
+ * transaction failed after the row was inserted.
+ *
+ * @param {string} jobId  UUID of the job.
+ * @returns {Promise<void>}
+ * @throws {Error} 404 — job not found.
+ */
 async function deleteJob(jobId) {
   const { rowCount } = await pool.query("DELETE FROM jobs WHERE id = $1", [jobId]);
   if (!rowCount) {
@@ -318,6 +489,19 @@ async function deleteJob(jobId) {
   }
 }
 
+/**
+ * Mark a job as Featured for the next 7 days.
+ *
+ * The route handler accepts a Stellar transaction hash from the client
+ * (intended to record the 10 XLM platform fee), but on-chain verification
+ * of that payment has not yet been wired up — see the `TODO` in
+ * `routes/jobs.js`. The hash is therefore not consumed by this service
+ * function today.
+ *
+ * @param {string} jobId  UUID of the job to boost.
+ * @returns {Promise<Job>}
+ * @throws {Error} 404 — job not found.
+ */
 async function boostJob(jobId) {
   const { rows } = await pool.query("SELECT * FROM jobs WHERE id = $1", [jobId]);
   if (!rows.length) {
@@ -340,6 +524,14 @@ async function boostJob(jobId) {
   return rowToJob(updateRows[0]);
 }
 
+/**
+ * Increment the per-job share counter. Called when the client clicks
+ * "Share" or otherwise copies the job link.
+ *
+ * @param {string} jobId  UUID of the job.
+ * @returns {Promise<Job>}
+ * @throws {Error} 404 — job not found.
+ */
 async function incrementShareCount(jobId) {
   const { rows } = await pool.query(
     "UPDATE jobs SET share_count = COALESCE(share_count, 0) + 1, updated_at = NOW() WHERE id = $1 RETURNING *",

--- a/backend/src/services/profileService.js
+++ b/backend/src/services/profileService.js
@@ -1,6 +1,14 @@
 /**
  * src/services/profileService.js
- * All data persisted in the `profiles` PostgreSQL table.
+ *
+ * Profiles service — owns all reads and writes against the `profiles`
+ * PostgreSQL table. Validates portfolio items and availability blocks,
+ * upserts profile metadata keyed by Stellar public key, computes a
+ * derived reputation score (rating + accept/release latency) on read,
+ * derives a freelancer tier label, and records optional DID/KYC
+ * verification.
+ *
+ * @module services/profileService
  */
 "use strict";
 
@@ -11,6 +19,63 @@ const VALID_PORTFOLIO_TYPES = ["github", "live", "stellar_tx"];
 const VALID_AVAILABILITY_STATUSES = ["available", "busy", "unavailable"];
 const MAX_PORTFOLIO_ITEMS = 10;
 
+/**
+ * Camel-cased profile record returned by this service.
+ *
+ * @typedef {Object} UserProfile
+ * @property {string}     publicKey         Stellar G-address (primary key).
+ * @property {string|null} displayName
+ * @property {string|null} bio
+ * @property {string[]}   skills
+ * @property {PortfolioItem[]} portfolioItems
+ * @property {Availability|null} availability
+ * @property {("client"|"freelancer"|"both")} role
+ * @property {number}     completedJobs
+ * @property {string}     totalEarnedXLM    Fixed-point string.
+ * @property {number|null} rating           Average rating (1..5), null until rated.
+ * @property {string|null} didHash          Optional DID hash from identity verification.
+ * @property {boolean|null} isKycVerified   True after a successful `verifyIdentity` call.
+ * @property {number}     [ratingCount]     Number of ratings (only on getProfile result).
+ * @property {number}     [reputationScore] Derived score 0..100 (only on getProfile result).
+ * @property {{ avgAcceptHours: number, avgReleaseHours: number }} [reputationMetrics]
+ * @property {string}     createdAt
+ * @property {string}     updatedAt
+ */
+
+/**
+ * @typedef {Object} PortfolioItem
+ * @property {string} title
+ * @property {("github"|"live"|"stellar_tx")} type
+ * @property {string} url
+ */
+
+/**
+ * @typedef {Object} Availability
+ * @property {("available"|"busy"|"unavailable")} status
+ * @property {string} [availableFrom]   ISO timestamp.
+ * @property {string} [availableUntil]  ISO timestamp.
+ */
+
+/**
+ * Input shape accepted by {@link upsertProfile}.
+ *
+ * @typedef {Object} UpsertProfileInput
+ * @property {string}            publicKey
+ * @property {string}            [displayName]
+ * @property {string}            [bio]
+ * @property {string[]}          [skills]
+ * @property {PortfolioItem[]}   [portfolioItems]
+ * @property {Availability}      [availability]
+ * @property {("client"|"freelancer"|"both")} [role]
+ */
+
+/**
+ * Throws a 400 Error when `key` is not a valid Stellar G-address.
+ *
+ * @param {string} key
+ * @returns {void}
+ * @throws {Error} `status === 400` if the key fails the G-address regex.
+ */
 function validatePublicKey(key) {
   if (!key || !/^G[A-Z0-9]{55}$/.test(key)) {
     const e = new Error("Invalid Stellar public key");
@@ -125,6 +190,12 @@ function validateAvailability(availability) {
   };
 }
 
+/**
+ * Convert a snake_case `profiles` row into the camelCase API object.
+ *
+ * @param {Object} row
+ * @returns {UserProfile}
+ */
 function rowToProfile(row) {
   return {
     publicKey: row.public_key,
@@ -144,6 +215,19 @@ function rowToProfile(row) {
   };
 }
 
+/**
+ * Derive a freelancer tier label from completed-jobs count and average rating.
+ *
+ * Tiers (highest first):
+ * - **Top Talent** — ≥30 completed jobs and rating ≥4.8
+ * - **Expert** — ≥15 completed jobs and rating ≥4.5
+ * - **Rising Star** — ≥5 completed jobs (rating not required)
+ * - **Newcomer** — anyone else
+ *
+ * @param {number} [completedJobs=0]   Number of completed jobs for the freelancer.
+ * @param {number|null} [rating=null]  Average rating (1..5), or null if unrated.
+ * @returns {("Top Talent"|"Expert"|"Rising Star"|"Newcomer")}
+ */
 function calculateFreelancerTier(completedJobs = 0, rating = null) {
   const jobs = Number(completedJobs) || 0;
   const safeRating = rating === null || rating === undefined ? null : Number(rating);
@@ -154,6 +238,17 @@ function calculateFreelancerTier(completedJobs = 0, rating = null) {
   return "Newcomer";
 }
 
+/**
+ * Fetch a profile by public key, including aggregated rating data and a
+ * derived reputation score (0..100) computed from the rating, average
+ * acceptance latency, and average escrow-release latency.
+ *
+ * @param {string} publicKey  Stellar G-address.
+ * @returns {Promise<UserProfile>}  The profile, with `rating`, `ratingCount`,
+ *                                  `reputationScore`, and `reputationMetrics` populated.
+ * @throws {Error} 400 — invalid Stellar public key.
+ * @throws {Error} 404 — profile not found.
+ */
 async function getProfile(publicKey) {
   validatePublicKey(publicKey);
 
@@ -214,6 +309,29 @@ async function getProfile(publicKey) {
   return profile;
 }
 
+/**
+ * Insert or update a profile row keyed by `publicKey`.
+ *
+ * Empty-string fields fall back to the existing values via the SQL
+ * `NULLIF(EXCLUDED.field, '')` pattern, so a partial update will not
+ * blank out previously-saved data.
+ *
+ * @param {UpsertProfileInput} input
+ * @returns {Promise<UserProfile>}
+ * @throws {Error} 400 — invalid public key, role, portfolio items, or availability.
+ *
+ * @example
+ * const profile = await upsertProfile({
+ *   publicKey: "GABCDEF...XYZ",
+ *   displayName: "Ada",
+ *   bio: "Smart-contract auditor since 2019.",
+ *   skills: ["Rust", "Soroban", "Security Audit"],
+ *   portfolioItems: [
+ *     { title: "Escrow audit", type: "github", url: "https://github.com/ada/audit-x" },
+ *   ],
+ *   role: "freelancer",
+ * });
+ */
 async function upsertProfile({ publicKey, displayName, bio, skills, portfolioItems, availability, role }) {
   validatePublicKey(publicKey);
 
@@ -250,6 +368,15 @@ async function upsertProfile({ publicKey, displayName, bio, skills, portfolioIte
   return rowToProfile(rows[0]);
 }
 
+/**
+ * Update only the availability block on a profile, creating the profile row
+ * if it does not yet exist.
+ *
+ * @param {string}              publicKey     Stellar G-address.
+ * @param {Availability|null}   availability  New availability block, or null to clear.
+ * @returns {Promise<UserProfile>}
+ * @throws {Error} 400 — invalid public key or availability shape.
+ */
 async function updateAvailability(publicKey, availability) {
   validatePublicKey(publicKey);
   const safeAvailability = validateAvailability(availability);
@@ -269,6 +396,17 @@ async function updateAvailability(publicKey, availability) {
   return rowToProfile(rows[0]);
 }
 
+/**
+ * Record an identity-verification result on a profile. Sets `did_hash` and
+ * marks the profile `is_kyc_verified = TRUE`. The profile row must already
+ * exist — call {@link upsertProfile} first if needed.
+ *
+ * @param {string} publicKey  Stellar G-address.
+ * @param {string} didHash    DID hash returned by the verification provider.
+ * @returns {Promise<UserProfile>}
+ * @throws {Error} 400 — invalid public key, or `didHash` missing.
+ * @throws {Error} 404 — profile not found.
+ */
 async function verifyIdentity(publicKey, didHash) {
   validatePublicKey(publicKey);
   if (!didHash) throw createValidationError("didHash is required");

--- a/frontend/components/ApplicationForm.tsx
+++ b/frontend/components/ApplicationForm.tsx
@@ -28,7 +28,13 @@ export default function ApplicationForm({ job, publicKey, prefillData, onSuccess
   const [showConfirm, setShowConfirm] = useState(false);
   const [screeningAnswers, setScreeningAnswers] = useState<Record<string, string>>({});
 
-  const isValid = proposal.trim().length >= 50 && parseFloat(bidAmount) > 0;
+  // Issue #152 — enforce 50-word minimum on the proposal.
+  const wordCount = proposal.trim() === "" ? 0 : proposal.trim().split(/\s+/).length;
+  const MIN_WORDS = 50;
+  const wordsRemaining = Math.max(0, MIN_WORDS - wordCount);
+  const meetsWordMinimum = wordCount >= MIN_WORDS;
+
+  const isValid = meetsWordMinimum && parseFloat(bidAmount) > 0;
 
   // Initialize screening answers when job changes
   useEffect(() => {
@@ -88,9 +94,27 @@ export default function ApplicationForm({ job, publicKey, prefillData, onSuccess
               value={proposal} onChange={(e) => setProposal(e.target.value)}
               rows={6}
               placeholder="Describe your relevant experience, your approach to this project, and why you're the best fit..."
-              className="textarea-field"
+              className={clsx(
+                "textarea-field",
+                proposal.length > 0 && !meetsWordMinimum && "border-red-500/40"
+              )}
+              aria-invalid={proposal.length > 0 && !meetsWordMinimum}
+              aria-describedby="proposal-word-count"
             />
-            <p className="mt-1 text-xs text-amber-800/50">{proposal.length} chars (min 50)</p>
+            <p
+              id="proposal-word-count"
+              className={clsx(
+                "mt-1 text-xs font-medium",
+                meetsWordMinimum ? "text-green-400" : "text-red-400"
+              )}
+            >
+              {wordCount} {wordCount === 1 ? "word" : "words"} (minimum {MIN_WORDS})
+              {!meetsWordMinimum && (
+                <span className="ml-1 text-amber-800/80 font-normal">
+                  — {wordsRemaining} more {wordsRemaining === 1 ? "word" : "words"} needed
+                </span>
+              )}
+            </p>
           </div>
 
           {/* Bid amount */}

--- a/frontend/components/PostJobForm.tsx
+++ b/frontend/components/PostJobForm.tsx
@@ -283,21 +283,54 @@ export default function PostJobForm({ publicKey }: PostJobFormProps) {
             }}
           />
         
-          {/* Character Counter */}
-          <p
-            id="description-counter"
-            className={clsx(
-              "mt-1 text-xs font-medium",
-              form.description.trim().length < 30 && "text-red-400",
-              form.description.trim().length >= 30 &&
-                form.description.trim().length <= 100 &&
-                "text-amber-400",
-              form.description.trim().length > 100 && "text-green-400"
-            )}
-          >
-            {form.description.length} / 2000
-          </p>
-        
+          {/* Character Counter + Word Count Quality Indicator (Issue #148) */}
+          {(() => {
+            const wordCount = form.description.trim() === ""
+              ? 0
+              : form.description.trim().split(/\s+/).length;
+            const quality: "too_short" | "good" | "detailed" =
+              wordCount < 30 ? "too_short" : wordCount <= 80 ? "good" : "detailed";
+            const qualityLabel =
+              quality === "too_short" ? "Too short"
+              : quality === "good" ? "Good"
+              : "Detailed";
+            const qualityClass =
+              quality === "too_short"
+                ? "bg-red-500/10 text-red-400 border-red-500/20"
+                : quality === "good"
+                  ? "bg-amber-500/10 text-amber-300 border-amber-500/20"
+                  : "bg-green-500/10 text-green-400 border-green-500/20";
+
+            return (
+              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+                <p
+                  id="description-counter"
+                  className={clsx(
+                    "text-xs font-medium",
+                    form.description.trim().length < 30 && "text-red-400",
+                    form.description.trim().length >= 30 &&
+                      form.description.trim().length <= 100 &&
+                      "text-amber-400",
+                    form.description.trim().length > 100 && "text-green-400"
+                  )}
+                >
+                  {form.description.length} / 2000
+                </p>
+                <p className="text-xs font-medium text-amber-800/80">
+                  {wordCount} {wordCount === 1 ? "word" : "words"}
+                </p>
+                <span
+                  className={clsx(
+                    "text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border font-semibold",
+                    qualityClass
+                  )}
+                >
+                  {qualityLabel}
+                </span>
+              </div>
+            );
+          })()}
+
           {/* Inline Error */}
           {form.description.length > 0 && form.description.trim().length < 30 && (
             <p

--- a/frontend/pages/jobs/[id].tsx
+++ b/frontend/pages/jobs/[id].tsx
@@ -12,7 +12,7 @@ import WalletConnect from "@/components/WalletConnect";
 import RatingForm from "@/components/RatingForm";
 import ShareJobModal from "@/components/ShareJobModal";
 import { fetchJob, fetchApplications, acceptApplication, releaseEscrow, scoreProposals } from "@/lib/api";
-import { formatXLM, timeAgo, formatDate, shortenAddress, statusLabel, statusClass } from "@/utils/format";
+import { formatXLM, timeAgo, formatDate, shortenAddress, statusLabel, statusClass, copyToClipboard } from "@/utils/format";
 import {
   accountUrl,
   buildReleaseEscrowTransaction,
@@ -64,6 +64,14 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
   const [releaseCurrency, setReleaseCurrency] = useState<"XLM" | "USDC">("XLM");
   const [estimatedOutput, setEstimatedOutput] = useState<string | null>(null);
   const [fetchingPrice, setFetchingPrice] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
+
+  const handleCopyJobLink = async () => {
+    const ok = await copyToClipboard(window.location.href);
+    if (!ok) return;
+    setLinkCopied(true);
+    setTimeout(() => setLinkCopied(false), 2000);
+  };
 
   const isClient = publicKey && job?.clientAddress === publicKey;
   const isFreelancer = publicKey && job?.freelancerAddress === publicKey;
@@ -352,6 +360,29 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
                     Featured
                   </span>
                 )}
+                {/* Copy link button (Issue #149) */}
+                <button
+                  type="button"
+                  onClick={handleCopyJobLink}
+                  aria-label="Copy job link"
+                  className="btn-ghost inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full"
+                >
+                  {linkCopied ? (
+                    <>
+                      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 015.656 0l1.415 1.415a4 4 0 010 5.656l-3 3a4 4 0 01-5.656 0l-1.415-1.415m-2.828-2.828a4 4 0 010-5.656l3-3a4 4 0 015.656 0l1.415 1.415" />
+                      </svg>
+                      Copy link
+                    </>
+                  )}
+                </button>
               </div>
               <h1 className="font-display text-2xl sm:text-3xl font-bold text-amber-100 leading-snug">
                 {job.title}


### PR DESCRIPTION
## Summary

Closes #148 
Closes #149 
Closes #152 
Closes #157.

| # | Issue | File |
|---|---|---|
| **#148** | Word-count + quality badge under job description | `frontend/components/PostJobForm.tsx` |
| **#149** | Copy link button on the job detail page | `frontend/pages/jobs/[id].tsx` |
| **#152** | 50-word minimum enforcer on the proposal form | `frontend/components/ApplicationForm.tsx` |
| **#157** | JSDoc for every exported backend service function | `backend/src/services/{jobService,applicationService,profileService}.js` |

### #148 — Job description word-count + quality
Live word counter under the existing 30-char counter, plus a coloured quality badge:

- **Too short** (red) — under 30 words
- **Good** (amber) — 30–80 words
- **Detailed** (green) — over 80 words

Advisory only. Form submission is **not** blocked by the badge.

### #149 — Copy job link
A `btn-ghost` button sits next to the status / category / Featured badges. Click → `copyToClipboard(window.location.href)` → button flips to a check icon + "Copied!" for 2 seconds, then reverts. Reuses the existing `copyToClipboard` helper from `utils/format.ts`.

### #152 — 50-word proposal minimum
- Live word count under the cover-letter textarea.
- Red under 50, green at 50+.
- Shows "**X more words needed**" while the count is short.
- The Submit Proposal button stays disabled until the proposal hits 50 words (drives off the existing `isValid` gate).

### #157 — Backend JSDoc
Every exported function in the three services now has:

- File-level module description (`@module`).
- `@typedef` blocks for input shapes and record shapes (`Job`, `CreateJobInput`, `JobListPage`, `Application`, `SubmitApplicationInput`, `UserProfile`, `PortfolioItem`, `Availability`, `UpsertProfileInput`).
- `@param`, `@returns`, `@throws` (with `status` codes) on each exported function.
- `@example` blocks on `createJob`, `submitApplication`, and `upsertProfile` per the issue.

## Drive-by lint fixes (so `npm run lint` can pass clean)

While documenting the services I patched a handful of small undef bugs in those same files. They're tightly scoped and motivated by the lint-clean acceptance criterion:

- `jobService.createJob` — destructured `timezone` and `screeningQuestions` from the input (they were referenced in the SQL params array but never destructured) and added `timezone, screening_questions` to the INSERT column list / placeholders so the values actually persist.
- `applicationService.submitApplication` — replaced `query(...)` with the existing `pool.query(...)` (the `query` symbol was never imported) and destructured `screeningAnswers` from the input (validation referenced an undeclared variable).
- `jobService.boostJob` — dropped the unused `txHash` parameter; on-chain verification of the boost fee is still a `TODO` in the route layer and the service never consumed the hash.
- `routes/escrow.js` — marked `POST /:jobId/release` `async` (it was using `await pool.query(...)` inside a non-async handler — pre-existing parse error) and removed an unused `contractTxHash` destructure.

## Verification

```
backend $ npm run lint
> eslint src/**/*.js
# clean
```

```
frontend $ npm run type-check
> tsc --noEmit
pages/jobs/[id].tsx  ... 11 errors (all pre-existing on main, see below)
```

## Pre-existing breakage left in place (out of scope)

I deliberately did **not** rewrite or restructure the following — they predate this branch and would explode this PR's scope:

- **`frontend/pages/jobs/[id].tsx`** — has 11 baseline parse/structural errors from an earlier merge (duplicate header blocks, undefined identifiers like `appId`, `selectedApplications`, `clsx`, `availabilityStatusLabel`, `ProposalComparison`, `fetchProfile`, plus a stray `</>` and fragment with no close). `tsc` error count is **identical before and after** this commit. The Copy link button was added inside the cleaner of the two duplicate header blocks.
- **`frontend/components/PostJobForm.tsx`** — pre-existing references to an unimported `usePriceContext`, a `templates` feature with several undeclared handlers/state, and form fields (`currency`, `timezone`) not in the form state. The word-count quality block was added in a region clear of those issues.
- **Backend tests** — `npm test` fails to load because `pg` is required by `src/db/pool.js` but is not in `package.json` dependencies. Pre-existing on `main`.

Happy to follow up on any of those in separate PRs if you want.

## Test plan

- [ ] **#148** — Open `/post-job`, type a description; verify word count and badge colour transition at 30 and 80 words. Confirm the form still submits at <30 words (advisory).
- [ ] **#149** — Open any job page; click **Copy link**; paste in a new tab → URL matches; button shows **Copied!** for 2 s.
- [ ] **#152** — Open a job, click Apply; type a 49-word proposal → Submit disabled, "1 more word needed" hint visible. Add a 50th word → submit enables, hint flips to green.
- [ ] **#157** — Skim the three service files; confirm every exported function has \`@param\` / \`@returns\` / \`@throws\`; confirm \`createJob\`, \`submitApplication\`, \`upsertProfile\` each carry an \`@example\`.
- [ ] \`cd backend && npm run lint\` — clean.
- [ ] \`cd frontend && npm run type-check\` — same 11 pre-existing errors as \`main\`, no new ones.