### PR TITLE
feat: feed filters, stats polling/SEO, markdown templates, image optimization

### DIFF
--- a/backend/src/routes/jobs.js
+++ b/backend/src/routes/jobs.js
@@ -13,15 +13,7 @@ const generalJobRateLimiter = createRateLimiter(30, 1); // 100 requests per minu
 
 
 const jobService = require("../services/jobService");
-const { createJob, getJob, listJobs, listJobsByClient, updateJobEscrowId, deleteJob, boostJob, incrementShareCount, raiseDispute, resolveDispute } = jobService.default || jobService;
-const { verifyJWT } = require("../middleware/auth");
-
-// Rate limiters for different job operations
-const generalJobRateLimiter = createRateLimiter(100, 1); // 100 requests per minute
-const jobCreationRateLimiter = createRateLimiter(10, 1); // 10 job creations per minute
-
-const jobService = require("../services/jobService");
-const { createJob, getJob, listJobs, listJobsByClient, updateJobEscrowId, deleteJob, boostJob, incrementShareCount, getRecommendedJobs } = jobService.default || jobService;
+const { createJob, getJob, listJobs, listJobsByClient, updateJobEscrowId, deleteJob, boostJob, incrementShareCount, raiseDispute, resolveDispute, getRecommendedJobs } = jobService.default || jobService;
 const { verifyJWT } = require("../middleware/auth");
 
 // Feed Helpers
