### PR TITLE
Add keyboard shortcut system for power users

### DIFF
--- a/frontend/components/ShortcutsModal.tsx
+++ b/frontend/components/ShortcutsModal.tsx
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+
+interface ShortcutsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  showJobDetailShortcuts: boolean;
+}
+
+function Key({ children }: { children: string }) {
+  return <kbd className="rounded border border-market-500/25 bg-ink-800 px-2 py-1 text-xs font-semibold text-market-300">{children}</kbd>;
+}
+
+export default function ShortcutsModal({ isOpen, onClose, showJobDetailShortcuts }: ShortcutsModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onEsc = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onEsc);
+    return () => window.removeEventListener("keydown", onEsc);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        aria-label="Close keyboard shortcuts"
+        onClick={onClose}
+      />
+
+      <div className="relative w-full max-w-xl rounded-2xl border border-market-500/20 bg-ink-900 p-6 shadow-2xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="font-display text-xl font-bold text-amber-100">Keyboard Shortcuts</h2>
+          <button type="button" onClick={onClose} className="btn-ghost px-3 py-1 text-xs">Close</button>
+        </div>
+
+        <div className="space-y-2 text-sm">
+          <ShortcutRow keys={["G", "J"]} description="Go to jobs" />
+          <ShortcutRow keys={["G", "D"]} description="Go to dashboard" />
+          <ShortcutRow keys={["N"]} description="Create a new job post" />
+          <ShortcutRow keys={["?"]} description="Toggle this shortcuts guide" />
+          {showJobDetailShortcuts && (
+            <>
+              <div className="my-2 border-t border-market-500/10" />
+              <ShortcutRow keys={["A"]} description="Open apply flow (job detail page)" />
+              <ShortcutRow keys={["Esc"]} description="Back to job listings (job detail page)" />
+            </>
+          )}
+        </div>
+
+        <p className="mt-5 text-xs text-amber-800">Shortcuts are disabled while typing in form fields.</p>
+      </div>
+    </div>
+  );
+}
+
+function ShortcutRow({ keys, description }: { keys: string[]; description: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-market-500/10 bg-ink-800/50 px-3 py-2">
+      <div className="flex items-center gap-1.5">
+        {keys.map((key, idx) => (
+          <div key={`${key}-${idx}`} className="flex items-center gap-1.5">
+            <Key>{key}</Key>
+            {idx < keys.length - 1 && <span className="text-xs text-amber-700">then</span>}
+          </div>
+        ))}
+      </div>
+      <span className="text-amber-200/90">{description}</span>
+    </div>
+  );
+}

