### PR TITLE
feat: add analytics endpoints and market insights page

### DIFF
--- a/backend/src/routes/jobs.js
+++ b/backend/src/routes/jobs.js
@@ -525,4 +525,22 @@ router.get("/recommended", verifyJWT, async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
+// GET /api/analytics/categories — stats per category
+router.get("/analytics/categories", generalJobRateLimiter, async (req, res, next) => {
+  try {
+    const { getCategoryAnalytics } = require("../services/jobService");
+    const data = await getCategoryAnalytics();
+    res.json({ success: true, data });
+  } catch (e) { next(e); }
+});
+
+// GET /api/analytics/overview — platform-wide totals
+router.get("/analytics/overview", generalJobRateLimiter, async (req, res, next) => {
+  try {
+    const { getAnalyticsOverview } = require("../services/jobService");
+    const data = await getAnalyticsOverview();
+    res.json({ success: true, data });
+  } catch (e) { next(e); }
+});
+
 module.exports = router;

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -606,6 +606,57 @@ async function resolveDispute(jobId) {
   return rowToJob(rows[0]);
 }
 
+async function getCategoryAnalytics() {
+  const { rows } = await pool.query(`
+    SELECT
+      category,
+      COUNT(*)                                                        AS job_count,
+      AVG(budget)                                                     AS avg_budget_xlm,
+      COUNT(*) FILTER (WHERE freelancer_address IS NOT NULL)          AS filled_count,
+      AVG(
+        EXTRACT(EPOCH FROM (updated_at - created_at)) / 86400.0
+      ) FILTER (WHERE freelancer_address IS NOT NULL)                 AS avg_days_to_fill
+    FROM jobs
+    GROUP BY category
+    ORDER BY job_count DESC
+  `);
+
+  return rows.map((r) => ({
+    category:      r.category,
+    jobCount:      parseInt(r.job_count, 10),
+    avgBudgetXLM:  r.avg_budget_xlm ? parseFloat(parseFloat(r.avg_budget_xlm).toFixed(2)) : 0,
+    filledCount:   parseInt(r.filled_count, 10),
+    avgDaysToFill: r.avg_days_to_fill ? parseFloat(parseFloat(r.avg_days_to_fill).toFixed(1)) : null,
+  }));
+}
+
+async function getAnalyticsOverview() {
+  const { rows } = await pool.query(`
+    SELECT
+      COUNT(*)                                                        AS total_jobs,
+      COUNT(*) FILTER (WHERE status = 'open')                        AS open_jobs,
+      COUNT(*) FILTER (WHERE status = 'in_progress')                 AS in_progress_jobs,
+      COUNT(*) FILTER (WHERE status = 'completed')                   AS completed_jobs,
+      AVG(budget)                                                     AS avg_budget_xlm,
+      COUNT(*) FILTER (WHERE freelancer_address IS NOT NULL)          AS total_filled,
+      AVG(
+        EXTRACT(EPOCH FROM (updated_at - created_at)) / 86400.0
+      ) FILTER (WHERE freelancer_address IS NOT NULL)                 AS avg_days_to_fill
+    FROM jobs
+  `);
+
+  const r = rows[0];
+  return {
+    totalJobs:      parseInt(r.total_jobs, 10),
+    openJobs:       parseInt(r.open_jobs, 10),
+    inProgressJobs: parseInt(r.in_progress_jobs, 10),
+    completedJobs:  parseInt(r.completed_jobs, 10),
+    avgBudgetXLM:   r.avg_budget_xlm ? parseFloat(parseFloat(r.avg_budget_xlm).toFixed(2)) : 0,
+    totalFilled:    parseInt(r.total_filled, 10),
+    avgDaysToFill:  r.avg_days_to_fill ? parseFloat(parseFloat(r.avg_days_to_fill).toFixed(1)) : null,
+  };
+}
+
 export default {
   createJob,
   getJob,
@@ -619,4 +670,6 @@ export default {
   incrementShareCount,
   raiseDispute,
   resolveDispute,
+  getCategoryAnalytics,
+  getAnalyticsOverview,
 };

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -20,6 +20,7 @@ const links = [
   { href: "/jobs",        labelKey: "nav.browseJobs" },
   { href: "/dashboard",   labelKey: "nav.dashboard" },
   { href: "/post-job",    labelKey: "nav.postJob" },
+  { href: "/insights",    labelKey: "nav.insights" },
 ];
 
 const STELLAR_NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet";

--- a/frontend/pages/insights.tsx
+++ b/frontend/pages/insights.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from "react";
+import Head from "next/head";
+import axios from "axios";
+
+interface CategoryStat {
+  category: string;
+  jobCount: number;
+  avgBudgetXLM: number;
+  filledCount: number;
+  avgDaysToFill: number | null;
+}
+
+interface Overview {
+  totalJobs: number;
+  openJobs: number;
+  inProgressJobs: number;
+  completedJobs: number;
+  avgBudgetXLM: number;
+  totalFilled: number;
+  avgDaysToFill: number | null;
+}
+
+export default function InsightsPage() {
+  const [overview, setOverview] = useState<Overview | null>(null);
+  const [categories, setCategories] = useState<CategoryStat[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Promise.all([
+      axios.get("/api/jobs/analytics/overview"),
+      axios.get("/api/jobs/analytics/categories"),
+    ])
+      .then(([overviewRes, categoriesRes]) => {
+        setOverview(overviewRes.data.data);
+        setCategories(categoriesRes.data.data);
+      })
+      .catch(() => setError("Failed to load market insights."))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+          <p className="mt-4 text-gray-600">Loading market insights...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <p className="text-red-500">{error}</p>
+      </div>
+    );
+  }
+
+  const maxJobs = categories[0]?.jobCount || 1;
+
+  return (
+    <>
+      <Head>
+        <title>Market Insights - Stellar MarketPay</title>
+        <meta name="description" content="Marketplace analytics: job counts, budgets, and fill times by category" />
+      </Head>
+
+      <div className="min-h-screen bg-gray-50 py-12 px-4">
+        <div className="max-w-6xl mx-auto">
+          <h1 className="text-3xl font-bold text-gray-900 mb-1">Market Insights</h1>
+          <p className="text-gray-500 mb-8">Live analytics across all job categories on Stellar MarketPay</p>
+
+          {/* Overview cards */}
+          {overview && (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
+              {[
+                { label: "Total Jobs", value: overview.totalJobs.toLocaleString() },
+                { label: "Open Now", value: overview.openJobs.toLocaleString() },
+                { label: "Avg Budget", value: `${overview.avgBudgetXLM} XLM` },
+                { label: "Avg Days to Fill", value: overview.avgDaysToFill != null ? `${overview.avgDaysToFill}d` : "—" },
+              ].map((card) => (
+                <div key={card.label} className="bg-white rounded-lg shadow p-5">
+                  <p className="text-xs text-gray-500 mb-1">{card.label}</p>
+                  <p className="text-2xl font-bold text-gray-900">{card.value}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Category table */}
+          {categories.length === 0 ? (
+            <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+              No category data available yet.
+            </div>
+          ) : (
+            <div className="bg-white rounded-lg shadow overflow-hidden mb-10">
+              <div className="px-6 py-4 border-b">
+                <h2 className="text-lg font-semibold text-gray-900">Stats by Category</h2>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="text-left py-3 px-6 text-gray-600 font-medium">Category</th>
+                      <th className="text-right py-3 px-6 text-gray-600 font-medium">Jobs</th>
+                      <th className="text-right py-3 px-6 text-gray-600 font-medium">Avg Budget (XLM)</th>
+                      <th className="text-right py-3 px-6 text-gray-600 font-medium">Filled</th>
+                      <th className="text-right py-3 px-6 text-gray-600 font-medium">Avg Days to Fill</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {categories.map((cat) => (
+                      <tr key={cat.category} className="border-t hover:bg-gray-50">
+                        <td className="py-3 px-6 text-gray-900 font-medium">{cat.category}</td>
+                        <td className="py-3 px-6 text-right">
+                          <div className="flex items-center justify-end gap-3">
+                            <div className="w-24 bg-gray-200 rounded-full h-1.5 hidden sm:block">
+                              <div
+                                className="bg-blue-500 h-1.5 rounded-full"
+                                style={{ width: `${(cat.jobCount / maxJobs) * 100}%` }}
+                              />
+                            </div>
+                            <span className="text-gray-900">{cat.jobCount}</span>
+                          </div>
+                        </td>
+                        <td className="py-3 px-6 text-right text-gray-900">{cat.avgBudgetXLM}</td>
+                        <td className="py-3 px-6 text-right text-gray-900">{cat.filledCount}</td>
+                        <td className="py-3 px-6 text-right text-gray-500">
+                          {cat.avgDaysToFill != null ? `${cat.avgDaysToFill}d` : "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -4,6 +4,7 @@
     "browseJobs": "Browse Jobs",
     "dashboard": "Dashboard",
     "postJob": "Post a Job",
+    "insights": "Market Insights",
     "connectWallet": "Connect Wallet",
     "disconnect": "Disconnect"
   },

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -4,6 +4,7 @@
     "browseJobs": "Explorar Trabajos",
     "dashboard": "Panel",
     "postJob": "Publicar Trabajo",
+    "insights": "Perspectivas del Mercado",
     "connectWallet": "Conectar Billetera",
     "disconnect": "Desconectar"
   },


### PR DESCRIPTION
- GET /api/jobs/analytics/categories: returns jobCount, avgBudgetXLM, filledCount, avgDaysToFill per category
- GET /api/jobs/analytics/overview: returns platform-wide totals
- Add getCategoryAnalytics and getAnalyticsOverview to jobService.js
- Add /pages/insights.tsx with overview cards and category stats table
- Add Market Insights link to Navbar with en/es translations

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
