### PR TITLE
feat: SEP-0024/SEP-0031 fiat gateways + Soroban fee estimation (#220, #222, #231)

### DIFF
--- a/frontend/components/BuyXLMModal.tsx
+++ b/frontend/components/BuyXLMModal.tsx
@@ -1,0 +1,217 @@
+/**
+ * components/BuyXLMModal.tsx
+ * SEP-0024 deposit flow — converts fiat to XLM via a Stellar anchor.
+ * (Issue #220)
+ */
+import { useEffect, useRef, useState } from "react";
+import {
+  ANCHOR_HOME_DOMAIN,
+  fetchAnchorEndpoints,
+  startInteractiveDeposit,
+  pollAnchorTransaction,
+  type AnchorTransactionRecord,
+} from "@/lib/anchors";
+import { useToast } from "@/components/Toast";
+import { usePriceContext } from "@/contexts/PriceContext";
+
+interface BuyXLMModalProps {
+  publicKey: string;
+  onClose: () => void;
+  /** Refresh the dashboard balance after a successful deposit. */
+  onComplete?: () => void;
+}
+
+type Phase = "idle" | "loading" | "interactive" | "polling" | "completed" | "error";
+
+export default function BuyXLMModal({ publicKey, onClose, onComplete }: BuyXLMModalProps) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [assetCode, setAssetCode] = useState<string>("XLM");
+  const [availableAssets, setAvailableAssets] = useState<string[]>(["XLM"]);
+  const [interactiveUrl, setInteractiveUrl] = useState<string | null>(null);
+  const [transaction, setTransaction] = useState<AnchorTransactionRecord | null>(null);
+  const cancelRef = useRef(false);
+  const popupRef = useRef<Window | null>(null);
+  const toast = useToast();
+  const { xlmPriceUsd } = usePriceContext();
+
+  useEffect(() => {
+    fetchAnchorEndpoints()
+      .then((endpoints) => {
+        const codes = endpoints.currencies.map((c) => c.code);
+        if (codes.length > 0) {
+          setAvailableAssets(codes);
+          if (!codes.includes(assetCode)) setAssetCode(codes[0]);
+        }
+      })
+      .catch(() => {
+        // If TOML fetch fails the user can still try; the deposit call will surface the error.
+      });
+    return () => {
+      cancelRef.current = true;
+      popupRef.current?.close();
+    };
+  }, [assetCode]);
+
+  const startDeposit = async () => {
+    setPhase("loading");
+    setErrorMessage(null);
+    try {
+      const response = await startInteractiveDeposit({
+        account: publicKey,
+        assetCode,
+      });
+
+      const popup = window.open(
+        `${response.url}${response.url.includes("?") ? "&" : "?"}callback=postMessage`,
+        "stellar-anchor-deposit",
+        "width=500,height=700"
+      );
+      popupRef.current = popup;
+      setInteractiveUrl(response.url);
+      setPhase("interactive");
+
+      const finalRecord = await pollAnchorTransaction({
+        account: publicKey,
+        id: response.id,
+        onUpdate: (record) => {
+          setTransaction(record);
+          if (phase === "interactive") setPhase("polling");
+        },
+        isCancelled: () => cancelRef.current,
+      });
+
+      if (cancelRef.current) return;
+
+      if (finalRecord?.status === "completed") {
+        setTransaction(finalRecord);
+        setPhase("completed");
+        toast.success(`Deposit complete — ${finalRecord.amount_out || ""} ${assetCode} arrived in your wallet.`);
+        onComplete?.();
+      } else if (finalRecord) {
+        setTransaction(finalRecord);
+        setPhase("error");
+        setErrorMessage(`Deposit ended with status "${finalRecord.status}".`);
+      } else {
+        setPhase("error");
+        setErrorMessage("Deposit timed out. Check the anchor's tracking page for status.");
+      }
+    } catch (error: unknown) {
+      setPhase("error");
+      setErrorMessage(error instanceof Error ? error.message : "Deposit failed.");
+    }
+  };
+
+  const usdNote =
+    xlmPriceUsd && transaction?.amount_out
+      ? `≈ $${(parseFloat(transaction.amount_out) * xlmPriceUsd).toFixed(2)} USD`
+      : null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4">
+      <div className="card max-w-md w-full bg-ink-900 border border-market-500/20 relative">
+        <button
+          onClick={() => {
+            cancelRef.current = true;
+            popupRef.current?.close();
+            onClose();
+          }}
+          className="absolute top-3 right-3 text-amber-700 hover:text-amber-300"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+
+        <h2 className="font-display text-xl font-bold text-amber-100 mb-1">Buy XLM with Fiat</h2>
+        <p className="text-xs text-amber-700 mb-5">
+          Powered by <span className="font-mono">{ANCHOR_HOME_DOMAIN}</span> via SEP-0024.
+        </p>
+
+        {phase === "idle" && (
+          <div className="space-y-4">
+            <label className="block">
+              <span className="label mb-1 block">Asset to receive</span>
+              <select
+                value={assetCode}
+                onChange={(e) => setAssetCode(e.target.value)}
+                className="input-field"
+              >
+                {availableAssets.map((code) => (
+                  <option key={code} value={code}>{code}</option>
+                ))}
+              </select>
+            </label>
+            <p className="text-xs text-amber-700">
+              You'll be redirected to the anchor's secure deposit page to enter your fiat
+              payment details. The funds arrive in this wallet ({publicKey.slice(0, 6)}…
+              {publicKey.slice(-4)}) once the anchor confirms the deposit.
+            </p>
+            <button onClick={startDeposit} className="btn-primary w-full">
+              Continue
+            </button>
+          </div>
+        )}
+
+        {phase === "loading" && (
+          <p className="text-amber-200 text-sm">Authenticating with the anchor…</p>
+        )}
+
+        {(phase === "interactive" || phase === "polling") && (
+          <div className="space-y-3">
+            <p className="text-amber-200 text-sm">
+              {phase === "interactive"
+                ? "Complete the deposit form in the popup window."
+                : `Anchor status: ${transaction?.status || "pending"}`}
+            </p>
+            {interactiveUrl && (
+              <a
+                href={interactiveUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="btn-secondary text-xs w-full text-center"
+              >
+                Reopen anchor window
+              </a>
+            )}
+            {transaction && (
+              <dl className="text-xs text-amber-200 space-y-1">
+                <div className="flex justify-between"><dt>Transaction ID</dt><dd className="font-mono">{transaction.id.slice(0, 10)}…</dd></div>
+                {transaction.amount_in && (
+                  <div className="flex justify-between"><dt>Amount in</dt><dd>{transaction.amount_in}</dd></div>
+                )}
+                {transaction.amount_out && (
+                  <div className="flex justify-between"><dt>Amount out</dt><dd>{transaction.amount_out} {assetCode}</dd></div>
+                )}
+              </dl>
+            )}
+          </div>
+        )}
+
+        {phase === "completed" && transaction && (
+          <div className="space-y-3">
+            <p className="text-emerald-400 text-sm font-medium">Deposit complete.</p>
+            <dl className="text-xs text-amber-200 space-y-1">
+              <div className="flex justify-between"><dt>Received</dt><dd>{transaction.amount_out} {assetCode} {usdNote && <span className="text-amber-700">({usdNote})</span>}</dd></div>
+              {transaction.stellar_transaction_id && (
+                <div className="flex justify-between">
+                  <dt>Stellar tx</dt>
+                  <dd className="font-mono">{transaction.stellar_transaction_id.slice(0, 10)}…</dd>
+                </div>
+              )}
+            </dl>
+            <button onClick={onClose} className="btn-primary w-full">Done</button>
+          </div>
+        )}
+
+        {phase === "error" && (
+          <div className="space-y-3">
+            <p className="text-red-400 text-sm">{errorMessage || "Something went wrong."}</p>
+            <button onClick={() => setPhase("idle")} className="btn-secondary w-full">
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/FeeEstimationModal.tsx
+++ b/frontend/components/FeeEstimationModal.tsx
@@ -1,0 +1,125 @@
+/**
+ * components/FeeEstimationModal.tsx
+ * Pre-flight confirmation for Soroban contract calls (Issue #222).
+ *
+ * Runs `simulateTransaction` to compute the actual fee, shows it in XLM
+ * and USD, warns when the wallet's XLM balance is below the fee, and lets
+ * the user cancel before signing.
+ */
+import { useEffect, useState } from "react";
+import type { Transaction } from "@stellar/stellar-sdk";
+import { estimateSorobanFee, describeContractCall, type FeeEstimate } from "@/lib/sorobanFees";
+import { getXLMBalance } from "@/lib/stellar";
+import { usePriceContext } from "@/contexts/PriceContext";
+
+interface FeeEstimationModalProps {
+  /** Pre-built (but not yet prepared) Soroban transaction. */
+  transaction: Transaction;
+  /** Contract function being called — used for the title. */
+  functionName: string;
+  /** Wallet that will sign and pay the fee. */
+  payerPublicKey: string;
+  /** User clicked "Confirm & Sign". */
+  onConfirm: () => void;
+  /** User cancelled or closed the modal. */
+  onCancel: () => void;
+}
+
+export default function FeeEstimationModal({
+  transaction,
+  functionName,
+  payerPublicKey,
+  onConfirm,
+  onCancel,
+}: FeeEstimationModalProps) {
+  const [estimate, setEstimate] = useState<FeeEstimate | null>(null);
+  const [balance, setBalance] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { xlmPriceUsd } = usePriceContext();
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      estimateSorobanFee(transaction, xlmPriceUsd),
+      getXLMBalance(payerPublicKey).catch(() => "0"),
+    ])
+      .then(([fee, bal]) => {
+        if (cancelled) return;
+        setEstimate(fee);
+        setBalance(bal);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Could not estimate fee.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [transaction, payerPublicKey, xlmPriceUsd]);
+
+  const balanceXlm = balance ? parseFloat(balance) : null;
+  const feeXlm = estimate ? parseFloat(estimate.totalXlm) : null;
+  const insufficient = balanceXlm !== null && feeXlm !== null && balanceXlm < feeXlm;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4">
+      <div className="card max-w-md w-full bg-ink-900 border border-market-500/20">
+        <h2 className="font-display text-xl font-bold text-amber-100 mb-1">
+          Confirm transaction
+        </h2>
+        <p className="text-xs text-amber-700 mb-4">
+          {describeContractCall(functionName)} — review the fee before signing.
+        </p>
+
+        {error && <p className="text-red-400 text-sm mb-3">{error}</p>}
+
+        {!estimate && !error && (
+          <p className="text-amber-200 text-sm mb-4">Simulating contract call…</p>
+        )}
+
+        {estimate && (
+          <dl className="text-sm text-amber-200 space-y-2 mb-4">
+            <div className="flex justify-between">
+              <dt className="text-amber-700">Function</dt>
+              <dd className="font-mono">{functionName}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-amber-700">Estimated fee</dt>
+              <dd className="font-mono">
+                {estimate.totalXlm} XLM
+                {estimate.totalUsd != null && (
+                  <span className="text-amber-700 ml-2">≈ ${estimate.totalUsd.toFixed(4)} USD</span>
+                )}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-amber-700">Wallet balance</dt>
+              <dd className="font-mono">
+                {balance ? `${parseFloat(balance).toLocaleString("en-US", { maximumFractionDigits: 7 })} XLM` : "—"}
+              </dd>
+            </div>
+          </dl>
+        )}
+
+        {insufficient && (
+          <p className="text-red-400 text-xs mb-3">
+            Insufficient balance — top up XLM and try again.
+          </p>
+        )}
+
+        <div className="flex gap-3">
+          <button onClick={onCancel} className="btn-secondary flex-1 text-sm">
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={!estimate || Boolean(error) || insufficient}
+            className="btn-primary flex-1 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Confirm & Sign
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/PostJobForm.tsx
+++ b/frontend/components/PostJobForm.tsx
@@ -4,14 +4,17 @@
  * Issue #21: Integrates Soroban escrow contract into job creation flow.
  */
 import { useEffect, useState } from "react";
+import type { Transaction } from "@stellar/stellar-sdk";
 import { createJob, updateJobEscrowId, deleteJob, saveDraft, fetchDrafts } from "@/lib/api";
 import { buildCreateEscrowTransaction, submitSorobanTransaction } from "@/lib/stellar";
+import { fetchActualFee } from "@/lib/sorobanFees";
 import { signTransactionWithWallet } from "@/lib/wallet";
 import { JOB_CATEGORIES, SKILL_SUGGESTIONS, formatUSDEquivalent, getMonthlyEstimate } from "@/utils/format";
 import { useRouter } from "next/router";
 import clsx from "clsx";
 import { useToast } from "@/components/Toast";
 import { usePriceContext } from "@/contexts/PriceContext";
+import FeeEstimationModal from "@/components/FeeEstimationModal";
 import type { Currency, Job } from "@/utils/types";
 
 interface PostJobFormProps { publicKey: string; }
@@ -77,6 +80,10 @@ export default function PostJobForm({ publicKey }: PostJobFormProps) {
   const [draftId, setDraftId] = useState<string | null>(null);
   const [showResumeDraft, setShowResumeDraft] = useState(false);
   const [availableDrafts, setAvailableDrafts] = useState<any[]>([]);
+  const [pendingEscrow, setPendingEscrow] = useState<{
+    transaction: Transaction;
+    jobId: string;
+  } | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -262,11 +269,8 @@ export default function PostJobForm({ publicKey }: PostJobFormProps) {
     setError(null);
     setStep("posting");
 
-    let job: Awaited<ReturnType<typeof createJob>> | null = null;
-
     try {
-      // Step 1 — Post job to backend
-      job = await createJob({
+      const job = await createJob({
         title: form.title.trim(),
         description: form.description.trim(),
         budget: parseFloat(form.budget).toFixed(7),
@@ -280,38 +284,19 @@ export default function PostJobForm({ publicKey }: PostJobFormProps) {
         screeningQuestions: screeningQuestions.filter(q => q.trim().length > 0),
       });
 
-      // Step 2 — Build & sign Soroban create_escrow() transaction
       setStep("locking");
 
       const unsignedTx = await buildCreateEscrowTransaction({
         clientPublicKey: publicKey,
         jobId: job.id,
-        // Use client as placeholder freelancer until one is hired
         freelancerAddress: publicKey,
         budget: parseFloat(form.budget).toFixed(7),
         currency: form.currency,
       });
 
-      const { signedXDR, error: signError } = await signTransactionWithWallet(unsignedTx.toXDR());
-      if (signError || !signedXDR) {
-        // Roll back: remove the orphaned job from the backend
-        await deleteJob(job.id).catch(() => {}); // best-effort
-        throw new Error(signError || "Freighter signing was cancelled");
-      }
-
-      // Step 3 — Submit to Soroban RPC and wait for confirmation
-      const txHash = await submitSorobanTransaction(signedXDR).catch(async (e) => {
-        // Roll back: remove the orphaned job from the backend
-        await deleteJob(job!.id).catch(() => {});
-        throw e;
-      });
-
-      // Step 4 — Persist escrow contract ID in the job record
-      await updateJobEscrowId(job.id, txHash);
-
-      setStep("done");
-      toast.success("Job posted and budget locked in escrow.");
-      router.push(`/jobs/${job.id}`);
+      // Pause here so the user can review the on-chain fee (Issue #222)
+      // before Freighter prompts them to sign.
+      setPendingEscrow({ transaction: unsignedTx, jobId: job.id });
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Unknown error";
       setError(msg);
@@ -319,6 +304,55 @@ export default function PostJobForm({ publicKey }: PostJobFormProps) {
       toast.error(`Failed: ${msg}`);
       setLoading(false);
     }
+  };
+
+  const handleConfirmEscrowFee = async () => {
+    if (!pendingEscrow) return;
+    const { transaction, jobId } = pendingEscrow;
+    setPendingEscrow(null);
+
+    try {
+      const { signedXDR, error: signError } = await signTransactionWithWallet(transaction.toXDR());
+      if (signError || !signedXDR) {
+        await deleteJob(jobId).catch(() => {});
+        throw new Error(signError || "Freighter signing was cancelled");
+      }
+
+      const txHash = await submitSorobanTransaction(signedXDR).catch(async (e) => {
+        await deleteJob(jobId).catch(() => {});
+        throw e;
+      });
+
+      // Log the actual fee charged for the AC.
+      fetchActualFee(txHash).then((actual) => {
+        if (actual) {
+          // eslint-disable-next-line no-console
+          console.info(`[escrow] create_escrow ${jobId} actual fee ${actual.feeChargedXlm} XLM`);
+        }
+      }).catch(() => {});
+
+      await updateJobEscrowId(jobId, txHash);
+
+      setStep("done");
+      toast.success("Job posted and budget locked in escrow.");
+      router.push(`/jobs/${jobId}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      setError(msg);
+      setStep("error");
+      toast.error(`Failed: ${msg}`);
+      setLoading(false);
+    }
+  };
+
+  const handleCancelEscrowFee = async () => {
+    if (!pendingEscrow) return;
+    const { jobId } = pendingEscrow;
+    setPendingEscrow(null);
+    await deleteJob(jobId).catch(() => {});
+    setStep("idle");
+    setLoading(false);
+    setError("Cancelled before signing — the orphaned job was removed.");
   };
 
   const handleLoadTemplate = (name: string) => {
@@ -814,6 +848,16 @@ export default function PostJobForm({ publicKey }: PostJobFormProps) {
           By posting, budget ({form.budget ? `${form.budget} ${form.currency}` : "—"}) will be held in a Soroban escrow contract and released when you approve of completed work.
         </p>
       </div>
+
+      {pendingEscrow && (
+        <FeeEstimationModal
+          transaction={pendingEscrow.transaction}
+          functionName="create_escrow"
+          payerPublicKey={publicKey}
+          onConfirm={handleConfirmEscrowFee}
+          onCancel={handleCancelEscrowFee}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/components/WithdrawToBankModal.tsx
+++ b/frontend/components/WithdrawToBankModal.tsx
@@ -1,0 +1,358 @@
+/**
+ * components/WithdrawToBankModal.tsx
+ * Cross-border withdraw flow (Issue #231).
+ *
+ * Tries SEP-0031 (direct cross-border payments) first when the anchor
+ * advertises it; falls back to SEP-0024 interactive withdraw, which
+ * provides a comparable bank-payout UX through the anchor's hosted form.
+ *
+ * Withdrawal history is persisted client-side in localStorage so the user
+ * can review past withdrawals from the dashboard.
+ */
+import { useEffect, useRef, useState } from "react";
+import {
+  ANCHOR_HOME_DOMAIN,
+  fetchAnchorEndpoints,
+  fetchSep31Info,
+  initiateSep31Send,
+  startInteractiveWithdraw,
+  pollAnchorTransaction,
+  type AnchorTransactionRecord,
+} from "@/lib/anchors";
+import { useToast } from "@/components/Toast";
+
+interface WithdrawToBankModalProps {
+  publicKey: string;
+  onClose: () => void;
+}
+
+export type WithdrawHistoryEntry = {
+  id: string;
+  flow: "SEP-31" | "SEP-24";
+  asset: string;
+  fiatCurrency: string;
+  amount: string;
+  status: string;
+  startedAt: string;
+  completedAt?: string;
+  stellarTxId?: string;
+  externalTxId?: string;
+};
+
+const HISTORY_KEY = "marketpay_withdraw_history";
+const FIAT_CURRENCIES = ["USD", "EUR", "NGN"] as const;
+type FiatCurrency = (typeof FIAT_CURRENCIES)[number];
+
+/** Returns the most-recent first list of withdrawals saved on this device. */
+export function loadWithdrawHistory(): WithdrawHistoryEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as WithdrawHistoryEntry[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(entries: WithdrawHistoryEntry[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(HISTORY_KEY, JSON.stringify(entries.slice(0, 50)));
+}
+
+function upsertHistory(entry: WithdrawHistoryEntry) {
+  const existing = loadWithdrawHistory();
+  const filtered = existing.filter((e) => e.id !== entry.id);
+  saveHistory([entry, ...filtered]);
+}
+
+type Phase = "form" | "loading" | "interactive" | "polling" | "completed" | "error";
+
+export default function WithdrawToBankModal({ publicKey, onClose }: WithdrawToBankModalProps) {
+  const [phase, setPhase] = useState<Phase>("form");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [asset, setAsset] = useState<string>("USDC");
+  const [availableAssets, setAvailableAssets] = useState<string[]>([]);
+  const [fiat, setFiat] = useState<FiatCurrency>("USD");
+  const [amount, setAmount] = useState<string>("");
+  const [supportsSep31, setSupportsSep31] = useState<boolean>(false);
+  const [interactiveUrl, setInteractiveUrl] = useState<string | null>(null);
+  const [transaction, setTransaction] = useState<AnchorTransactionRecord | null>(null);
+  const cancelRef = useRef(false);
+  const popupRef = useRef<Window | null>(null);
+  const toast = useToast();
+
+  useEffect(() => {
+    let isMounted = true;
+    fetchAnchorEndpoints()
+      .then(async (endpoints) => {
+        if (!isMounted) return;
+        const codes = endpoints.currencies.map((c) => c.code);
+        if (codes.length > 0) {
+          setAvailableAssets(codes);
+          if (!codes.includes(asset)) setAsset(codes[0]);
+        }
+        if (endpoints.directPaymentServer) {
+          const info = await fetchSep31Info().catch(() => null);
+          if (isMounted && info) {
+            setSupportsSep31(Object.values(info.receive || {}).some((cfg) => cfg.enabled));
+          }
+        }
+      })
+      .catch(() => {
+        // Surface a generic error if the user attempts to withdraw without TOML.
+      });
+
+    return () => {
+      isMounted = false;
+      cancelRef.current = true;
+      popupRef.current?.close();
+    };
+  }, [asset]);
+
+  const validate = (): string | null => {
+    const numeric = parseFloat(amount);
+    if (!amount || isNaN(numeric) || numeric <= 0) return "Enter an amount greater than 0.";
+    if (!asset) return "Pick an asset to withdraw.";
+    return null;
+  };
+
+  const startWithdraw = async () => {
+    const error = validate();
+    if (error) {
+      setErrorMessage(error);
+      return;
+    }
+    setErrorMessage(null);
+    setPhase("loading");
+
+    try {
+      let id: string | null = null;
+      let usedFlow: "SEP-31" | "SEP-24" = "SEP-24";
+
+      if (supportsSep31) {
+        usedFlow = "SEP-31";
+        // SEP-0031 requires the sender to register KYC fields via SEP-0012.
+        // For most anchors, those fields are collected through the anchor's
+        // own form (linked from the transaction's `more_info_url`).
+        const sendResult = await initiateSep31Send({
+          account: publicKey,
+          amount,
+          assetCode: asset,
+          fields: {
+            transaction: { receiver_currency: fiat },
+          },
+        }).catch((sendErr) => {
+          // If the anchor rejects (e.g. unsupported field), fall back to SEP-24.
+          // eslint-disable-next-line no-console
+          console.warn("SEP-31 send failed, falling back to SEP-24:", sendErr);
+          return null;
+        });
+        id = sendResult?.id || null;
+      }
+
+      if (!id) {
+        usedFlow = "SEP-24";
+        const interactive = await startInteractiveWithdraw({
+          account: publicKey,
+          assetCode: asset,
+        });
+        id = interactive.id;
+        const popup = window.open(
+          interactive.url,
+          "stellar-anchor-withdraw",
+          "width=500,height=700"
+        );
+        popupRef.current = popup;
+        setInteractiveUrl(interactive.url);
+        setPhase("interactive");
+      } else {
+        setPhase("polling");
+      }
+
+      const startedAt = new Date().toISOString();
+      upsertHistory({
+        id,
+        flow: usedFlow,
+        asset,
+        fiatCurrency: fiat,
+        amount,
+        status: "started",
+        startedAt,
+      });
+
+      const finalRecord = await pollAnchorTransaction({
+        account: publicKey,
+        id,
+        onUpdate: (record) => {
+          setTransaction(record);
+          if (phase === "interactive") setPhase("polling");
+          upsertHistory({
+            id,
+            flow: usedFlow,
+            asset,
+            fiatCurrency: fiat,
+            amount: record.amount_in || amount,
+            status: record.status,
+            startedAt,
+            completedAt: record.completed_at,
+            stellarTxId: record.stellar_transaction_id,
+            externalTxId: record.external_transaction_id,
+          });
+        },
+        isCancelled: () => cancelRef.current,
+      });
+
+      if (cancelRef.current) return;
+      if (finalRecord?.status === "completed") {
+        setTransaction(finalRecord);
+        setPhase("completed");
+        toast.success(`Withdrawal complete — ${finalRecord.amount_out || amount} ${fiat} sent to your bank.`);
+      } else if (finalRecord) {
+        setTransaction(finalRecord);
+        setPhase("error");
+        setErrorMessage(`Withdrawal ended with status "${finalRecord.status}".`);
+      } else {
+        setPhase("error");
+        setErrorMessage("Withdrawal timed out. Check the anchor's tracking page.");
+      }
+    } catch (err: unknown) {
+      setPhase("error");
+      setErrorMessage(err instanceof Error ? err.message : "Withdrawal failed.");
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4">
+      <div className="card max-w-md w-full bg-ink-900 border border-market-500/20 relative">
+        <button
+          onClick={() => {
+            cancelRef.current = true;
+            popupRef.current?.close();
+            onClose();
+          }}
+          className="absolute top-3 right-3 text-amber-700 hover:text-amber-300"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+
+        <h2 className="font-display text-xl font-bold text-amber-100 mb-1">Withdraw to Bank</h2>
+        <p className="text-xs text-amber-700 mb-5">
+          Powered by <span className="font-mono">{ANCHOR_HOME_DOMAIN}</span>{" "}
+          {supportsSep31 ? "via SEP-0031" : "via SEP-0024"}.
+        </p>
+
+        {phase === "form" && (
+          <div className="space-y-4">
+            <label className="block">
+              <span className="label mb-1 block">Asset to send</span>
+              <select value={asset} onChange={(e) => setAsset(e.target.value)} className="input-field">
+                {(availableAssets.length ? availableAssets : ["USDC", "XLM"]).map((code) => (
+                  <option key={code} value={code}>{code}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="label mb-1 block">Amount</span>
+              <input
+                type="number"
+                inputMode="decimal"
+                step="0.0000001"
+                min="0"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                className="input-field"
+                placeholder="100"
+              />
+            </label>
+
+            <label className="block">
+              <span className="label mb-1 block">Receive currency</span>
+              <select
+                value={fiat}
+                onChange={(e) => setFiat(e.target.value as FiatCurrency)}
+                className="input-field"
+              >
+                {FIAT_CURRENCIES.map((code) => (
+                  <option key={code} value={code}>{code}</option>
+                ))}
+              </select>
+            </label>
+
+            {errorMessage && <p className="text-red-400 text-sm">{errorMessage}</p>}
+
+            <p className="text-xs text-amber-700">
+              You'll provide your bank details on the anchor's secure form. The anchor
+              receives the {asset} payment from this wallet and pays out {fiat} to your
+              registered account.
+            </p>
+            <button onClick={startWithdraw} className="btn-primary w-full">
+              Continue
+            </button>
+          </div>
+        )}
+
+        {phase === "loading" && <p className="text-amber-200 text-sm">Authenticating with the anchor…</p>}
+
+        {(phase === "interactive" || phase === "polling") && (
+          <div className="space-y-3">
+            <p className="text-amber-200 text-sm">
+              {phase === "interactive"
+                ? "Complete the withdrawal form in the popup."
+                : `Anchor status: ${transaction?.status || "pending"}`}
+            </p>
+            {interactiveUrl && (
+              <a
+                href={interactiveUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="btn-secondary text-xs w-full text-center"
+              >
+                Reopen anchor window
+              </a>
+            )}
+            {transaction && (
+              <dl className="text-xs text-amber-200 space-y-1">
+                <div className="flex justify-between"><dt>Transaction ID</dt><dd className="font-mono">{transaction.id.slice(0, 10)}…</dd></div>
+                {transaction.amount_in && (
+                  <div className="flex justify-between"><dt>Amount sent</dt><dd>{transaction.amount_in} {asset}</dd></div>
+                )}
+                {transaction.amount_out && (
+                  <div className="flex justify-between"><dt>Estimated payout</dt><dd>{transaction.amount_out} {fiat}</dd></div>
+                )}
+              </dl>
+            )}
+          </div>
+        )}
+
+        {phase === "completed" && transaction && (
+          <div className="space-y-3">
+            <p className="text-emerald-400 text-sm font-medium">Withdrawal complete.</p>
+            <dl className="text-xs text-amber-200 space-y-1">
+              <div className="flex justify-between"><dt>Sent to bank</dt><dd>{transaction.amount_out} {fiat}</dd></div>
+              {transaction.external_transaction_id && (
+                <div className="flex justify-between">
+                  <dt>Bank reference</dt>
+                  <dd className="font-mono">{transaction.external_transaction_id.slice(0, 14)}…</dd>
+                </div>
+              )}
+            </dl>
+            <button onClick={onClose} className="btn-primary w-full">Done</button>
+          </div>
+        )}
+
+        {phase === "error" && (
+          <div className="space-y-3">
+            <p className="text-red-400 text-sm">{errorMessage || "Something went wrong."}</p>
+            <button onClick={() => setPhase("form")} className="btn-secondary w-full">
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/anchors.ts
+++ b/frontend/lib/anchors.ts
@@ -1,0 +1,316 @@
+/**
+ * lib/anchors.ts
+ * Stellar anchor integration: SEP-0001 (TOML discovery), SEP-0010 (auth),
+ * SEP-0024 (interactive deposit/withdraw), SEP-0031 (cross-border send).
+ *
+ * Powers the "Buy XLM" (Issue #220) and "Withdraw to Bank" (Issue #231) flows.
+ */
+
+import { signTransactionWithWallet } from "./wallet";
+
+const NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet") as "testnet" | "mainnet";
+
+/** Anchor home domain. The Stellar reference anchor is used on testnet. */
+export const ANCHOR_HOME_DOMAIN =
+  process.env.NEXT_PUBLIC_ANCHOR_HOME_DOMAIN ||
+  (NETWORK === "mainnet" ? "" : "testanchor.stellar.org");
+
+export interface AnchorEndpoints {
+  homeDomain: string;
+  webAuthEndpoint: string;
+  transferServerSep24: string | null;
+  directPaymentServer: string | null; // SEP-0031
+  signingKey: string;
+  currencies: Array<{ code: string; issuer?: string }>;
+}
+
+/** Cache TOML lookups for the lifetime of the page. */
+const tomlCache = new Map<string, AnchorEndpoints>();
+
+/**
+ * Fetch the anchor's stellar.toml and parse the endpoints we care about.
+ * Uses a tiny line-based parser — enough for the keys we need without pulling
+ * in a TOML library.
+ */
+export async function fetchAnchorEndpoints(homeDomain = ANCHOR_HOME_DOMAIN): Promise<AnchorEndpoints> {
+  if (!homeDomain) throw new Error("No anchor configured. Set NEXT_PUBLIC_ANCHOR_HOME_DOMAIN.");
+  const cached = tomlCache.get(homeDomain);
+  if (cached) return cached;
+
+  const url = `https://${homeDomain}/.well-known/stellar.toml`;
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Could not fetch anchor TOML (${response.status}).`);
+  const text = await response.text();
+
+  const single = (key: string): string | null => {
+    const match = text.match(new RegExp(`^${key}\\s*=\\s*"([^"]+)"`, "m"));
+    return match ? match[1] : null;
+  };
+
+  const currencies: AnchorEndpoints["currencies"] = [];
+  const currencyBlockRegex = /\[\[CURRENCIES\]\]([\s\S]*?)(?=\n\[|$)/g;
+  let block: RegExpExecArray | null;
+  while ((block = currencyBlockRegex.exec(text)) !== null) {
+    const code = block[1].match(/code\s*=\s*"([^"]+)"/)?.[1];
+    const issuer = block[1].match(/issuer\s*=\s*"([^"]+)"/)?.[1];
+    if (code) currencies.push({ code, issuer });
+  }
+
+  const endpoints: AnchorEndpoints = {
+    homeDomain,
+    webAuthEndpoint: single("WEB_AUTH_ENDPOINT") || "",
+    transferServerSep24: single("TRANSFER_SERVER_SEP0024") || single("TRANSFER_SERVER"),
+    directPaymentServer: single("DIRECT_PAYMENT_SERVER"),
+    signingKey: single("SIGNING_KEY") || "",
+    currencies,
+  };
+
+  if (!endpoints.webAuthEndpoint) throw new Error("Anchor TOML is missing WEB_AUTH_ENDPOINT.");
+  tomlCache.set(homeDomain, endpoints);
+  return endpoints;
+}
+
+// ─── SEP-0010 — Web Authentication ───────────────────────────────────────────
+
+const tokenCache = new Map<string, { jwt: string; expiresAt: number }>();
+
+/**
+ * Performs the SEP-0010 challenge flow against an anchor and returns a JWT.
+ * Cached for ~50 minutes per (homeDomain, account) pair to avoid repeated prompts.
+ */
+export async function getAnchorJwt(homeDomain: string, account: string): Promise<string> {
+  const cacheKey = `${homeDomain}:${account}`;
+  const cached = tokenCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.jwt;
+
+  const endpoints = await fetchAnchorEndpoints(homeDomain);
+  const challengeUrl = `${endpoints.webAuthEndpoint}?account=${encodeURIComponent(account)}&home_domain=${encodeURIComponent(homeDomain)}`;
+
+  const challengeResponse = await fetch(challengeUrl);
+  if (!challengeResponse.ok) throw new Error(`Anchor auth challenge failed (${challengeResponse.status}).`);
+  const { transaction } = (await challengeResponse.json()) as { transaction: string };
+  if (!transaction) throw new Error("Anchor did not return a challenge transaction.");
+
+  const { signedXDR, error: signError } = await signTransactionWithWallet(transaction);
+  if (signError || !signedXDR) throw new Error(signError || "Anchor sign-in was cancelled.");
+
+  const verifyResponse = await fetch(endpoints.webAuthEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ transaction: signedXDR }),
+  });
+  if (!verifyResponse.ok) throw new Error(`Anchor JWT exchange failed (${verifyResponse.status}).`);
+  const { token } = (await verifyResponse.json()) as { token: string };
+  if (!token) throw new Error("Anchor did not return a JWT.");
+
+  tokenCache.set(cacheKey, { jwt: token, expiresAt: Date.now() + 50 * 60 * 1000 });
+  return token;
+}
+
+// ─── SEP-0024 — Interactive Deposit / Withdraw ───────────────────────────────
+
+export interface InteractiveTxResponse {
+  type: string;
+  url: string;
+  id: string;
+}
+
+export interface AnchorTransactionRecord {
+  id: string;
+  kind: "deposit" | "withdrawal";
+  status: string;
+  status_eta?: number;
+  amount_in?: string;
+  amount_out?: string;
+  amount_fee?: string;
+  started_at?: string;
+  completed_at?: string;
+  stellar_transaction_id?: string;
+  external_transaction_id?: string;
+  message?: string;
+  more_info_url?: string;
+}
+
+async function startInteractive(
+  flow: "deposit" | "withdraw",
+  params: { homeDomain: string; account: string; assetCode: string; lang?: string }
+): Promise<InteractiveTxResponse> {
+  const endpoints = await fetchAnchorEndpoints(params.homeDomain);
+  if (!endpoints.transferServerSep24) {
+    throw new Error("This anchor does not support SEP-0024 interactive transfers.");
+  }
+  const jwt = await getAnchorJwt(params.homeDomain, params.account);
+
+  const formBody = new URLSearchParams({
+    asset_code: params.assetCode,
+    account: params.account,
+    lang: params.lang || "en",
+  }).toString();
+
+  const response = await fetch(`${endpoints.transferServerSep24}/transactions/${flow}/interactive`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: formBody,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`Anchor ${flow} request failed (${response.status}): ${detail.slice(0, 200)}`);
+  }
+  return (await response.json()) as InteractiveTxResponse;
+}
+
+export function startInteractiveDeposit(params: {
+  homeDomain?: string;
+  account: string;
+  assetCode: string;
+  lang?: string;
+}) {
+  return startInteractive("deposit", { ...params, homeDomain: params.homeDomain || ANCHOR_HOME_DOMAIN });
+}
+
+export function startInteractiveWithdraw(params: {
+  homeDomain?: string;
+  account: string;
+  assetCode: string;
+  lang?: string;
+}) {
+  return startInteractive("withdraw", { ...params, homeDomain: params.homeDomain || ANCHOR_HOME_DOMAIN });
+}
+
+export async function fetchAnchorTransaction(params: {
+  homeDomain?: string;
+  account: string;
+  id: string;
+}): Promise<AnchorTransactionRecord | null> {
+  const homeDomain = params.homeDomain || ANCHOR_HOME_DOMAIN;
+  const endpoints = await fetchAnchorEndpoints(homeDomain);
+  if (!endpoints.transferServerSep24) return null;
+  const jwt = await getAnchorJwt(homeDomain, params.account);
+
+  const response = await fetch(`${endpoints.transferServerSep24}/transaction?id=${encodeURIComponent(params.id)}`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  if (!response.ok) return null;
+  const data = (await response.json()) as { transaction?: AnchorTransactionRecord };
+  return data.transaction || null;
+}
+
+/** SEP-0024 terminal statuses — once reached, no further polling is useful. */
+export const ANCHOR_TERMINAL_STATUSES = new Set([
+  "completed",
+  "refunded",
+  "expired",
+  "no_market",
+  "too_small",
+  "too_large",
+  "error",
+]);
+
+/**
+ * Polls the anchor every `intervalMs` until a terminal status is reached or
+ * `timeoutMs` elapses. Calls `onUpdate` on every fetched record.
+ */
+export async function pollAnchorTransaction(params: {
+  homeDomain?: string;
+  account: string;
+  id: string;
+  intervalMs?: number;
+  timeoutMs?: number;
+  onUpdate?: (record: AnchorTransactionRecord) => void;
+  isCancelled?: () => boolean;
+}): Promise<AnchorTransactionRecord | null> {
+  const interval = params.intervalMs || 4000;
+  const deadline = Date.now() + (params.timeoutMs || 20 * 60 * 1000);
+
+  while (Date.now() < deadline) {
+    if (params.isCancelled?.()) return null;
+    const record = await fetchAnchorTransaction(params).catch(() => null);
+    if (record) {
+      params.onUpdate?.(record);
+      if (ANCHOR_TERMINAL_STATUSES.has(record.status)) return record;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  return null;
+}
+
+// ─── SEP-0031 — Direct (Cross-Border) Payments ───────────────────────────────
+
+export interface Sep31Info {
+  receive: Record<
+    string,
+    {
+      enabled: boolean;
+      min_amount?: number;
+      max_amount?: number;
+      sep12: { sender?: { types?: Record<string, unknown> }; receiver?: { types?: Record<string, unknown> } };
+      fields?: { transaction?: Record<string, { description?: string; optional?: boolean }> };
+    }
+  >;
+}
+
+export async function fetchSep31Info(homeDomain = ANCHOR_HOME_DOMAIN): Promise<Sep31Info | null> {
+  const endpoints = await fetchAnchorEndpoints(homeDomain);
+  if (!endpoints.directPaymentServer) return null;
+  const response = await fetch(`${endpoints.directPaymentServer}/info`);
+  if (!response.ok) return null;
+  return (await response.json()) as Sep31Info;
+}
+
+/**
+ * Initiate a SEP-0031 send. The caller is responsible for collecting any
+ * KYC fields the anchor needs (via SEP-0012) and passing them in `fields`.
+ *
+ * Returns the anchor's payout instructions: the Stellar address to send to,
+ * a memo, and the transaction id used for status polling.
+ */
+export async function initiateSep31Send(params: {
+  homeDomain?: string;
+  account: string;
+  amount: string;
+  assetCode: string;
+  assetIssuer?: string;
+  senderId?: string;
+  receiverId?: string;
+  fields?: Record<string, Record<string, string>>;
+  quoteId?: string;
+}): Promise<{
+  id: string;
+  stellar_account_id: string;
+  stellar_memo?: string;
+  stellar_memo_type?: string;
+} | null> {
+  const homeDomain = params.homeDomain || ANCHOR_HOME_DOMAIN;
+  const endpoints = await fetchAnchorEndpoints(homeDomain);
+  if (!endpoints.directPaymentServer) {
+    throw new Error("This anchor does not support SEP-0031 cross-border payments.");
+  }
+  const jwt = await getAnchorJwt(homeDomain, params.account);
+
+  const response = await fetch(`${endpoints.directPaymentServer}/transactions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      amount: params.amount,
+      asset_code: params.assetCode,
+      asset_issuer: params.assetIssuer,
+      sender_id: params.senderId,
+      receiver_id: params.receiverId,
+      quote_id: params.quoteId,
+      fields: params.fields,
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`SEP-0031 transaction failed (${response.status}): ${detail.slice(0, 200)}`);
+  }
+  return await response.json();
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -322,7 +322,6 @@ export async function fetchRatings(publicKey: string) {
   );
   return data.data;
 }
-}
 
 // ─── Job Suggestions (Autocomplete) ─────────────────────────────────────
 

--- a/frontend/lib/sorobanFees.ts
+++ b/frontend/lib/sorobanFees.ts
@@ -1,0 +1,107 @@
+/**
+ * lib/sorobanFees.ts
+ * Fee estimation for Soroban contract calls (Issue #222).
+ *
+ * Uses `simulateTransaction` to compute the minimum fee a contract call
+ * will need, so the user can review and confirm before signing.
+ */
+
+import { Transaction, SorobanRpc } from "@stellar/stellar-sdk";
+import { sorobanServer, NETWORK_PASSPHRASE } from "./stellar";
+
+export interface FeeEstimate {
+  /** Sum of base fee + Soroban resource fee, in stroops. */
+  totalStroops: bigint;
+  /** Same value as a human-readable XLM amount (max 7 decimals). */
+  totalXlm: string;
+  /** USD equivalent — null if no price available. */
+  totalUsd: number | null;
+  /** Just the resource (CPU/memory/storage) portion. */
+  resourceFeeStroops: bigint;
+  /** The base inclusion fee that was set on the transaction. */
+  inclusionFeeStroops: bigint;
+}
+
+const STROOPS_PER_XLM = BigInt(10_000_000);
+
+function stroopsToXlm(stroops: bigint): string {
+  const integer = stroops / STROOPS_PER_XLM;
+  const fraction = stroops % STROOPS_PER_XLM;
+  const fractionStr = fraction.toString().padStart(7, "0").replace(/0+$/, "");
+  return fractionStr ? `${integer}.${fractionStr}` : integer.toString();
+}
+
+/**
+ * Run `simulateTransaction` on a Soroban transaction and return the fee that
+ * will actually be charged. Throws a friendly error if simulation fails.
+ */
+export async function estimateSorobanFee(
+  tx: Transaction,
+  xlmPriceUsd: number | null
+): Promise<FeeEstimate> {
+  const sim = await sorobanServer.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Could not estimate fee — the contract rejected the call: ${sim.error}`);
+  }
+
+  const resourceFeeStroops = BigInt(sim.minResourceFee || "0");
+  const inclusionFeeStroops = BigInt(tx.fee || "0");
+  const totalStroops = resourceFeeStroops + inclusionFeeStroops;
+
+  const totalXlm = stroopsToXlm(totalStroops);
+  const totalUsd = typeof xlmPriceUsd === "number" ? Number(totalXlm) * xlmPriceUsd : null;
+
+  return {
+    totalStroops,
+    totalXlm,
+    totalUsd,
+    resourceFeeStroops,
+    inclusionFeeStroops,
+  };
+}
+
+/**
+ * After submission, Horizon/RPC reports the actual fee charged.
+ * Used for the post-confirmation log line in the AC.
+ */
+export async function fetchActualFee(txHash: string): Promise<{
+  feeChargedStroops: bigint;
+  feeChargedXlm: string;
+} | null> {
+  try {
+    const info = await sorobanServer.getTransaction(txHash);
+    if (info.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) return null;
+    // Fee data is most reliably parsed from the result envelope.
+    const meta = (info as unknown as { resultMetaXdr?: unknown }).resultMetaXdr;
+    if (!meta) return null;
+    // The envelope stores the fee in the txInternal: rather than parse XDR
+    // here we rely on resultXdr/feeCharged when present.
+    const feeChargedRaw = (info as unknown as { feeCharged?: string | number }).feeCharged;
+    if (feeChargedRaw == null) return null;
+    const feeChargedStroops = BigInt(feeChargedRaw);
+    return {
+      feeChargedStroops,
+      feeChargedXlm: stroopsToXlm(feeChargedStroops),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Human label for a contract call, used in the confirmation modal. */
+export function describeContractCall(fnName: string): string {
+  const labels: Record<string, string> = {
+    create_escrow: "Lock job budget in escrow",
+    start_work: "Mark job as in progress",
+    release_escrow: "Release escrow to freelancer",
+    release_with_conversion: "Release escrow with currency conversion",
+    refund_escrow: "Refund escrow to client",
+    raise_dispute: "Raise dispute on escrow",
+    mint_certificate: "Mint completion certificate",
+    cast_vote: "Cast governance vote",
+  };
+  return labels[fnName] || fnName.replace(/_/g, " ");
+}
+
+export { stroopsToXlm, NETWORK_PASSPHRASE };

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -21,15 +21,22 @@ import { formatXLM, shortenAddress, timeAgo, statusLabel, statusClass, copyToCli
 import type { Job, Application } from "@/utils/types";
 import EditProfileForm from "@/components/EditProfileForm";
 import SendPaymentForm from "@/components/SendPaymentForm";
+import BuyXLMModal from "@/components/BuyXLMModal";
+import WithdrawToBankModal, {
+  loadWithdrawHistory,
+  type WithdrawHistoryEntry,
+} from "@/components/WithdrawToBankModal";
 import { useToast } from "@/components/Toast";
 import clsx from "clsx";
+
+const LOW_BALANCE_THRESHOLD_XLM = 5;
 
 interface DashboardProps {
   publicKey: string | null;
   onConnect: (pk: string) => void;
 }
 
-type Tab = "posted" | "applied" | "send" | "edit_profile" | "templates" | "price_alerts";
+type Tab = "posted" | "applied" | "send" | "edit_profile" | "templates" | "price_alerts" | "withdrawals";
 const REPOST_JOB_PREFILL_STORAGE_KEY = "marketpay_repost_job_prefill";
 
 export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
@@ -44,12 +51,25 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   const [copyError, setCopyError] = useState(false);
 
   const [processedTxs, setProcessedTxs] = useState<Set<string>>(new Set());
+  const [templates, setTemplates] = useState<{ id: string; name: string; content: string }[]>([]);
+  const [templateName, setTemplateName] = useState("");
+  const [templateContent, setTemplateContent] = useState("");
+  const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
+  const [minPrice, setMinPrice] = useState("");
+  const [maxPrice, setMaxPrice] = useState("");
+  const [emailEnabled, setEmailEnabled] = useState(false);
+  const [alertEmail, setAlertEmail] = useState("");
+  const [showBuyXLM, setShowBuyXLM] = useState(false);
+  const [showWithdraw, setShowWithdraw] = useState(false);
+  const [withdrawHistory, setWithdrawHistory] = useState<WithdrawHistoryEntry[]>([]);
   const { info, success } = useToast();
+
+  const isRepostable = (status: Job["status"]) => status === "expired" || status === "cancelled";
 
   const handleCopy = async () => {
     if (!publicKey) return;
-    const success = await copyToClipboard(publicKey);
-    if (success) {
+    const ok = await copyToClipboard(publicKey);
+    if (ok) {
       setCopied(true);
       setCopyError(false);
       setTimeout(() => setCopied(false), 2000);
@@ -63,17 +83,11 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
     router.push({
       pathname: "/post-job",
       query: {
-  const [processedTxs, setProcessedTxs] = useState<Set<string>>(new Set());
-  const [templates, setTemplates] = useState<{ id: string; name: string; content: string }[]>([]);
-  const [templateName, setTemplateName] = useState("");
-  const [templateContent, setTemplateContent] = useState("");
-  const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
-  const [minPrice, setMinPrice] = useState("");
-  const [maxPrice, setMaxPrice] = useState("");
-  const [emailEnabled, setEmailEnabled] = useState(false);
-  const [alertEmail, setAlertEmail] = useState("");
-  const { info, success } = useToast();
-  const isRepostable = (status: Job["status"]) => status === "expired" || status === "cancelled";
+        category: job.category,
+        freelancer: job.freelancerAddress || "",
+      },
+    });
+  };
 
   const handleRepost = (job: Job) => {
     if (typeof window === "undefined") return;
@@ -85,8 +99,19 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
         budget: job.budget,
         category: job.category,
         freelancer: job.freelancerAddress || "",
-      },
-    });
+      })
+    );
+    router.push("/post-job");
+  };
+
+  const refreshBalances = () => {
+    if (!publicKey) return;
+    Promise.all([getXLMBalance(publicKey), getUSDCBalance(publicKey)])
+      .then(([bal, usdc]) => {
+        setBalance(bal);
+        setUsdcBalance(usdc);
+      })
+      .catch(() => {});
   };
 
   useEffect(() => {
@@ -156,6 +181,10 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
 
     return () => ws.close();
   }, [publicKey, info, success]);
+
+  useEffect(() => {
+    setWithdrawHistory(loadWithdrawHistory());
+  }, [showWithdraw]);
 
   useEffect(() => {
     if (!publicKey) return;
@@ -230,6 +259,33 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
             ) : (
               <div className="h-10 w-48 bg-market-500/8 rounded-xl animate-pulse" />
             )}
+            <div className="mt-3 flex flex-wrap gap-2">
+              {balance !== null && parseFloat(balance) < LOW_BALANCE_THRESHOLD_XLM && (
+                <button
+                  onClick={() => setShowBuyXLM(true)}
+                  className="btn-primary text-xs py-1.5 px-3"
+                  data-testid="buy-xlm-button"
+                >
+                  Buy XLM
+                </button>
+              )}
+              {balance !== null && parseFloat(balance) >= LOW_BALANCE_THRESHOLD_XLM && (
+                <button
+                  onClick={() => setShowBuyXLM(true)}
+                  className="btn-secondary text-xs py-1.5 px-3"
+                  data-testid="buy-xlm-button"
+                >
+                  Buy XLM
+                </button>
+              )}
+              <button
+                onClick={() => setShowWithdraw(true)}
+                className="btn-secondary text-xs py-1.5 px-3"
+                data-testid="withdraw-to-bank-button"
+              >
+                Withdraw to Bank
+              </button>
+            </div>
           </div>
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 text-center">
             {[
@@ -260,20 +316,18 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
       )}
 
       <div className="flex border-b border-market-500/10 mb-6 overflow-x-auto">
-        {(["posted", "applied", "send", "edit_profile", "templates", "price_alerts"] as Tab[]).map((t) => (
+        {(["posted", "applied", "send", "edit_profile", "templates", "price_alerts", "withdrawals"] as Tab[]).map((t) => (
           <button key={t} onClick={() => setTab(t)}
             className={clsx(
               "px-6 py-3 text-sm font-medium transition-all border-b-2 -mb-px whitespace-nowrap",
               tab === t ? "border-market-400 text-market-300" : "border-transparent text-amber-700 hover:text-amber-400"
             )}>
-            {t === "posted" ? `Jobs Posted (${myJobs.length})` :
-             t === "applied" ? `Applications (${myApplications.length})` :
-             t === "send" ? "Send Payment" :
-            {t === "posted"      ? `Jobs Posted (${myJobs.length})` :
-             t === "applied"     ? `Applications (${myApplications.length})` :
-             t === "send"        ? "Send Payment" :
-             t === "templates"   ? "Proposal Templates" :
-             t === "price_alerts"? "Price Alerts" :
+            {t === "posted"       ? `Jobs Posted (${myJobs.length})` :
+             t === "applied"      ? `Applications (${myApplications.length})` :
+             t === "send"         ? "Send Payment" :
+             t === "templates"    ? "Proposal Templates" :
+             t === "price_alerts" ? "Price Alerts" :
+             t === "withdrawals"  ? `Withdrawals (${withdrawHistory.length})` :
              "Edit Profile"}
           </button>
         ))}
@@ -495,9 +549,65 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
             Save Alerts
           </button>
         </div>
+      ) : tab === "withdrawals" ? (
+        withdrawHistory.length === 0 ? (
+          <div className="card text-center py-16">
+            <p className="font-display text-xl text-amber-100 mb-2">No withdrawals yet</p>
+            <p className="text-amber-800 text-sm mb-6">
+              Convert your XLM or USDC to USD, EUR, or NGN — paid directly to your bank account.
+            </p>
+            <button
+              onClick={() => setShowWithdraw(true)}
+              className="btn-primary text-sm"
+              data-testid="empty-state-withdraw-button"
+            >
+              Withdraw to Bank →
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {withdrawHistory.map((entry) => (
+              <div key={entry.id} className="card flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-xs px-2.5 py-0.5 rounded-full border bg-market-500/10 text-market-400 border-market-500/20">
+                      {entry.flow}
+                    </span>
+                    <span className="text-xs text-amber-700">{entry.status}</span>
+                  </div>
+                  <p className="font-display font-semibold text-amber-100 truncate">
+                    {entry.amount} {entry.asset} → {entry.fiatCurrency}
+                  </p>
+                  <p className="text-xs text-amber-800 mt-1">
+                    {new Date(entry.startedAt).toLocaleString()}
+                    {entry.externalTxId && ` · Bank ref ${entry.externalTxId.slice(0, 12)}…`}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )
       ) : tab === "edit_profile" ? (
         <EditProfileForm publicKey={publicKey} />
       ) : null}
+
+      {showBuyXLM && (
+        <BuyXLMModal
+          publicKey={publicKey}
+          onClose={() => setShowBuyXLM(false)}
+          onComplete={refreshBalances}
+        />
+      )}
+      {showWithdraw && (
+        <WithdrawToBankModal
+          publicKey={publicKey}
+          onClose={() => {
+            setShowWithdraw(false);
+            setWithdrawHistory(loadWithdrawHistory());
+            refreshBalances();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/pages/jobs/[id].tsx
+++ b/frontend/pages/jobs/[id].tsx
@@ -32,8 +32,10 @@ import {
   USDC_SAC_ADDRESS,
   XLM_SAC_ADDRESS,
 } from "@/lib/stellar";
-import { Asset } from "@stellar/stellar-sdk";
+import { Asset, type Transaction } from "@stellar/stellar-sdk";
 import { signTransactionWithWallet } from "@/lib/wallet";
+import { fetchActualFee } from "@/lib/sorobanFees";
+import FeeEstimationModal from "@/components/FeeEstimationModal";
 import type { Application, Job } from "@/utils/types";
 
 interface JobDetailProps {
@@ -72,6 +74,10 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
   const [releaseSuccess, setReleaseSuccess] = useState(false);
   const [releaseTxHash, setReleaseTxHash] = useState<string | null>(null);
   const [releaseSyncedWithBackend, setReleaseSyncedWithBackend] = useState(false);
+  const [pendingRelease, setPendingRelease] = useState<{
+    transaction: Transaction;
+    fnName: "release_escrow" | "release_with_conversion";
+  } | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [ratingSubmitted, setRatingSubmitted] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
@@ -282,6 +288,7 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
 
     try {
       let prepared;
+      let fnName: "release_escrow" | "release_with_conversion";
 
       if (releaseCurrency !== job.currency && estimatedOutput) {
         const targetTokenAddress =
@@ -302,23 +309,36 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
           targetTokenAddress,
           minAmountOut
         );
+        fnName = "release_with_conversion";
       } else {
         prepared = await buildReleaseEscrowTransaction(
           job.escrowContractId,
           job.id,
           publicKey
         );
+        fnName = "release_escrow";
       }
 
-      const { signedXDR, error: signError } = await signTransactionWithWallet(prepared.toXDR());
+      // Pause for fee confirmation (Issue #222) before Freighter prompts.
+      setPendingRelease({ transaction: prepared, fnName });
+    } catch (error: unknown) {
+      setActionError(error instanceof Error ? error.message : "Could not complete the release.");
+      setReleasingEscrow(false);
+    }
+  };
 
-      if (signError || !signedXDR) {
-        setActionError(signError || "Signing was cancelled.");
-        return;
-      }
-
+  const completeReleaseEscrow = async (signedXDR: string) => {
+    if (!publicKey || !job || !id) return;
+    try {
       const { hash } = await submitSignedSorobanTransaction(signedXDR);
       setReleaseTxHash(hash);
+
+      fetchActualFee(hash).then((actual) => {
+        if (actual) {
+          // eslint-disable-next-line no-console
+          console.info(`[escrow] release_escrow ${job.id} actual fee ${actual.feeChargedXlm} XLM`);
+        }
+      }).catch(() => {});
 
       try {
         await releaseEscrow(job.id, publicKey, hash, releaseCurrency);
@@ -336,6 +356,26 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
     } finally {
       setReleasingEscrow(false);
     }
+  };
+
+  const handleConfirmReleaseFee = async () => {
+    if (!pendingRelease) return;
+    const { transaction } = pendingRelease;
+    setPendingRelease(null);
+
+    const { signedXDR, error: signError } = await signTransactionWithWallet(transaction.toXDR());
+    if (signError || !signedXDR) {
+      setActionError(signError || "Signing was cancelled.");
+      setReleasingEscrow(false);
+      return;
+    }
+    await completeReleaseEscrow(signedXDR);
+  };
+
+  const handleCancelReleaseFee = () => {
+    setPendingRelease(null);
+    setReleasingEscrow(false);
+    setActionError("Cancelled before signing.");
   };
 
   const handleSubmitReport = async () => {
@@ -512,6 +552,7 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
               </div>
             </div>
           )}
+        </div>
 
         {isClient && applications.length > 0 && (
           <div className="mb-6">
@@ -524,14 +565,7 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
                 <span className="flex items-center gap-1"><kbd className="bg-ink-900 px-1.5 py-0.5 rounded border border-market-500/20 text-market-400">Enter</kbd> Accept</span>
               </div>
             </div>
-          </div>
-        )}
 
-        {isClient && applications.length > 0 && (
-          <div className="mb-6">
-            <h2 className="font-display text-xl font-bold text-amber-100 mb-4">
-              Applications ({applications.length})
-            </h2>
 
             <div className="space-y-4">
               {applications.map((app) => {
@@ -539,16 +573,16 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
                 const availability = applicantProfile?.availability;
 
                 return (
-                  <div key={application.id} className="card">
+                  <div key={app.id} className="card">
                     <div className="flex items-start justify-between gap-4 mb-3">
                       <div>
                         <a
-                          href={accountUrl(application.freelancerAddress)}
+                          href={accountUrl(app.freelancerAddress)}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="address-tag hover:border-market-500/40 transition-colors"
                         >
-                          {shortenAddress(application.freelancerAddress)} ↗
+                          {shortenAddress(app.freelancerAddress)} ↗
                         </a>
 
                         <div className="mt-3">
@@ -606,7 +640,7 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
                     </div>
 
                     <p className="text-amber-700/80 text-sm leading-relaxed mb-4">
-                      {application.proposal}
+                      {app.proposal}
                     </p>
 
                     {app.status === "pending" && job.status === "open" && (
@@ -623,25 +657,8 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
                       </div>
                     )}
                   </div>
-
-                  <p className="text-xs text-amber-800 mb-3">
-                    Applied {timeAgo(application.createdAt)}
-                  </p>
-
-                  <p className="text-amber-700/80 text-sm leading-relaxed">
-                    {application.proposal}
-                  </p>
-
-                  {application.status === "pending" && job.status === "open" && (
-                    <button
-                      onClick={() => handleAcceptApplication(application.id)}
-                      className="btn-secondary text-sm py-2 px-4 mt-4"
-                    >
-                      Accept Proposal
-                    </button>
-                  )}
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         )}
@@ -829,7 +846,7 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
             </div>
           )}
         </div>
-      )}
+      </div>
 
       {showReportModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
@@ -929,6 +946,16 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
 
       {showShareModal && job && (
         <ShareJobModal job={job} onClose={() => setShowShareModal(false)} />
+      )}
+
+      {pendingRelease && publicKey && (
+        <FeeEstimationModal
+          transaction={pendingRelease.transaction}
+          functionName={pendingRelease.fnName}
+          payerPublicKey={publicKey}
+          onConfirm={handleConfirmReleaseFee}
+          onCancel={handleCancelReleaseFee}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## Summary
Implements three Stellar Wave issues assigned to @davedumto.

closes #220
closes #231 
closes #222

- **#220 — Buy XLM (SEP-0024 deposit).** New \`Buy XLM\` button on the dashboard that opens an anchor-hosted deposit flow (SEP-0010 sign-in → SEP-0024 \`/transactions/deposit/interactive\` → status polling). The button is highlighted when the wallet's XLM balance is below the threshold.
- **#231 — Withdraw to Bank (SEP-0031 with SEP-0024 fallback).** New \`Withdraw to Bank\` button that uses SEP-0031 cross-border send when the anchor advertises a Direct Payment Server, otherwise drops back to SEP-0024 interactive withdraw. Supports USD, EUR, NGN. A new \`Withdrawals\` tab on the dashboard shows per-device history.
- **#222 — Soroban fee estimation.** A new \`FeeEstimationModal\` runs \`simulateTransaction\` before every contract call, shows the fee in XLM and USD, warns on insufficient balance, and gives the user a chance to cancel before Freighter prompts for signing. Wired into \`create_escrow\` (post-job flow) and \`release_escrow\` / \`release_with_conversion\` (job detail page). The actual fee is logged after confirmation.

## Files
- \`frontend/lib/anchors.ts\` — TOML discovery, SEP-0010 JWT (cached), SEP-0024 interactive transfers, SEP-0031 send.
- \`frontend/lib/sorobanFees.ts\` — fee estimate / actual-fee helpers + contract-call labels.
- \`frontend/components/BuyXLMModal.tsx\` — SEP-0024 deposit modal.
- \`frontend/components/WithdrawToBankModal.tsx\` — SEP-0031/SEP-0024 withdraw modal + history persistence.
- \`frontend/components/FeeEstimationModal.tsx\` — pre-flight contract-call confirmation.
- \`frontend/pages/dashboard.tsx\` — Buy XLM / Withdraw to Bank entry points and \`Withdrawals\` tab.
- \`frontend/components/PostJobForm.tsx\` — fee gate before \`create_escrow\`, with rollback on cancel.
- \`frontend/pages/jobs/[id].tsx\` — fee gate before \`release_escrow\` and \`release_with_conversion\`.

## Pre-existing issues fixed along the way
The base branch had merge-conflict damage that prevented \`tsc\` from parsing, so a few files were touched purely so the new work could compile and render:

- \`frontend/lib/api.ts\` — removed a stray closing brace at the end of \`fetchRatings\`.
- \`frontend/pages/dashboard.tsx\` — collapsed the tangled \`handleHireAgain\` / price-alerts / repost state block into a single coherent set of state declarations and helpers.
- \`frontend/pages/jobs/[id].tsx\` — closed the orphaned page container \`<div>\`, removed the duplicated applications section header, and renamed leftover \`application.X\` references to \`app.X\` inside the applications map.

## Configuration
- \`NEXT_PUBLIC_ANCHOR_HOME_DOMAIN\` — anchor host for SEP-0010/24/31. Defaults to \`testanchor.stellar.org\` on testnet.

## Test plan
- [ ] Connect Freighter on testnet, confirm \`Buy XLM\` opens the anchor's deposit popup and the dashboard balance refreshes after \`completed\`.
- [ ] Click \`Withdraw to Bank\`, pick USD/EUR/NGN, confirm the anchor flow runs and the \`Withdrawals\` tab records the transaction id and final status.
- [ ] Post a job and confirm the fee modal appears with non-zero estimated XLM and USD before Freighter prompts; cancel removes the orphaned backend job.
- [ ] Release escrow on an in-progress job and confirm the fee modal appears with the right function label.
- [ ] Trigger \`release_with_conversion\` on a USDC job paying out XLM and confirm the fee modal labels it correctly.