--- a/frontend/hooks/useKeyboardShortcuts.ts
+++ b/frontend/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,124 @@
+import { useEffect } from "react";
+
+type UseKeyboardShortcutsOptions = {
+  isJobDetailPage: boolean;
+  onGoToJobs: () => void;
+  onGoToDashboard: () => void;
+  onNewJobPost: () => void;
+  onToggleShortcutsModal: () => void;
+  onJobApply: () => void;
+  onJobBackToListing: () => void;
+  shortcutsModalOpen: boolean;
+};
+
+const SEQUENCE_TIMEOUT_MS = 900;
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === "input" || tagName === "textarea" || tagName === "select") {
+    return true;
+  }
+
+  return target.isContentEditable;
+}
+
+export function useKeyboardShortcuts({
+  isJobDetailPage,
+  onGoToJobs,
+  onGoToDashboard,
+  onNewJobPost,
+  onToggleShortcutsModal,
+  onJobApply,
+  onJobBackToListing,
+  shortcutsModalOpen,
+}: UseKeyboardShortcutsOptions) {
+  useEffect(() => {
+    let sequencePrefix: "g" | null = null;
+    let sequenceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearSequence = () => {
+      sequencePrefix = null;
+      if (sequenceTimer) {
+        clearTimeout(sequenceTimer);
+        sequenceTimer = null;
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isTypingTarget(event.target)) return;
+
+      const key = event.key.toLowerCase();
+
+      if (sequencePrefix === "g") {
+        if (key === "j") {
+          event.preventDefault();
+          onGoToJobs();
+          clearSequence();
+          return;
+        }
+
+        if (key === "d") {
+          event.preventDefault();
+          onGoToDashboard();
+          clearSequence();
+          return;
+        }
+      }
+
+      if (key === "g") {
+        clearSequence();
+        sequencePrefix = "g";
+        sequenceTimer = setTimeout(clearSequence, SEQUENCE_TIMEOUT_MS);
+        return;
+      }
+
+      clearSequence();
+
+      if (key === "n") {
+        event.preventDefault();
+        onNewJobPost();
+        return;
+      }
+
+      const isQuestionMark = event.key === "?" || (event.key === "/" && event.shiftKey);
+      if (isQuestionMark) {
+        event.preventDefault();
+        onToggleShortcutsModal();
+        return;
+      }
+
+      if (!isJobDetailPage) return;
+
+      if (key === "a") {
+        event.preventDefault();
+        onJobApply();
+        return;
+      }
+
+      if (event.key === "Escape") {
+        if (shortcutsModalOpen) return;
+        event.preventDefault();
+        onJobBackToListing();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      clearSequence();
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [
+    isJobDetailPage,
+    onGoToJobs,
+    onGoToDashboard,
+    onNewJobPost,
+    onToggleShortcutsModal,
+    onJobApply,
+    onJobBackToListing,
+    shortcutsModalOpen,
+  ]);
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,15 +1,37 @@
 import type { AppProps } from "next/app";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import Navbar from "@/components/Navbar";
 import { connectWallet, getConnectedPublicKey, signTransactionWithWallet } from "@/lib/wallet";
 import { fetchAuthChallenge, verifyAuthChallenge, setJwtToken } from "@/lib/api";
 import "@/styles/globals.css";
 import { ToastProvider } from "@/components/Toast";
 import { PriceProvider } from "@/contexts/PriceContext";
+import ShortcutsModal from "@/components/ShortcutsModal";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 
 export default function App({ Component, pageProps }: AppProps) {
   const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [shortcutsModalOpen, setShortcutsModalOpen] = useState(false);
+  const router = useRouter();
+
+  const isJobDetailPage = router.pathname === "/jobs/[id]";
+
+  const handleToggleShortcutsModal = useCallback(() => {
+    setShortcutsModalOpen((current) => !current);
+  }, []);
+
+  useKeyboardShortcuts({
+    isJobDetailPage,
+    onGoToJobs: () => router.push("/jobs"),
+    onGoToDashboard: () => router.push("/dashboard"),
+    onNewJobPost: () => router.push("/post-job"),
+    onToggleShortcutsModal: handleToggleShortcutsModal,
+    onJobApply: () => window.dispatchEvent(new CustomEvent("shortcut-apply-job")),
+    onJobBackToListing: () => router.push("/jobs"),
+    shortcutsModalOpen,
+  });
 
   const handleAuthAndConnect = async (pk: string) => {
     try {
@@ -67,6 +89,11 @@ export default function App({ Component, pageProps }: AppProps) {
           <main>
             <Component {...pageProps} publicKey={publicKey} onConnect={handleConnect} />
           </main>
+          <ShortcutsModal
+            isOpen={shortcutsModalOpen}
+            onClose={() => setShortcutsModalOpen(false)}
+            showJobDetailShortcuts={isJobDetailPage}
+          />
         </div>
         </PriceProvider>
       </ToastProvider>

--- a/frontend/pages/jobs/[id].tsx
+++ b/frontend/pages/jobs/[id].tsx
@@ -130,6 +130,20 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
       .finally(() => setLoading(false));
   }, [id, router, router.isReady]);
 
+
+  useEffect(() => {
+    const handleApplyShortcut = () => {
+      if (job?.status !== "open") return;
+      if (!publicKey) return;
+      if (isClient) return;
+      if (hasApplied) return;
+      setShowApplyForm(true);
+    };
+
+    window.addEventListener("shortcut-apply-job", handleApplyShortcut);
+    return () => window.removeEventListener("shortcut-apply-job", handleApplyShortcut);
+  }, [job?.status, publicKey, isClient, hasApplied]);
+
   useEffect(() => {
     if (!isClient || applications.length === 0) {
       setApplicantProfiles({});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Stellar-MarketPay--frock",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Description
Added a reusable hook frontend/hooks/useKeyboardShortcuts.ts that registers global key handlers, supports G sequences with a timeout, ignores Ctrl/Cmd/Alt combos, and disables shortcuts when focus is in input/textarea/select/contenteditable elements.
Implemented the ShortcutsModal component at frontend/components/ShortcutsModal.tsx which displays key visuals (kbd) and route-aware entries (job-detail-only shortcuts included).
Wired shortcuts into the app shell in frontend/pages/_app.tsx to handle navigation (G then J → /jobs, G then D → /dashboard, N → /post-job) and toggling the modal with ?.
Integrated job-detail behavior in frontend/pages/jobs/[id].tsx so A triggers the apply flow via a shortcut-apply-job event and Esc navigates back to the listing (modal open blocks Esc).

Testing
Ran type checking with cd frontend && npm run type-check, which failed due to existing unrelated TypeScript errors in frontend/pages/jobs/[id].tsx and duplicate exports in frontend/utils/format.ts; no new shortcut-specific type errors were reported.
No automated end-to-end tests were added or executed for this change in this rollout.


## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #209 

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
