### PR TITLE
Add data-layer support for GitHub profiles, job analytics, and encrypted messages

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -26,7 +26,14 @@ ALTER TABLE profiles
 
 ALTER TABLE profiles
   ADD COLUMN IF NOT EXISTS did_hash TEXT,
-  ADD COLUMN IF NOT EXISTS is_kyc_verified BOOLEAN NOT NULL DEFAULT FALSE;
+  ADD COLUMN IF NOT EXISTS is_kyc_verified BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS github_username TEXT,
+  ADD COLUMN IF NOT EXISTS github_avatar_url TEXT,
+  ADD COLUMN IF NOT EXISTS github_profile_url TEXT,
+  ADD COLUMN IF NOT EXISTS github_primary_languages TEXT[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS github_top_repos JSONB NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS github_token_encrypted TEXT,
+  ADD COLUMN IF NOT EXISTS github_connected_at TIMESTAMPTZ;
 
 -- ─────────────────────────────────────────
 -- jobs
@@ -95,6 +102,36 @@ CREATE TABLE IF NOT EXISTS applications (
 
 CREATE INDEX IF NOT EXISTS applications_job_id_idx             ON applications(job_id);
 CREATE INDEX IF NOT EXISTS applications_freelancer_address_idx ON applications(freelancer_address);
+
+-- ─────────────────────────────────────────
+-- job analytics (Issue #212)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS job_views (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id          UUID        NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+  ip_hash         TEXT        NOT NULL,
+  viewed_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS job_views_job_id_idx ON job_views(job_id, viewed_at DESC);
+CREATE INDEX IF NOT EXISTS job_views_job_ip_idx ON job_views(job_id, ip_hash);
+
+-- ─────────────────────────────────────────
+-- encrypted private messages (Issue #213)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS private_messages (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  sender_address        TEXT        NOT NULL REFERENCES profiles(public_key),
+  recipient_address     TEXT        NOT NULL REFERENCES profiles(public_key),
+  sender_public_key     TEXT        NOT NULL,
+  recipient_public_key  TEXT        NOT NULL,
+  nonce                 TEXT        NOT NULL,
+  cipher_text           TEXT        NOT NULL,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS private_messages_participants_idx
+  ON private_messages(sender_address, recipient_address, created_at DESC);
 
 ALTER TABLE applications
   ADD COLUMN IF NOT EXISTS currency TEXT NOT NULL DEFAULT 'XLM',


### PR DESCRIPTION
## Summary
- Extend `profiles` with GitHub linkage fields (username, avatar, top repos, primary languages, encrypted token metadata).
- Add `job_views` table/indexes for per-job total and unique-view analytics support.
- Add `private_messages` table/index for storing encrypted direct-message payloads (nonce + ciphertext).

## Test plan
- Run backend migrations on startup and verify schema updates apply cleanly.
- Validate new tables/columns exist in PostgreSQL and can be queried.

Closes #211
Closes #213
Closes #212

Made with [Cursor](https://cursor.com)