@@ -48,6 +40,34 @@ function truncateDescription(description, maxLength = 200) {
   if (!description) return "";
   if (description.length <= maxLength) return description;
   return description.substring(0, maxLength - 3) + "...";
+}
+
+// Apply feed-only query filters (skills, budget range) to an already-fetched job list.
+function filterFeedJobs(jobs, { skills, min_budget, max_budget } = {}) {
+  let filtered = jobs;
+  const wanted = String(skills || "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  if (wanted.length > 0) {
+    filtered = filtered.filter((job) =>
+      (job.skills || []).some((s) => wanted.includes(String(s).toLowerCase()))
+    );
+  }
+  const min = parseFloat(min_budget);
+  if (!isNaN(min)) filtered = filtered.filter((job) => parseFloat(job.budget) >= min);
+  const max = parseFloat(max_budget);
+  if (!isNaN(max)) filtered = filtered.filter((job) => parseFloat(job.budget) <= max);
+  return filtered;
+}
+
+// Build a feed title suffix that reflects the active filters.
+function feedTitleSuffix({ category, skills } = {}) {
+  const parts = [];
+  if (category) parts.push(`in ${category}`);
+  const skillList = String(skills || "").split(",").map((s) => s.trim()).filter(Boolean);
+  if (skillList.length > 0) parts.push(`matching ${skillList.join(", ")}`);
+  return parts.length ? ` — ${parts.join(" ")}` : "";
 }
 
 function normalizeAddress(address) {
@@ -398,17 +418,20 @@ router.post("/:id/resolve", verifyJWT, generalJobRateLimiter, async (req, res, n
 // GET /api/jobs/feed.rss — RSS 2.0 feed
 router.get("/feed.rss", generalJobRateLimiter, async (req, res, next) => {
   try {
-    const { category } = req.query;
-    const result = await listJobs({ category, status: "open", limit: 20 });
-    const jobs = result.jobs;
+    const { category, skills, min_budget, max_budget } = req.query;
+    const result = await listJobs({ category, status: "open", limit: 50 });
+    const jobs = filterFeedJobs(result.jobs, { skills, min_budget, max_budget }).slice(0, 20);
     const baseUrl = process.env.BASE_URL || "http://localhost:3000";
-    const feedUrl = `${baseUrl}/api/jobs/feed.rss${category ? `?category=${encodeURIComponent(category)}` : ""}`;
+    const query = new URLSearchParams(
+      Object.entries({ category, skills, min_budget, max_budget }).filter(([, v]) => v)
+    ).toString();
+    const feedUrl = `${baseUrl}/api/jobs/feed.rss${query ? `?${query}` : ""}`;
     const lastBuildDate = jobs.length > 0 ? formatDateRss(new Date(jobs[0].createdAt)) : formatDateRss(new Date());
 
     let rss = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
-    <title>Stellar MarketPay — Job Listings</title>
+    <title>${escapeXml(`Stellar MarketPay — Job Listings${feedTitleSuffix({ category, skills })}`)}</title>
     <description>Latest freelance job opportunities on Stellar MarketPay</description>
     <link>${baseUrl}/jobs</link>
     <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
@@ -427,6 +450,8 @@ router.get("/feed.rss", generalJobRateLimiter, async (req, res, next) => {
       <guid isPermaLink="true">${jobUrl}</guid>
       <pubDate>${pubDate}</pubDate>
       <category>${escapeXml(job.category)}</category>
+      <dc:creator>${escapeXml(job.clientDisplayName || job.clientAddress || "Anonymous")}</dc:creator>
+      <skills>${escapeXml((job.skills || []).join(", "))}</skills>
       <budget>${escapeXml(job.budget.toString())} XLM</budget>
     </item>
 `;
@@ -443,16 +468,19 @@ router.get("/feed.rss", generalJobRateLimiter, async (req, res, next) => {
 // GET /api/jobs/feed.atom
 router.get("/feed.atom", generalJobRateLimiter, async (req, res, next) => {
   try {
-    const { category } = req.query;
-    const result = await listJobs({ category, status: "open", limit: 20 });
-    const jobs = result.jobs;
+    const { category, skills, min_budget, max_budget } = req.query;
+    const result = await listJobs({ category, status: "open", limit: 50 });
+    const jobs = filterFeedJobs(result.jobs, { skills, min_budget, max_budget }).slice(0, 20);
     const baseUrl = process.env.BASE_URL || "http://localhost:3000";
-    const feedUrl = `${baseUrl}/api/jobs/feed.atom${category ? `?category=${encodeURIComponent(category)}` : ""}`;
+    const query = new URLSearchParams(
+      Object.entries({ category, skills, min_budget, max_budget }).filter(([, v]) => v)
+    ).toString();
+    const feedUrl = `${baseUrl}/api/jobs/feed.atom${query ? `?${query}` : ""}`;
     const updatedDate = jobs.length > 0 ? formatDateAtom(new Date(jobs[0].createdAt)) : formatDateAtom(new Date());
 
     let atom = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title>Stellar MarketPay — Job Listings</title>
+  <title>${escapeXml(`Stellar MarketPay — Job Listings${feedTitleSuffix({ category, skills })}`)}</title>
   <subtitle>Latest freelance job opportunities on Stellar MarketPay</subtitle>
   <link href="${baseUrl}/jobs" rel="alternate" type="text/html" />
   <link href="${feedUrl}" rel="self" type="application/atom+xml" />
@@ -471,7 +499,9 @@ router.get("/feed.atom", generalJobRateLimiter, async (req, res, next) => {
     <id>${jobUrl}</id>
     <published>${published}</published>
     <updated>${published}</updated>
+    <author><name>${escapeXml(job.clientDisplayName || job.clientAddress || "Anonymous")}</name></author>
     <category term="${escapeXml(job.category)}" />
+    <skills>${escapeXml((job.skills || []).join(", "))}</skills>
     <budget>${escapeXml(job.budget.toString())} XLM</budget>
   </entry>
 `;

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -5,6 +5,16 @@ const nextConfig = {
     defaultLocale: 'en',
     locales: ['en', 'es'],
   },
+  images: {
+    formats: ['image/webp'],
+    remotePatterns: [
+      { protocol: 'https', hostname: 'ipfs.io' },
+      { protocol: 'https', hostname: 'gateway.pinata.cloud' },
+      { protocol: 'https', hostname: 'cloudflare-ipfs.com' },
+      { protocol: 'https', hostname: 'nftstorage.link' },
+      { protocol: 'https', hostname: 'w3s.link' },
+    ],
+  },
   webpack: (config) => {
     config.resolve.fallback = { ...config.resolve.fallback, fs: false, net: false, tls: false };
     return config;

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -2,7 +2,7 @@
  * pages/dashboard.tsx
  * User dashboard — shows posted jobs, applications, and wallet balance.
  */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import WalletConnect from "@/components/WalletConnect";
@@ -77,6 +77,39 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   const [templateName, setTemplateName] = useState("");
   const [templateContent, setTemplateContent] = useState("");
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
+  const templateEditorRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Wrap/insert Markdown syntax around the current selection in the template editor.
+  const applyTemplateMarkdown = (syntax: "bold" | "italic" | "list" | "code" | "link") => {
+    const el = templateEditorRef.current;
+    if (!el) return;
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    const selected = templateContent.slice(start, end);
+    let next: string;
+    let cursor: number;
+    if (syntax === "list") {
+      const block = (selected || "item").split("\n").map((line) => `- ${line}`).join("\n");
+      next = templateContent.slice(0, start) + block + templateContent.slice(end);
+      cursor = start + block.length;
+    } else {
+      const wrappers: Record<string, [string, string]> = {
+        bold: ["**", "**"],
+        italic: ["_", "_"],
+        code: ["`", "`"],
+        link: ["[", "](url)"],
+      };
+      const [open, close] = wrappers[syntax];
+      const inner = selected || "text";
+      next = templateContent.slice(0, start) + open + inner + close + templateContent.slice(end);
+      cursor = start + open.length + inner.length + close.length;
+    }
+    setTemplateContent(next);
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(cursor, cursor);
+    });
+  };
   const [minPrice, setMinPrice] = useState("");
   const [maxPrice, setMaxPrice] = useState("");
   const [emailEnabled, setEmailEnabled] = useState(false);
@@ -403,7 +436,20 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
         <div className="space-y-4">
           <div className="card space-y-3">
             <input value={templateName} onChange={(e) => setTemplateName(e.target.value)} className="input-field" placeholder="Template name" />
-            <textarea value={templateContent} onChange={(e) => setTemplateContent(e.target.value)} className="textarea-field" rows={5} placeholder="Template proposal content" />
+            <div className="flex flex-wrap gap-2">
+              {(["bold", "italic", "list", "code", "link"] as const).map((syntax) => (
+                <button
+                  key={syntax}
+                  type="button"
+                  className="btn-secondary text-xs px-2 py-1 capitalize"
+                  onClick={() => applyTemplateMarkdown(syntax)}
+                >
+                  {syntax}
+                </button>
+              ))}
+            </div>
+            <textarea ref={templateEditorRef} value={templateContent} onChange={(e) => setTemplateContent(e.target.value)} className="textarea-field font-mono" rows={5} placeholder="Template proposal content (Markdown supported)" />
+            <p className="text-xs text-amber-700">Markdown supported — use the buttons above to format.</p>
             <button className="btn-primary text-sm" onClick={async () => {
               if (!templateName.trim() || !templateContent.trim()) return;
               if (editingTemplateId) {

--- a/frontend/pages/disputes/[jobId].tsx
+++ b/frontend/pages/disputes/[jobId].tsx
@@ -45,8 +45,11 @@ function EvidenceCard({ ev, isOwn }: { ev: DisputeEvidence; isOwn: boolean }) {
           <img
             src={ev.gatewayUrl}
             alt={ev.fileName}
+            width={80}
+            height={64}
             className="w-20 h-16 object-cover rounded-lg border border-market-500/20"
             loading="lazy"
+            decoding="async"
           />
         )}
         <a

--- a/frontend/pages/stats.tsx
+++ b/frontend/pages/stats.tsx
@@ -58,6 +58,9 @@ export default function StatsPage() {
     };
 
     loadStats();
+    // Refresh stats every 5 minutes (stats do not need to be real-time).
+    const interval = setInterval(loadStats, 5 * 60 * 1000);
+    return () => clearInterval(interval);
   }, []);
 
   if (loading) {
@@ -78,6 +81,9 @@ export default function StatsPage() {
       <Head>
         <title>Platform Statistics - Stellar MarketPay</title>
         <meta name="description" content="View platform-wide statistics and metrics" />
+        <meta property="og:title" content="Platform Statistics - Stellar MarketPay" />
+        <meta property="og:description" content="Live platform-wide metrics: jobs posted, escrow value, completion rate, and top categories." />
+        <meta property="og:type" content="website" />
       </Head>
 
       <div className="min-h-screen bg-gray-50 py-12 px-4">


### PR DESCRIPTION
## Summary
Small, focused improvements addressing four assigned issues:

- **#351 — Job feed filtering:** `feed.rss` and `feed.atom` now accept `skills`, `min_budget`, and `max_budget` query params (in addition to `category`). The feed title reflects active filters (e.g. *"… in Development matching React"*), and each item now includes the creator (`dc:creator`/`author`), skills, and budget.
- **#347 — Stats page:** the `/stats` page now refreshes every 5 minutes (client-side polling) and exposes Open Graph meta tags (`og:title`, `og:description`, `og:type`).
- **#349 — Proposal templates:** added a Markdown formatting toolbar (bold, italic, list, code, link) to the template editor that wraps the current selection — no new dependencies, edits are plain text so there's no XSS surface.
- **#341 — Image optimization:** configured `next.config.mjs` with WebP output and `remotePatterns` for common IPFS gateways, and added explicit dimensions + `decoding="async"` to the dispute evidence image to prevent layout shift.

While editing `backend/src/routes/jobs.js` for #351 I also removed a duplicate block of module-level `const` declarations (`generalJobRateLimiter`, `jobService`, etc.) that caused a `SyntaxError: Identifier already declared` and prevented the route file from loading on `main`.

## Test plan
- [ ] `GET /api/jobs/feed.rss?category=Development&skills=react&min_budget=50&max_budget=500` returns only matching jobs with a filter-aware title
- [ ] `feed.atom` honors the same params
- [ ] `/stats` shows OG tags in page source and re-fetches after 5 minutes
- [ ] Template editor toolbar wraps selected text with Markdown syntax
- [ ] `npx tsc --noEmit` passes for changed files (pre-existing errors in `pages/jobs/[id].tsx` are unrelated)

Closes #351
Closes #347
Closes #349
Closes #341