### PR TITLE
Add job repost feature for expired or cancelled jobs

### DIFF
--- a/frontend/components/PostJobForm.tsx
+++ b/frontend/components/PostJobForm.tsx
@@ -12,7 +12,7 @@ import { useRouter } from "next/router";
 import clsx from "clsx";
 import { useToast } from "@/components/Toast";
 import { usePriceContext } from "@/contexts/PriceContext";
-import type { Currency } from "@/utils/types";
+import type { Currency, Job } from "@/utils/types";
 
 interface PostJobFormProps { publicKey: string; }
 
@@ -40,6 +40,7 @@ type JobTemplate = {
 
 const JOB_TEMPLATES_STORAGE_KEY = "stellar-marketpay-job-templates";
 const SCOPE_PREFILL_STORAGE_KEY = "marketpay_scope_prefill";
+const REPOST_JOB_PREFILL_STORAGE_KEY = "marketpay_repost_job_prefill";
 const emptyForm: FormState = {
   title: "",
   description: "",
@@ -90,6 +91,40 @@ export default function PostJobForm({ publicKey }: PostJobFormProps) {
       // Ignore malformed prefill payload
     } finally {
       window.localStorage.removeItem(SCOPE_PREFILL_STORAGE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const rawRepostPrefill = window.localStorage.getItem(REPOST_JOB_PREFILL_STORAGE_KEY);
+    if (!rawRepostPrefill) return;
+
+    try {
+      const prefill = JSON.parse(rawRepostPrefill) as Partial<Job>;
+      setForm((prev) => ({
+        ...prev,
+        title: typeof prefill.title === "string" ? prefill.title : prev.title,
+        description: typeof prefill.description === "string" ? prefill.description : prev.description,
+        budget: typeof prefill.budget === "string" ? prefill.budget : prev.budget,
+        category: typeof prefill.category === "string" ? prefill.category : prev.category,
+        currency: prefill.currency === "USDC" || prefill.currency === "XLM" ? prefill.currency : prev.currency,
+        timezone: typeof prefill.timezone === "string" ? prefill.timezone : prev.timezone,
+        deadline: "",
+      }));
+
+      if (Array.isArray(prefill.skills)) {
+        setSkills(prefill.skills.filter((skill): skill is string => typeof skill === "string"));
+      }
+      if (Array.isArray(prefill.screeningQuestions)) {
+        const filteredQuestions = prefill.screeningQuestions.filter(
+          (question): question is string => typeof question === "string"
+        );
+        setScreeningQuestions(filteredQuestions.length > 0 ? filteredQuestions : [""]);
+      }
+    } catch (_) {
+      // Ignore malformed repost prefill payload
+    } finally {
+      window.localStorage.removeItem(REPOST_JOB_PREFILL_STORAGE_KEY);
     }
   }, []);
 

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -4,6 +4,7 @@
  */
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import WalletConnect from "@/components/WalletConnect";
 import { fetchMyJobs, fetchMyApplications } from "@/lib/api";
 import { getXLMBalance, getUSDCBalance, streamAccountTransactions } from "@/lib/stellar";
@@ -20,8 +21,10 @@ interface DashboardProps {
 }
 
 type Tab = "posted" | "applied" | "send" | "edit_profile";
+const REPOST_JOB_PREFILL_STORAGE_KEY = "marketpay_repost_job_prefill";
 
 export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
+  const router = useRouter();
   const [tab, setTab] = useState<Tab>("posted");
   const [myJobs, setMyJobs] = useState<Job[]>([]);
   const [myApplications, setMyApplications] = useState<Application[]>([]);
@@ -46,6 +49,25 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
 
   const [processedTxs, setProcessedTxs] = useState<Set<string>>(new Set());
   const { info, success } = useToast();
+  const isRepostable = (status: Job["status"]) => status === "expired" || status === "cancelled";
+
+  const handleRepost = (job: Job) => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(
+      REPOST_JOB_PREFILL_STORAGE_KEY,
+      JSON.stringify({
+        title: job.title,
+        description: job.description,
+        budget: job.budget,
+        category: job.category,
+        skills: job.skills,
+        currency: job.currency,
+        timezone: job.timezone || "",
+        screeningQuestions: job.screeningQuestions || [],
+      })
+    );
+    router.push("/post-job?mode=repost");
+  };
 
   useEffect(() => {
     if (!publicKey) return;
@@ -239,21 +261,28 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
               </button>
             </div>
             {myJobs.map((job) => (
-              <Link key={job.id} href={`/jobs/${job.id}`}>
-                <div className="card-hover flex items-center justify-between gap-4">
-                  <div className="flex-1 min-w-0">
+              <div key={job.id} className="card-hover flex items-center justify-between gap-4">
+                  <Link href={`/jobs/${job.id}`} className="flex-1 min-w-0 block">
                     <div className="flex items-center gap-2 mb-1">
                       <span className={statusClass(job.status)}>{statusLabel(job.status)}</span>
                       <span className="text-xs text-amber-800">{job.category}</span>
                     </div>
                     <p className="font-display font-semibold text-amber-100 truncate">{job.title}</p>
                     <p className="text-xs text-amber-800 mt-1">{job.applicantCount} applicant{job.applicantCount !== 1 ? "s" : ""} · {timeAgo(job.createdAt)}</p>
-                  </div>
-                  <div className="text-right flex-shrink-0">
+                  </Link>
+                  <div className="text-right flex-shrink-0 space-y-2">
                     <p className="font-mono font-semibold text-market-400">{formatXLM(job.budget)}</p>
+                    {isRepostable(job.status) && (
+                      <button
+                        type="button"
+                        className="btn-secondary text-xs px-3 py-1.5"
+                        onClick={() => handleRepost(job)}
+                      >
+                        Repost Job
+                      </button>
+                    )}
                   </div>
-                </div>
-              </Link>
+              </div>
             ))}
           </div>
         )

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -97,6 +97,10 @@
     @apply badge bg-red-500/10 text-red-400 border-red-500/20;
   }
 
+  .badge-expired {
+    @apply badge bg-amber-500/10 text-amber-300 border-amber-500/20;
+  }
+
   .address-tag {
     @apply font-mono text-xs bg-ink-700 text-market-400/80 px-2.5 py-1 rounded-lg border border-market-500/15;
   }

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -110,11 +110,23 @@ export async function copyToClipboard(text: string): Promise<boolean> {
 }
 
 export function statusLabel(status: JobStatus): string {
-  return { open: "Open", in_progress: "In Progress", completed: "Completed", cancelled: "Cancelled" }[status];
+  return {
+    open: "Open",
+    in_progress: "In Progress",
+    completed: "Completed",
+    cancelled: "Cancelled",
+    expired: "Expired",
+  }[status];
 }
 
 export function statusClass(status: JobStatus): string {
-  return { open: "badge-open", in_progress: "badge-progress", completed: "badge-complete", cancelled: "badge-cancelled" }[status];
+  return {
+    open: "badge-open",
+    in_progress: "badge-progress",
+    completed: "badge-complete",
+    cancelled: "badge-cancelled",
+    expired: "badge-expired",
+  }[status];
 }
 
 export function availabilityStatusLabel(status?: Availability["status"] | null): string {

--- a/frontend/utils/types.ts
+++ b/frontend/utils/types.ts
@@ -3,7 +3,7 @@
  * Shared TypeScript types for Stellar MarketPay.
  */
 
-export type JobStatus = "open" | "in_progress" | "completed" | "cancelled";
+export type JobStatus = "open" | "in_progress" | "completed" | "cancelled" | "expired";
 export type UserRole  = "client" | "freelancer" | "both";
 export type Currency  = "XLM" | "USDC";
 export type FreelancerTier = "Newcomer" | "Rising Star" | "Expert" | "Top Talent";


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Description
Added expired to the JobStatus union (frontend/utils/types.ts) and mapped it to a new label/class in statusLabel/statusClass (frontend/utils/format.ts) and a corresponding CSS badge style (.badge-expired) in frontend/styles/globals.css.
Added a Repost Job button and repost eligibility logic to the client dashboard job cards (frontend/pages/dashboard.tsx) which stores a repost prefill payload in localStorage and navigates to /post-job.
Updated PostJobForm (frontend/components/PostJobForm.tsx) to consume the repost prefill key (marketpay_repost_job_prefill) and initialize form fields (title, description, budget, category, skills, currency, timezone, screening questions) while explicitly clearing the deadline so the client must set a new one.
No backend changes; repost uses the existing createJob flow so newly created jobs receive new IDs, open status and updated timestamps.

Testing
Ran type-check with npm run type-check; it failed but due to pre-existing unrelated TypeScript issues in pages/jobs/[id].tsx and duplicate exports in utils/format.ts, not due to the repost changes.
No other automated tests were executed in this change set.

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #198 

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
