### PR TITLE
feat(#346): implement time tracking integration with billing calculation

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -258,3 +258,42 @@ CREATE TABLE IF NOT EXISTS dispute_evidence (
 );
 
 CREATE INDEX IF NOT EXISTS dispute_evidence_job_id_idx ON dispute_evidence(job_id);
+
+-- ─────────────────────────────────────────
+-- time_entries  (Issue #346 — time tracking)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS time_entries (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id              UUID        NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+  freelancer_address  TEXT        NOT NULL REFERENCES profiles(public_key),
+  duration_minutes    INTEGER     NOT NULL CHECK (duration_minutes > 0 AND duration_minutes <= 1440),
+  description         TEXT,
+  started_at          TIMESTAMPTZ,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS time_entries_job_id_idx         ON time_entries(job_id);
+CREATE INDEX IF NOT EXISTS time_entries_freelancer_idx     ON time_entries(freelancer_address);
+
+-- ─────────────────────────────────────────
+-- time_invoices  (Issue #346 — billing)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS time_invoices (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id              UUID        NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+  freelancer_address  TEXT        NOT NULL REFERENCES profiles(public_key),
+  client_address      TEXT        NOT NULL REFERENCES profiles(public_key),
+  total_minutes       INTEGER     NOT NULL CHECK (total_minutes > 0),
+  hourly_rate_xlm     NUMERIC(20,7) NOT NULL,
+  total_amount_xlm    NUMERIC(20,7) NOT NULL,
+  status              TEXT        NOT NULL DEFAULT 'pending'
+                                  CHECK (status IN ('pending', 'approved', 'rejected')),
+  entry_ids           UUID[]      NOT NULL DEFAULT '{}',
+  contract_tx_hash    TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS time_invoices_job_id_idx        ON time_invoices(job_id);
+CREATE INDEX IF NOT EXISTS time_invoices_freelancer_idx    ON time_invoices(freelancer_address);
+CREATE INDEX IF NOT EXISTS time_invoices_client_idx        ON time_invoices(client_address);

--- a/backend/src/routes/timeEntries.js
+++ b/backend/src/routes/timeEntries.js
@@ -1,0 +1,129 @@
+/**
+ * src/routes/timeEntries.js
+ * Time tracking and billing endpoints — Issue #346
+ *
+ * POST /api/time-entries                    — log a time entry
+ * GET  /api/time-entries/job/:jobId         — get all entries for a job
+ * GET  /api/time-entries/job/:jobId/invoices — get all invoices for a job
+ * POST /api/time-entries/invoice            — generate invoice from entries
+ * PATCH /api/time-entries/invoice/:invoiceId/review — client approves/rejects
+ */
+"use strict";
+
+const express = require("express");
+const router = express.Router();
+const { verifyJWT } = require("../middleware/auth");
+const { createRateLimiter } = require("../middleware/rateLimiter");
+const {
+  logTimeEntry,
+  getTimeEntriesForJob,
+  generateInvoice,
+  getInvoicesForJob,
+  reviewInvoice,
+} = require("../services/timeTrackingService");
+
+const readLimiter   = createRateLimiter(60, 1);
+const writeLimiter  = createRateLimiter(30, 1);
+
+/**
+ * POST /api/time-entries
+ * Log a time entry for a job.
+ *
+ * Body: { jobId, freelancerAddress, durationMinutes, description?, startedAt? }
+ */
+router.post("/", verifyJWT, writeLimiter, async (req, res, next) => {
+  try {
+    const { jobId, durationMinutes, description, startedAt } = req.body;
+    const freelancerAddress = req.user.publicKey;
+
+    const entry = await logTimeEntry({
+      jobId,
+      freelancerAddress,
+      durationMinutes,
+      description,
+      startedAt,
+    });
+
+    res.status(201).json({ success: true, data: entry });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * GET /api/time-entries/job/:jobId
+ * Get all time entries for a job.
+ * Accessible by the job's client or freelancer (JWT required).
+ */
+router.get("/job/:jobId", verifyJWT, readLimiter, async (req, res, next) => {
+  try {
+    const entries = await getTimeEntriesForJob(req.params.jobId);
+    res.json({ success: true, data: entries });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * GET /api/time-entries/job/:jobId/invoices
+ * Get all invoices for a job.
+ */
+router.get("/job/:jobId/invoices", verifyJWT, readLimiter, async (req, res, next) => {
+  try {
+    const invoices = await getInvoicesForJob(req.params.jobId);
+    res.json({ success: true, data: invoices });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * POST /api/time-entries/invoice
+ * Generate an invoice from time entries.
+ *
+ * Body: { jobId, hourlyRateXlm, entryIds? }
+ */
+router.post("/invoice", verifyJWT, writeLimiter, async (req, res, next) => {
+  try {
+    const { jobId, hourlyRateXlm, entryIds } = req.body;
+    const freelancerAddress = req.user.publicKey;
+
+    const invoice = await generateInvoice({
+      jobId,
+      freelancerAddress,
+      hourlyRateXlm,
+      entryIds,
+    });
+
+    res.status(201).json({ success: true, data: invoice });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * PATCH /api/time-entries/invoice/:invoiceId/review
+ * Client approves or rejects an invoice.
+ *
+ * Body: { decision: "approved" | "rejected", contractTxHash? }
+ */
+router.patch("/invoice/:invoiceId/review", verifyJWT, writeLimiter, async (req, res, next) => {
+  try {
+    const { invoiceId } = req.params;
+    const { decision, contractTxHash } = req.body;
+    const clientAddress = req.user.publicKey;
+
+    const invoice = await reviewInvoice({
+      invoiceId,
+      clientAddress,
+      decision,
+      contractTxHash,
+    });
+
+    res.json({ success: true, data: invoice });
+  } catch (e) {
+    next(e);
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -30,6 +30,7 @@ const messageRoutes   = require("./routes/messageRoutes");
 const webauthnRoutes  = require("./routes/webauthn");
 const disputeRoutes   = require("./routes/disputes");
 const adminRoutes     = require("./routes/admin");
+const timeEntryRoutes = require("./routes/timeEntries");
 const pool            = require("./db/pool");
 const migrate         = require("./db/migrate");
 const IndexerService  = require("./services/indexerService");
@@ -198,6 +199,7 @@ app.use("/api/messages",      messageRoutes);
 app.use("/api/webauthn",      webauthnRoutes);
 app.use("/api/disputes",      disputeRoutes);
 app.use("/api/admin",         adminRoutes);
+app.use("/api/time-entries",  timeEntryRoutes);
 
 app.use((err, req, res, next) => {
   logError(req.logger || serviceLogger, err, {

--- a/backend/src/services/timeTrackingService.js
+++ b/backend/src/services/timeTrackingService.js
@@ -1,0 +1,340 @@
+/**
+ * src/services/timeTrackingService.js
+ * Service: time entry logging and invoice generation for hourly jobs.
+ *
+ * Tables used:
+ *   time_entries  — individual tracked or manually-entered work sessions
+ *   time_invoices — grouped invoice submitted by freelancer for client approval
+ */
+"use strict";
+
+const pool = require("../db/pool");
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function validatePublicKey(key) {
+  if (!key || !/^G[A-Z0-9]{55}$/.test(key)) {
+    const e = new Error("Invalid Stellar public key");
+    e.status = 400;
+    throw e;
+  }
+}
+
+function rowToEntry(row) {
+  return {
+    id: row.id,
+    jobId: row.job_id,
+    freelancerAddress: row.freelancer_address,
+    durationMinutes: row.duration_minutes,
+    description: row.description,
+    startedAt: row.started_at,
+    createdAt: row.created_at,
+  };
+}
+
+function rowToInvoice(row) {
+  return {
+    id: row.id,
+    jobId: row.job_id,
+    freelancerAddress: row.freelancer_address,
+    clientAddress: row.client_address,
+    totalMinutes: row.total_minutes,
+    hourlyRateXlm: row.hourly_rate_xlm,
+    totalAmountXlm: row.total_amount_xlm,
+    status: row.status,
+    entryIds: row.entry_ids || [],
+    contractTxHash: row.contract_tx_hash,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ─── Time Entries ─────────────────────────────────────────────────────────────
+
+/**
+ * Log a single time entry for a job.
+ *
+ * @param {Object} params
+ * @param {string} params.jobId            UUID of the job.
+ * @param {string} params.freelancerAddress Stellar G-address of the freelancer.
+ * @param {number} params.durationMinutes  Positive integer minutes worked.
+ * @param {string} [params.description]    Optional description of work done.
+ * @param {string} [params.startedAt]      ISO timestamp when work started (defaults to NOW).
+ * @returns {Promise<Object>} The created time entry.
+ */
+async function logTimeEntry({ jobId, freelancerAddress, durationMinutes, description, startedAt }) {
+  validatePublicKey(freelancerAddress);
+
+  if (!jobId) {
+    const e = new Error("jobId is required");
+    e.status = 400;
+    throw e;
+  }
+
+  const minutes = parseInt(durationMinutes, 10);
+  if (!minutes || minutes <= 0 || minutes > 1440) {
+    const e = new Error("durationMinutes must be a positive integer no greater than 1440 (24 h)");
+    e.status = 400;
+    throw e;
+  }
+
+  // Verify the job exists and the caller is the assigned freelancer
+  const { rows: jobRows } = await pool.query(
+    "SELECT id, freelancer_address, status FROM jobs WHERE id = $1",
+    [jobId]
+  );
+  if (!jobRows.length) {
+    const e = new Error("Job not found");
+    e.status = 404;
+    throw e;
+  }
+  const job = jobRows[0];
+  if (job.freelancer_address !== freelancerAddress) {
+    const e = new Error("Only the assigned freelancer can log time for this job");
+    e.status = 403;
+    throw e;
+  }
+  if (!["in_progress", "completed"].includes(job.status)) {
+    const e = new Error("Time can only be logged for jobs that are in progress or completed");
+    e.status = 400;
+    throw e;
+  }
+
+  const { rows } = await pool.query(
+    `INSERT INTO time_entries
+       (job_id, freelancer_address, duration_minutes, description, started_at, created_at)
+     VALUES ($1, $2, $3, $4, $5, NOW())
+     RETURNING *`,
+    [
+      jobId,
+      freelancerAddress,
+      minutes,
+      description ? description.trim().slice(0, 500) : null,
+      startedAt || null,
+    ]
+  );
+
+  return rowToEntry(rows[0]);
+}
+
+/**
+ * Retrieve all time entries for a job.
+ *
+ * @param {string} jobId UUID of the job.
+ * @returns {Promise<Object[]>} Array of time entries ordered oldest-first.
+ */
+async function getTimeEntriesForJob(jobId) {
+  if (!jobId) {
+    const e = new Error("jobId is required");
+    e.status = 400;
+    throw e;
+  }
+
+  const { rows } = await pool.query(
+    `SELECT * FROM time_entries
+     WHERE job_id = $1
+     ORDER BY created_at ASC`,
+    [jobId]
+  );
+
+  return rows.map(rowToEntry);
+}
+
+// ─── Invoices ─────────────────────────────────────────────────────────────────
+
+/**
+ * Generate an invoice from a set of time entries.
+ *
+ * The invoice captures the total minutes, the agreed hourly rate, and the
+ * calculated XLM amount.  It starts in `pending` status awaiting client
+ * approval.
+ *
+ * @param {Object} params
+ * @param {string}   params.jobId              UUID of the job.
+ * @param {string}   params.freelancerAddress  Stellar G-address of the freelancer.
+ * @param {number}   params.hourlyRateXlm      Agreed hourly rate in XLM (positive).
+ * @param {string[]} [params.entryIds]         Specific entry UUIDs to include.
+ *                                             Defaults to all un-invoiced entries.
+ * @returns {Promise<Object>} The created invoice.
+ */
+async function generateInvoice({ jobId, freelancerAddress, hourlyRateXlm, entryIds }) {
+  validatePublicKey(freelancerAddress);
+
+  if (!jobId) {
+    const e = new Error("jobId is required");
+    e.status = 400;
+    throw e;
+  }
+
+  const rate = parseFloat(hourlyRateXlm);
+  if (!rate || rate <= 0) {
+    const e = new Error("hourlyRateXlm must be a positive number");
+    e.status = 400;
+    throw e;
+  }
+
+  // Verify job and participants
+  const { rows: jobRows } = await pool.query(
+    "SELECT id, freelancer_address, client_address, status FROM jobs WHERE id = $1",
+    [jobId]
+  );
+  if (!jobRows.length) {
+    const e = new Error("Job not found");
+    e.status = 404;
+    throw e;
+  }
+  const job = jobRows[0];
+  if (job.freelancer_address !== freelancerAddress) {
+    const e = new Error("Only the assigned freelancer can generate an invoice for this job");
+    e.status = 403;
+    throw e;
+  }
+
+  // Fetch the entries to include
+  let entries;
+  if (Array.isArray(entryIds) && entryIds.length > 0) {
+    const { rows } = await pool.query(
+      `SELECT * FROM time_entries
+       WHERE id = ANY($1::uuid[]) AND job_id = $2 AND freelancer_address = $3`,
+      [entryIds, jobId, freelancerAddress]
+    );
+    entries = rows;
+    if (!entries.length) {
+      const e = new Error("No matching time entries found for the provided IDs");
+      e.status = 400;
+      throw e;
+    }
+  } else {
+    // Default: all entries not yet included in an approved/pending invoice
+    const { rows } = await pool.query(
+      `SELECT te.* FROM time_entries te
+       WHERE te.job_id = $1
+         AND te.freelancer_address = $2
+         AND NOT EXISTS (
+           SELECT 1 FROM time_invoices ti
+           WHERE ti.job_id = $1
+             AND ti.status IN ('pending', 'approved')
+             AND te.id = ANY(ti.entry_ids)
+         )
+       ORDER BY te.created_at ASC`,
+      [jobId, freelancerAddress]
+    );
+    entries = rows;
+    if (!entries.length) {
+      const e = new Error("No un-invoiced time entries found for this job");
+      e.status = 400;
+      throw e;
+    }
+  }
+
+  const totalMinutes = entries.reduce((sum, e) => sum + e.duration_minutes, 0);
+  const totalHours = totalMinutes / 60;
+  const totalAmountXlm = (totalHours * rate).toFixed(7);
+  const includedIds = entries.map((e) => e.id);
+
+  const { rows: invoiceRows } = await pool.query(
+    `INSERT INTO time_invoices
+       (job_id, freelancer_address, client_address, total_minutes, hourly_rate_xlm,
+        total_amount_xlm, status, entry_ids, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7, NOW(), NOW())
+     RETURNING *`,
+    [
+      jobId,
+      freelancerAddress,
+      job.client_address,
+      totalMinutes,
+      rate.toFixed(7),
+      totalAmountXlm,
+      includedIds,
+    ]
+  );
+
+  return rowToInvoice(invoiceRows[0]);
+}
+
+/**
+ * Retrieve all invoices for a job.
+ *
+ * @param {string} jobId UUID of the job.
+ * @returns {Promise<Object[]>} Array of invoices ordered newest-first.
+ */
+async function getInvoicesForJob(jobId) {
+  if (!jobId) {
+    const e = new Error("jobId is required");
+    e.status = 400;
+    throw e;
+  }
+
+  const { rows } = await pool.query(
+    `SELECT * FROM time_invoices WHERE job_id = $1 ORDER BY created_at DESC`,
+    [jobId]
+  );
+
+  return rows.map(rowToInvoice);
+}
+
+/**
+ * Client approves or rejects an invoice.
+ *
+ * Approving an invoice records the optional on-chain tx hash and marks the
+ * invoice as approved.  The actual escrow partial_release is handled by the
+ * existing escrow route — this service only tracks the approval decision.
+ *
+ * @param {Object} params
+ * @param {string}  params.invoiceId      UUID of the invoice.
+ * @param {string}  params.clientAddress  Stellar G-address of the client.
+ * @param {"approved"|"rejected"} params.decision
+ * @param {string}  [params.contractTxHash] On-chain tx hash (for approved invoices).
+ * @returns {Promise<Object>} The updated invoice.
+ */
+async function reviewInvoice({ invoiceId, clientAddress, decision, contractTxHash }) {
+  validatePublicKey(clientAddress);
+
+  if (!["approved", "rejected"].includes(decision)) {
+    const e = new Error("decision must be 'approved' or 'rejected'");
+    e.status = 400;
+    throw e;
+  }
+
+  const { rows: invRows } = await pool.query(
+    "SELECT * FROM time_invoices WHERE id = $1",
+    [invoiceId]
+  );
+  if (!invRows.length) {
+    const e = new Error("Invoice not found");
+    e.status = 404;
+    throw e;
+  }
+  const invoice = invRows[0];
+
+  if (invoice.client_address !== clientAddress) {
+    const e = new Error("Only the job client can review this invoice");
+    e.status = 403;
+    throw e;
+  }
+  if (invoice.status !== "pending") {
+    const e = new Error(`Invoice is already ${invoice.status}`);
+    e.status = 400;
+    throw e;
+  }
+
+  const { rows: updated } = await pool.query(
+    `UPDATE time_invoices
+     SET status = $1,
+         contract_tx_hash = $2,
+         updated_at = NOW()
+     WHERE id = $3
+     RETURNING *`,
+    [decision, contractTxHash || null, invoiceId]
+  );
+
+  return rowToInvoice(updated[0]);
+}
+
+module.exports = {
+  logTimeEntry,
+  getTimeEntriesForJob,
+  generateInvoice,
+  getInvoicesForJob,
+  reviewInvoice,
+};

--- a/frontend/components/TimeTracker.tsx
+++ b/frontend/components/TimeTracker.tsx
@@ -1,99 +1,529 @@
-import { useEffect, useState } from "react";
+/**
+ * components/TimeTracker.tsx
+ * Issue #346 — Time tracking integration with billing calculation.
+ *
+ * Features:
+ *  - Live timer per job with start / stop
+ *  - Manual time entry for offline work
+ *  - Accumulated hours → billable XLM amount (hours × rate)
+ *  - Submit time entries as an invoice
+ *  - Client approve / reject invoice panel
+ *  - Export time log as CSV
+ */
+"use client";
 
-interface Session {
-  start: number;
-  end: number;
+import { useEffect, useRef, useState, useCallback } from "react";
+import type { TimeEntry, TimeInvoice } from "@/utils/types";
+import {
+  logTimeEntry,
+  fetchTimeEntries,
+  fetchTimeInvoices,
+  generateTimeInvoice,
+  reviewTimeInvoice,
+} from "@/lib/api";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function minutesToHHMM(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${h}h ${m.toString().padStart(2, "0")}m`;
 }
 
-export default function TimeTracker({ jobId }: { jobId: string }) {
-  const [running, setRunning] = useState(false);
-  const [startTime, setStartTime] = useState<number | null>(null);
-  const [sessions, setSessions] = useState<Session[]>([]);
-  const [hourlyRate, setHourlyRate] = useState<number>(0);
+function secondsToHHMMSS(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  return [h, m, s].map((v) => v.toString().padStart(2, "0")).join(":");
+}
 
-  // Load from localStorage
-  useEffect(() => {
-    const stored = localStorage.getItem(`time-${jobId}`);
-    if (stored) setSessions(JSON.parse(stored));
+function xlmAmount(totalMinutes: number, rateXlm: number): string {
+  return ((totalMinutes / 60) * rateXlm).toFixed(4);
+}
+
+function exportCsv(entries: TimeEntry[], jobId: string) {
+  const header = "id,started_at,duration_minutes,description,created_at\n";
+  const rows = entries
+    .map(
+      (e) =>
+        `${e.id},${e.startedAt ?? ""},${e.durationMinutes},"${(e.description ?? "").replace(/"/g, '""')}",${e.createdAt}`,
+    )
+    .join("\n");
+  const blob = new Blob([header + rows], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `time-log-${jobId}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ─── props ────────────────────────────────────────────────────────────────────
+
+interface TimeTrackerProps {
+  /** UUID of the job being tracked. */
+  jobId: string;
+  /** Whether the current user is the client (shows invoice review panel). */
+  isClient?: boolean;
+  /** Whether the current user is the freelancer (shows timer + submit). */
+  isFreelancer?: boolean;
+}
+
+// ─── component ────────────────────────────────────────────────────────────────
+
+export default function TimeTracker({
+  jobId,
+  isClient = false,
+  isFreelancer = false,
+}: TimeTrackerProps) {
+  // ── timer state ──────────────────────────────────────────────────────────
+  const [running, setRunning] = useState(false);
+  const [elapsed, setElapsed] = useState(0); // seconds
+  const startRef = useRef<number | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // ── data state ───────────────────────────────────────────────────────────
+  const [entries, setEntries] = useState<TimeEntry[]>([]);
+  const [invoices, setInvoices] = useState<TimeInvoice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  // ── form state ───────────────────────────────────────────────────────────
+  const [hourlyRate, setHourlyRate] = useState<number>(0);
+  const [timerDesc, setTimerDesc] = useState("");
+
+  // manual entry
+  const [showManual, setShowManual] = useState(false);
+  const [manualMinutes, setManualMinutes] = useState("");
+  const [manualDesc, setManualDesc] = useState("");
+  const [manualStartedAt, setManualStartedAt] = useState("");
+  const [submittingManual, setSubmittingManual] = useState(false);
+
+  // invoice
+  const [submittingInvoice, setSubmittingInvoice] = useState(false);
+  const [reviewingId, setReviewingId] = useState<string | null>(null);
+
+  // ── load data ────────────────────────────────────────────────────────────
+  const reload = useCallback(async () => {
+    try {
+      const [e, i] = await Promise.all([
+        fetchTimeEntries(jobId),
+        fetchTimeInvoices(jobId),
+      ]);
+      setEntries(e);
+      setInvoices(i);
+    } catch {
+      // silently ignore — user may not be authenticated yet
+    } finally {
+      setLoading(false);
+    }
   }, [jobId]);
 
-  // Save to localStorage
   useEffect(() => {
-    localStorage.setItem(`time-${jobId}`, JSON.stringify(sessions));
-  }, [sessions, jobId]);
+    reload();
+  }, [reload]);
 
-  const start = () => {
-    setRunning(true);
-    setStartTime(Date.now());
-  };
-
-  const stop = () => {
-    if (!startTime) return;
-
-    const newSession = {
-      start: startTime,
-      end: Date.now(),
+  // ── timer tick ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (running) {
+      intervalRef.current = setInterval(() => {
+        setElapsed(Math.floor((Date.now() - (startRef.current ?? Date.now())) / 1000));
+      }, 1000);
+    } else {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
     };
+  }, [running]);
 
-    setSessions([...sessions, newSession]);
+  // ── timer controls ───────────────────────────────────────────────────────
+  const handleStart = () => {
+    startRef.current = Date.now();
+    setElapsed(0);
+    setRunning(true);
+    setError(null);
+  };
+
+  const handleStop = async () => {
+    if (!startRef.current) return;
     setRunning(false);
-    setStartTime(null);
+    const durationMinutes = Math.max(1, Math.round(elapsed / 60));
+    const startedAt = new Date(startRef.current).toISOString();
+    startRef.current = null;
+    setElapsed(0);
+
+    try {
+      await logTimeEntry({
+        jobId,
+        durationMinutes,
+        description: timerDesc.trim() || undefined,
+        startedAt,
+      });
+      setTimerDesc("");
+      flash("Time entry saved.");
+      await reload();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to save time entry.");
+    }
   };
 
-  const reset = () => {
-    setSessions([]);
-    localStorage.removeItem(`time-${jobId}`);
+  // ── manual entry ─────────────────────────────────────────────────────────
+  const handleManualSubmit = async () => {
+    const mins = parseInt(manualMinutes, 10);
+    if (!mins || mins <= 0) {
+      setError("Duration must be a positive number of minutes.");
+      return;
+    }
+    setSubmittingManual(true);
+    setError(null);
+    try {
+      await logTimeEntry({
+        jobId,
+        durationMinutes: mins,
+        description: manualDesc.trim() || undefined,
+        startedAt: manualStartedAt || undefined,
+      });
+      setManualMinutes("");
+      setManualDesc("");
+      setManualStartedAt("");
+      setShowManual(false);
+      flash("Manual entry saved.");
+      await reload();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to save manual entry.");
+    } finally {
+      setSubmittingManual(false);
+    }
   };
 
-  const totalSeconds = sessions.reduce(
-    (acc, s) => acc + (s.end - s.start) / 1000,
-    0
-  );
+  // ── invoice ──────────────────────────────────────────────────────────────
+  const handleGenerateInvoice = async () => {
+    if (!hourlyRate || hourlyRate <= 0) {
+      setError("Set a positive hourly rate before generating an invoice.");
+      return;
+    }
+    setSubmittingInvoice(true);
+    setError(null);
+    try {
+      await generateTimeInvoice({ jobId, hourlyRateXlm: hourlyRate });
+      flash("Invoice submitted to client.");
+      await reload();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to generate invoice.");
+    } finally {
+      setSubmittingInvoice(false);
+    }
+  };
 
-  const totalHours = totalSeconds / 3600;
-  const estimated = totalHours * hourlyRate;
+  const handleReview = async (invoiceId: string, decision: "approved" | "rejected") => {
+    setReviewingId(invoiceId);
+    setError(null);
+    try {
+      await reviewTimeInvoice(invoiceId, decision);
+      flash(`Invoice ${decision}.`);
+      await reload();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to update invoice.");
+    } finally {
+      setReviewingId(null);
+    }
+  };
+
+  // ── derived totals ───────────────────────────────────────────────────────
+  const totalMinutes = entries.reduce((s, e) => s + e.durationMinutes, 0);
+  const pendingInvoice = invoices.find((i) => i.status === "pending");
+  const hasPendingInvoice = Boolean(pendingInvoice);
+
+  // ── flash helper ─────────────────────────────────────────────────────────
+  function flash(msg: string) {
+    setSuccessMsg(msg);
+    setTimeout(() => setSuccessMsg(null), 3000);
+  }
+
+  // ── render ───────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="card mt-6 animate-pulse">
+        <div className="h-5 bg-market-500/10 rounded w-1/3 mb-3" />
+        <div className="h-4 bg-market-500/8 rounded w-2/3" />
+      </div>
+    );
+  }
 
   return (
-    <div className="card mt-6">
-      <h2 className="text-lg font-semibold text-amber-100 mb-3">
-        ⏱ Time Tracker
-      </h2>
-
-      <div className="flex gap-3 mb-4">
-        {!running ? (
-          <button onClick={start} className="btn-primary">Start</button>
-        ) : (
-          <button onClick={stop} className="btn-secondary">Stop</button>
+    <div className="card mt-6 space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-amber-100">⏱ Time Tracker</h2>
+        {entries.length > 0 && (
+          <button
+            onClick={() => exportCsv(entries, jobId)}
+            className="text-xs text-market-400 hover:text-market-300 underline"
+          >
+            Export CSV
+          </button>
         )}
-        <button onClick={reset} className="btn-secondary">Reset</button>
       </div>
 
-      <div className="mb-3">
-        <label className="text-sm text-amber-300">Hourly Rate</label>
-        <input
-          type="number"
-          value={hourlyRate}
-          onChange={(e) => setHourlyRate(Number(e.target.value))}
-          className="w-full mt-1 p-2 rounded bg-ink-800 border border-market-500/20"
-        />
-      </div>
+      {/* Alerts */}
+      {error && (
+        <p className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
+      {successMsg && (
+        <p className="text-sm text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-3 py-2">
+          {successMsg}
+        </p>
+      )}
 
-      <p className="text-sm text-amber-300">
-        Total Hours: {totalHours.toFixed(2)}
-      </p>
-
-      <p className="text-sm text-market-400">
-        Estimated Earnings: {estimated.toFixed(2)}
-      </p>
-
-      <div className="mt-4 space-y-2">
-        {sessions.map((s, i) => (
-          <div key={i} className="text-xs text-amber-700">
-            {new Date(s.start).toLocaleTimeString()} →{" "}
-            {new Date(s.end).toLocaleTimeString()}
+      {/* Freelancer panel */}
+      {isFreelancer && (
+        <>
+          {/* Hourly rate */}
+          <div>
+            <label className="text-xs text-amber-700 block mb-1">
+              Hourly Rate (XLM)
+            </label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={hourlyRate || ""}
+              onChange={(e) => setHourlyRate(parseFloat(e.target.value) || 0)}
+              placeholder="e.g. 25"
+              className="w-full p-2 rounded-lg bg-ink-800 border border-market-500/20 text-amber-100 text-sm focus:outline-none focus:border-market-500/50"
+            />
           </div>
-        ))}
-      </div>
+
+          {/* Live timer */}
+          <div className="bg-ink-800 rounded-xl p-4 border border-market-500/15">
+            <div className="font-mono text-3xl text-market-400 mb-3 text-center">
+              {secondsToHHMMSS(elapsed)}
+            </div>
+
+            <input
+              type="text"
+              value={timerDesc}
+              onChange={(e) => setTimerDesc(e.target.value)}
+              placeholder="What are you working on? (optional)"
+              className="w-full mb-3 p-2 rounded-lg bg-ink-700 border border-market-500/15 text-amber-100 text-sm focus:outline-none focus:border-market-500/40"
+            />
+
+            <div className="flex gap-2">
+              {!running ? (
+                <button
+                  onClick={handleStart}
+                  className="flex-1 btn-primary py-2 text-sm"
+                >
+                  ▶ Start
+                </button>
+              ) : (
+                <button
+                  onClick={handleStop}
+                  className="flex-1 btn-secondary py-2 text-sm"
+                >
+                  ■ Stop &amp; Save
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Manual entry toggle */}
+          <div>
+            <button
+              onClick={() => setShowManual((v) => !v)}
+              className="text-xs text-market-400 hover:text-market-300 underline"
+            >
+              {showManual ? "Hide manual entry" : "+ Add manual entry"}
+            </button>
+
+            {showManual && (
+              <div className="mt-3 space-y-2 bg-ink-800 rounded-xl p-4 border border-market-500/15">
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="text-xs text-amber-700 block mb-1">
+                      Duration (minutes)
+                    </label>
+                    <input
+                      type="number"
+                      min="1"
+                      max="1440"
+                      value={manualMinutes}
+                      onChange={(e) => setManualMinutes(e.target.value)}
+                      placeholder="e.g. 90"
+                      className="w-full p-2 rounded-lg bg-ink-700 border border-market-500/15 text-amber-100 text-sm focus:outline-none focus:border-market-500/40"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs text-amber-700 block mb-1">
+                      Started at (optional)
+                    </label>
+                    <input
+                      type="datetime-local"
+                      value={manualStartedAt}
+                      onChange={(e) => setManualStartedAt(e.target.value)}
+                      className="w-full p-2 rounded-lg bg-ink-700 border border-market-500/15 text-amber-100 text-sm focus:outline-none focus:border-market-500/40"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label className="text-xs text-amber-700 block mb-1">
+                    Description (optional)
+                  </label>
+                  <input
+                    type="text"
+                    value={manualDesc}
+                    onChange={(e) => setManualDesc(e.target.value)}
+                    placeholder="What did you work on?"
+                    className="w-full p-2 rounded-lg bg-ink-700 border border-market-500/15 text-amber-100 text-sm focus:outline-none focus:border-market-500/40"
+                  />
+                </div>
+                <button
+                  onClick={handleManualSubmit}
+                  disabled={submittingManual}
+                  className="btn-primary py-2 text-sm w-full"
+                >
+                  {submittingManual ? "Saving…" : "Save Entry"}
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Totals */}
+          {entries.length > 0 && (
+            <div className="bg-ink-800 rounded-xl p-4 border border-market-500/15 space-y-1">
+              <div className="flex justify-between text-sm">
+                <span className="text-amber-700">Total tracked</span>
+                <span className="text-amber-100 font-mono">
+                  {minutesToHHMM(totalMinutes)}
+                </span>
+              </div>
+              {hourlyRate > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-amber-700">Billable amount</span>
+                  <span className="text-market-400 font-mono font-semibold">
+                    {xlmAmount(totalMinutes, hourlyRate)} XLM
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Submit invoice */}
+          {entries.length > 0 && !hasPendingInvoice && (
+            <button
+              onClick={handleGenerateInvoice}
+              disabled={submittingInvoice || hourlyRate <= 0}
+              className="btn-primary w-full py-2.5 text-sm disabled:opacity-50"
+            >
+              {submittingInvoice ? "Submitting…" : "Submit Invoice to Client"}
+            </button>
+          )}
+
+          {hasPendingInvoice && (
+            <p className="text-xs text-amber-700 text-center">
+              Invoice pending client review.
+            </p>
+          )}
+        </>
+      )}
+
+      {/* Client invoice review panel */}
+      {isClient && invoices.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold text-amber-300">Invoices</h3>
+          {invoices.map((inv) => (
+            <div
+              key={inv.id}
+              className="bg-ink-800 rounded-xl p-4 border border-market-500/15 space-y-2"
+            >
+              <div className="flex justify-between text-sm">
+                <span className="text-amber-700">Time billed</span>
+                <span className="text-amber-100 font-mono">
+                  {minutesToHHMM(inv.totalMinutes)}
+                </span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-amber-700">Rate</span>
+                <span className="text-amber-100 font-mono">
+                  {parseFloat(inv.hourlyRateXlm).toFixed(2)} XLM/hr
+                </span>
+              </div>
+              <div className="flex justify-between text-sm font-semibold">
+                <span className="text-amber-300">Total</span>
+                <span className="text-market-400 font-mono">
+                  {parseFloat(inv.totalAmountXlm).toFixed(4)} XLM
+                </span>
+              </div>
+
+              <div className="flex items-center justify-between pt-1">
+                {inv.status === "pending" ? (
+                  <div className="flex gap-2 w-full">
+                    <button
+                      onClick={() => handleReview(inv.id, "approved")}
+                      disabled={reviewingId === inv.id}
+                      className="flex-1 btn-primary py-2 text-xs"
+                    >
+                      {reviewingId === inv.id ? "…" : "Approve"}
+                    </button>
+                    <button
+                      onClick={() => handleReview(inv.id, "rejected")}
+                      disabled={reviewingId === inv.id}
+                      className="flex-1 btn-secondary py-2 text-xs"
+                    >
+                      {reviewingId === inv.id ? "…" : "Reject"}
+                    </button>
+                  </div>
+                ) : (
+                  <span
+                    className={`text-xs px-2.5 py-1 rounded-full border font-medium ${
+                      inv.status === "approved"
+                        ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20"
+                        : "bg-red-500/10 text-red-400 border-red-500/20"
+                    }`}
+                  >
+                    {inv.status.charAt(0).toUpperCase() + inv.status.slice(1)}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Shared time log */}
+      {(isFreelancer || isClient) && entries.length > 0 && (
+        <div>
+          <h3 className="text-xs font-semibold text-amber-700 uppercase tracking-wide mb-2">
+            Time Log
+          </h3>
+          <div className="space-y-1 max-h-48 overflow-y-auto pr-1">
+            {entries.map((entry) => (
+              <div
+                key={entry.id}
+                className="flex items-start justify-between text-xs text-amber-700 bg-ink-800/50 rounded-lg px-3 py-2"
+              >
+                <span className="flex-1 mr-2 truncate">
+                  {entry.description ?? <em className="opacity-50">No description</em>}
+                </span>
+                <span className="font-mono shrink-0 text-amber-500">
+                  {minutesToHHMM(entry.durationMinutes)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {entries.length === 0 && !isFreelancer && (
+        <p className="text-sm text-amber-800 text-center py-2">
+          No time entries yet.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -918,3 +918,73 @@ export async function unfreezeWallet(address: string) {
   return data;
 }
 
+
+// ─── Time Tracking (Issue #346) ───────────────────────────────────────────────
+
+import type { TimeEntry, TimeInvoice } from "@/utils/types";
+
+/**
+ * Log a time entry for a job.
+ */
+export async function logTimeEntry(payload: {
+  jobId: string;
+  durationMinutes: number;
+  description?: string;
+  startedAt?: string;
+}): Promise<TimeEntry> {
+  const { data } = await api.post<{ success: boolean; data: TimeEntry }>(
+    "/api/time-entries",
+    payload,
+  );
+  return data.data;
+}
+
+/**
+ * Fetch all time entries for a job.
+ */
+export async function fetchTimeEntries(jobId: string): Promise<TimeEntry[]> {
+  const { data } = await api.get<{ success: boolean; data: TimeEntry[] }>(
+    `/api/time-entries/job/${jobId}`,
+  );
+  return data.data;
+}
+
+/**
+ * Fetch all invoices for a job.
+ */
+export async function fetchTimeInvoices(jobId: string): Promise<TimeInvoice[]> {
+  const { data } = await api.get<{ success: boolean; data: TimeInvoice[] }>(
+    `/api/time-entries/job/${jobId}/invoices`,
+  );
+  return data.data;
+}
+
+/**
+ * Generate an invoice from time entries.
+ */
+export async function generateTimeInvoice(payload: {
+  jobId: string;
+  hourlyRateXlm: number;
+  entryIds?: string[];
+}): Promise<TimeInvoice> {
+  const { data } = await api.post<{ success: boolean; data: TimeInvoice }>(
+    "/api/time-entries/invoice",
+    payload,
+  );
+  return data.data;
+}
+
+/**
+ * Client approves or rejects a time invoice.
+ */
+export async function reviewTimeInvoice(
+  invoiceId: string,
+  decision: "approved" | "rejected",
+  contractTxHash?: string,
+): Promise<TimeInvoice> {
+  const { data } = await api.patch<{ success: boolean; data: TimeInvoice }>(
+    `/api/time-entries/invoice/${invoiceId}/review`,
+    { decision, ...(contractTxHash ? { contractTxHash } : {}) },
+  );
+  return data.data;
+}

--- a/frontend/pages/jobs/[id].tsx
+++ b/frontend/pages/jobs/[id].tsx
@@ -319,8 +319,12 @@ export default function JobDetail({ publicKey, onConnect }: JobDetailProps) {
           </div>
         </div>
 
-        {isFreelancer && job.status === "in_progress" && (
-          <TimeTracker jobId={job.id} />
+        {(isFreelancer || isClient) && job.status === "in_progress" && (
+          <TimeTracker
+            jobId={job.id}
+            isFreelancer={isFreelancer}
+            isClient={isClient}
+          />
         )}
 
         {isClient && (

--- a/frontend/utils/types.ts
+++ b/frontend/utils/types.ts
@@ -174,3 +174,32 @@ export interface TokenBalance {
   balance: string;
   symbol: string;
 }
+
+// ─── Time Tracking (Issue #346) ───────────────────────────────────────────────
+
+export interface TimeEntry {
+  id: string;
+  jobId: string;
+  freelancerAddress: string;
+  durationMinutes: number;
+  description: string | null;
+  startedAt: string | null;
+  createdAt: string;
+}
+
+export type InvoiceStatus = "pending" | "approved" | "rejected";
+
+export interface TimeInvoice {
+  id: string;
+  jobId: string;
+  freelancerAddress: string;
+  clientAddress: string;
+  totalMinutes: number;
+  hourlyRateXlm: string;
+  totalAmountXlm: string;
+  status: InvoiceStatus;
+  entryIds: string[];
+  contractTxHash: string | null;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary

Connects the existing `TimeTracker` component to the backend billing and payment system. Freelancers on hourly jobs can now track time, see the billable XLM amount in real time, and submit invoices for client approval. Clients can approve or reject invoices directly from the job page.

Closes #346

---

## Changes

### Backend
- **`schema.sql`** — Added two new idempotent tables:
  - `time_entries` — stores individual tracked or manually-entered work sessions per job
  - `time_invoices` — stores grouped invoices with `pending / approved / rejected` status

- **`timeTrackingService.js`** — New service with:
  - `logTimeEntry` — validates freelancer ownership and logs a session
  - `getTimeEntriesForJob` — fetches all entries for a job
  - `generateInvoice` — calculates total minutes × hourly rate → XLM amount, creates invoice
  - `getInvoicesForJob` — fetches all invoices for a job
  - `reviewInvoice` — client approves or rejects a pending invoice

- **`timeEntries.js`** — New route file (all endpoints JWT-protected + rate-limited):
  - `POST /api/time-entries` — log a time entry
  - `GET /api/time-entries/job/:jobId` — get all entries for a job
  - `GET /api/time-entries/job/:jobId/invoices` — get all invoices for a job
  - `POST /api/time-entries/invoice` — generate invoice from entries
  - `PATCH /api/time-entries/invoice/:invoiceId/review` — client approves/rejects

- **`server.js`** — Wired `/api/time-entries` route

### Frontend
- **`types.ts`** — Added `TimeEntry`, `TimeInvoice`, `InvoiceStatus` types
- **`api.ts`** — Added `logTimeEntry`, `fetchTimeEntries`, `fetchTimeInvoices`, `generateTimeInvoice`, `reviewTimeInvoice` API functions
- **`TimeTracker.tsx`** — Fully replaced with:
  - Live timer (start / stop & save)
  - Manual time entry form for offline work
  - Accumulated hours + billable XLM display (hours × rate)
  - Submit invoice to client button
  - Client approve / reject invoice panel
  - Export time log as CSV
- **`jobs/[id].tsx`** — Updated `TimeTracker` usage to pass `isClient` and `isFreelancer` props so both parties see the relevant panel when job is `in_progress`

---

## Acceptance Criteria

- [x] Timer tracks time per job
- [x] Accumulated time shows billable XLM amount
- [x] Time entries submittable as invoice
- [x] Client can approve/reject invoiced hours

---

## Testing

1. Start a job as freelancer → open job page → use timer or manual entry
2. Set hourly rate → verify XLM amount updates
3. Submit invoice → client sees approve/reject panel
4. Approve invoice → status updates to `approved`
5. Export CSV → verify all entries are included
