### PR TITLE
feat: drag-and-drop evidence upload, Redis caching, cursor pagination deprecation, a11y

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
         "express-rate-limit": "^7.3.1",
         "form-data": "^4.0.0",
         "helmet": "^7.1.0",
+        "ioredis": "^5.3.2",
         "jsonwebtoken": "^9.0.3",
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",

--- a/backend/src/routes/jobs.js
+++ b/backend/src/routes/jobs.js
@@ -18,6 +18,7 @@ const {
   getRecommendedJobs, getSuggestions, extendJobExpiry, incrementViewCount,
 } = require("../services/jobService");
 const { verifyJWT } = require("../middleware/auth");
+const cache = require("../services/cacheService");
 
 // Feed Helpers
 
@@ -162,9 +163,24 @@ router.get("/", generalJobRateLimiter, async (req, res, next) => {
       timezone,
       viewerAddress,
       include_expired,
+      page,
     } = req.query;
     const safeLimit = Math.max(1, Math.min(parseInt(limit, 10) || 20, 100));
     const includeExpired = include_expired === "true";
+
+    // Deprecated offset-style `page` param — cursor pagination is canonical (#291).
+    if (page !== undefined && cursor === undefined) {
+      res.set("Deprecation", "true");
+      res.set("Link", '</api/jobs>; rel="deprecation"');
+      res.set("Sunset", "2025-12-31");
+    }
+
+    const cacheKey = cache.jobListKey({ category, status, limit: String(safeLimit), search, cursor, timezone, viewerAddress, include_expired: String(includeExpired) });
+    const cached = await cache.get(cacheKey);
+    if (cached) {
+      res.set("X-Cache", "HIT");
+      return res.json({ success: true, ...cached, ...(page !== undefined && cursor === undefined && { _deprecation: "The `page` parameter is deprecated. Use cursor-based pagination via `nextCursor`." }) });
+    }
 
     const result = await listJobs({
       category,
@@ -176,10 +192,16 @@ router.get("/", generalJobRateLimiter, async (req, res, next) => {
       viewerAddress,
       includeExpired,
     });
+
+    await cache.set(cacheKey, { data: result.jobs, nextCursor: result.nextCursor }, cache.TTL.JOBS_LIST);
+    res.set("X-Cache", "MISS");
     res.json({
       success: true,
       data: result.jobs,
       nextCursor: result.nextCursor,
+      ...(page !== undefined && cursor === undefined && {
+        _deprecation: "The `page` parameter is deprecated. Use cursor-based pagination via `nextCursor`.",
+      }),
     });
   } catch (e) {
     next(e);
@@ -302,6 +324,7 @@ router.get("/:id", generalJobRateLimiter, async (req, res, next) => {
 router.post("/", jobCreationRateLimiter, async (req, res, next) => {
   try {
     const job = await createJob(req.body);
+    await cache.delPattern("jobs:list:*");
     res.status(201).json({ success: true, data: job });
   } catch (e) {
     next(e);

--- a/backend/src/routes/profiles.js
+++ b/backend/src/routes/profiles.js
@@ -12,6 +12,7 @@ const { uploadFile, getGatewayUrl, MAX_FILE_SIZE } = require("../services/ipfsSe
 
 const profileUpdateRateLimiter = createRateLimiter(5, 1); // 5 profile updates per minute
 const generalProfileRateLimiter = createRateLimiter(30, 1); // 100 requests per minute for getting profiles
+const cache = require("../services/cacheService");
 
 const {
   getProfile,
@@ -31,7 +32,18 @@ const {
 } = require("../services/priceAlertService");
 
 router.get("/:publicKey", generalProfileRateLimiter, async (req, res, next) => {
-  try { res.json({ success: true, data: await getProfile(req.params.publicKey) }); }
+  try {
+    const key = cache.profileKey(req.params.publicKey);
+    const cached = await cache.get(key);
+    if (cached) {
+      res.set("X-Cache", "HIT");
+      return res.json({ success: true, data: cached });
+    }
+    const data = await getProfile(req.params.publicKey);
+    await cache.set(key, data, cache.TTL.PROFILE);
+    res.set("X-Cache", "MISS");
+    res.json({ success: true, data });
+  }
   catch (e) { next(e); }
 });
 
@@ -46,7 +58,11 @@ router.get("/:publicKey/response-time", generalProfileRateLimiter, async (req, r
 });
 
 router.post("/", profileUpdateRateLimiter, async (req, res, next) => {
-  try { res.json({ success: true, data: await upsertProfile(req.body) }); }
+  try {
+    const data = await upsertProfile(req.body);
+    if (req.body.publicKey) await cache.del(cache.profileKey(req.body.publicKey));
+    res.json({ success: true, data });
+  }
   catch (e) { next(e); }
 });
 

--- a/backend/src/services/cacheService.js
+++ b/backend/src/services/cacheService.js
@@ -1,0 +1,140 @@
+/**
+ * src/services/cacheService.js
+ * Redis-backed cache with graceful degradation (#290).
+ *
+ * All public methods silently fall through to the caller on Redis errors so
+ * the API never returns 5xx because Redis is down or misconfigured.
+ *
+ * TTLs:
+ *   job listings  — 30 s  (jobs change frequently)
+ *   profiles      — 300 s (5 min)
+ */
+"use strict";
+
+const Redis = require("ioredis");
+
+const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+
+let client = null;
+
+function getClient() {
+  if (client) return client;
+  try {
+    client = new Redis(REDIS_URL, {
+      lazyConnect: true,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      connectTimeout: 2000,
+    });
+    client.on("error", (err) => {
+      // Log but don't crash — graceful degradation
+      console.warn("[cache] Redis error:", err.message);
+    });
+  } catch (err) {
+    console.warn("[cache] Failed to create Redis client:", err.message);
+    client = null;
+  }
+  return client;
+}
+
+/**
+ * Build a deterministic cache key for job list queries.
+ * Sorts params alphabetically so key is stable regardless of insertion order.
+ *
+ * @param {Record<string, string|undefined>} queryParams
+ * @returns {string}
+ */
+function jobListKey(queryParams) {
+  const sorted = Object.entries(queryParams)
+    .filter(([, v]) => v !== undefined && v !== "")
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `jobs:list:${new URLSearchParams(sorted).toString()}`;
+}
+
+/**
+ * Build the profile cache key for a given public key.
+ *
+ * @param {string} publicKey
+ * @returns {string}
+ */
+function profileKey(publicKey) {
+  return `profile:${publicKey}`;
+}
+
+/**
+ * Get a cached value. Returns null on miss or error.
+ *
+ * @param {string} key
+ * @returns {Promise<any|null>}
+ */
+async function get(key) {
+  const redis = getClient();
+  if (!redis) return null;
+  try {
+    const raw = await redis.get(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Set a cached value with a TTL in seconds.
+ *
+ * @param {string} key
+ * @param {any} value
+ * @param {number} ttlSeconds
+ */
+async function set(key, value, ttlSeconds) {
+  const redis = getClient();
+  if (!redis) return;
+  try {
+    await redis.setex(key, ttlSeconds, JSON.stringify(value));
+  } catch {
+    // Swallow — graceful degradation
+  }
+}
+
+/**
+ * Delete all keys matching a glob pattern.
+ * Used to invalidate job list cache on write operations.
+ *
+ * @param {string} pattern  e.g. "jobs:list:*"
+ */
+async function delPattern(pattern) {
+  const redis = getClient();
+  if (!redis) return;
+  try {
+    let cursor = "0";
+    do {
+      const [nextCursor, keys] = await redis.scan(cursor, "MATCH", pattern, "COUNT", 100);
+      cursor = nextCursor;
+      if (keys.length) await redis.del(...keys);
+    } while (cursor !== "0");
+  } catch {
+    // Swallow — graceful degradation
+  }
+}
+
+/**
+ * Delete a single key.
+ *
+ * @param {string} key
+ */
+async function del(key) {
+  const redis = getClient();
+  if (!redis) return;
+  try {
+    await redis.del(key);
+  } catch {
+    // Swallow — graceful degradation
+  }
+}
+
+module.exports = { get, set, del, delPattern, jobListKey, profileKey };
+
+// TTL constants exported so callers don't hard-code numbers.
+module.exports.TTL = {
+  JOBS_LIST: 30,   // 30 s — jobs change frequently
+  PROFILE: 300,    // 5 min
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,17 @@ services:
       - backend
     command: npm run dev
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   backend:
     build:
       context: ./backend
@@ -31,9 +42,12 @@ services:
       - STELLAR_NETWORK=testnet
       - HORIZON_URL=https://horizon-testnet.stellar.org
       - ALLOWED_ORIGINS=http://localhost:3000
+      - REDIS_URL=redis://redis:6379
     volumes:
       - ./backend:/app
       - /app/node_modules
+    depends_on:
+      - redis
     command: npm run dev
 
     

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -68,6 +68,14 @@ export default function Navbar({ publicKey, onConnect, onDisconnect }: NavbarPro
   }, [router.pathname]);
 
   return (
+    <>
+      {/* Skip to main content (#287) */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-market-500 focus:text-white focus:font-bold focus:text-sm"
+      >
+        Skip to main content
+      </a>
     <nav className="sticky top-0 z-50 border-b border-[rgba(251,191,36,0.10)] bg-ink-900/85 backdrop-blur-xl">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between gap-4">
 
@@ -155,6 +163,7 @@ export default function Navbar({ publicKey, onConnect, onDisconnect }: NavbarPro
         </div>
       </div>
     </nav>
+    </>
   );
 }
 

--- a/frontend/components/ShareJobModal.tsx
+++ b/frontend/components/ShareJobModal.tsx
@@ -2,7 +2,7 @@
  * components/ShareJobModal.tsx
  * Modal for sharing job listings with pre-filled application forms
  */
-import { useState } from "react";
+import { useState, useEffect, useRef, KeyboardEvent } from "react";
 import type { Job } from "@/utils/types";
 
 interface ShareJobModalProps {
@@ -21,6 +21,30 @@ export default function ShareJobModal({ job, onClose }: ShareJobModalProps) {
     jobId: job.id,
   });
   const [showQR, setShowQR] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus trap (#287): keep focus inside modal
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'a[href],button:not([disabled]),input,select,textarea,[tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    first?.focus();
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") { onClose(); return; }
+      if (e.key !== "Tab") return;
+      if (e.shiftKey) {
+        if (document.activeElement === first) { e.preventDefault(); last?.focus(); }
+      } else {
+        if (document.activeElement === last) { e.preventDefault(); first?.focus(); }
+      }
+    };
+    dialog.addEventListener("keydown", handleKeyDown);
+    return () => dialog.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
 
   // Generate canonical job URL
   const jobUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/jobs/${job.id}`;
@@ -58,8 +82,14 @@ export default function ShareJobModal({ job, onClose }: ShareJobModalProps) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-ink-900/90 backdrop-blur-sm flex items-center justify-center p-4">
-      <div className="w-full max-w-md bg-ink-800 rounded-xl border border-market-500/20 shadow-xl">
+    <div className="fixed inset-0 z-50 bg-ink-900/90 backdrop-blur-sm flex items-center justify-center p-4" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Share job: ${job.title}`}
+        className="w-full max-w-md bg-ink-800 rounded-xl border border-market-500/20 shadow-xl"
+      >
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-market-500/10">
           <h3 className="font-display text-lg font-semibold text-amber-100">Share Job</h3>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -968,13 +968,20 @@ export async function fetchDisputeDetail(
 export async function uploadDisputeEvidence(
   jobId: string,
   file: File,
+  onProgress?: (pct: number) => void,
 ): Promise<DisputeEvidence> {
   const formData = new FormData();
   formData.append("file", file);
   const { data } = await api.post<{ success: boolean; data: DisputeEvidence }>(
     `/api/disputes/${jobId}/evidence`,
     formData,
-    { headers: { "Content-Type": "multipart/form-data" }, timeout: 60000 },
+    {
+      headers: { "Content-Type": "multipart/form-data" },
+      timeout: 60000,
+      onUploadProgress: onProgress
+        ? (e) => { if (e.total) onProgress(Math.round((e.loaded / e.total) * 100)); }
+        : undefined,
+    },
   );
   return data.data;
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -198,7 +198,7 @@ function App({ Component, pageProps }: AppProps) {
               onConnect={handleConnect}
               onDisconnect={() => setPublicKey(null)}
             />
-            <main className="flex-1">
+            <main id="main-content" className="flex-1">
               <Component
                 {...pageProps}
                 publicKey={publicKey}

--- a/frontend/pages/disputes/[jobId].tsx
+++ b/frontend/pages/disputes/[jobId].tsx
@@ -1,11 +1,11 @@
 /**
  * pages/disputes/[jobId].tsx
- * Dispute detail page — evidence upload and review (Issue #223)
+ * Dispute detail page — evidence upload and review (Issues #223, #289)
  *
- * Both client and freelancer can upload up to 10 files (images, PDFs, text).
- * Files are stored on IPFS via Pinata. Admin can view all evidence here.
+ * Both client and freelancer can upload up to 10 files (images, PDFs, text)
+ * via drag-and-drop or file picker. Files are stored on IPFS via Pinata.
  */
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback, DragEvent } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import {
@@ -65,6 +65,21 @@ function EvidenceCard({ ev, isOwn }: { ev: DisputeEvidence; isOwn: boolean }) {
   );
 }
 
+// Per-file upload tracking
+interface PendingFile {
+  id: string;
+  file: File;
+  progress: number; // 0-100
+  status: "pending" | "uploading" | "done" | "error";
+  errorMsg?: string;
+}
+
+function validateFile(file: File): string | null {
+  if (!ALLOWED_TYPES.includes(file.type)) return "Only images, PDFs, and plain text files are allowed.";
+  if (file.size > MAX_SIZE_MB * 1024 * 1024) return `File exceeds ${MAX_SIZE_MB} MB limit.`;
+  return null;
+}
+
 interface PageProps {
   publicKey: string | null;
 }
@@ -73,12 +88,14 @@ export default function DisputePage({ publicKey }: PageProps) {
   const router    = useRouter();
   const jobId     = Array.isArray(router.query.jobId) ? router.query.jobId[0] : router.query.jobId;
   const fileRef   = useRef<HTMLInputElement>(null);
+  const dropRef   = useRef<HTMLDivElement>(null);
   const { success, info } = useToast();
 
-  const [detail, setDetail]       = useState<DisputeDetail | null>(null);
-  const [loading, setLoading]     = useState(true);
-  const [uploading, setUploading] = useState(false);
-  const [fileError, setFileError] = useState("");
+  const [detail, setDetail]         = useState<DisputeDetail | null>(null);
+  const [loading, setLoading]       = useState(true);
+  const [pendingFiles, setPending]  = useState<PendingFile[]>([]);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [dropError, setDropError]   = useState("");
 
   useEffect(() => {
     if (!jobId) return;
@@ -88,33 +105,56 @@ export default function DisputePage({ publicKey }: PageProps) {
       .finally(() => setLoading(false));
   }, [jobId]);
 
-  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setFileError("");
+  const myEvidentCount = (detail?.evidence ?? []).filter((ev) => ev.uploaderAddress === publicKey).length;
+  const slotsLeft = 10 - myEvidentCount - pendingFiles.filter((f) => f.status !== "error").length;
 
-    if (!ALLOWED_TYPES.includes(file.type)) {
-      setFileError("Only images, PDFs, and plain text files are allowed.");
-      return;
+  const enqueueFiles = useCallback((files: File[]) => {
+    setDropError("");
+    const toAdd: PendingFile[] = [];
+    for (const file of files) {
+      const err = validateFile(file);
+      if (err) { setDropError(err); continue; }
+      if (slotsLeft - toAdd.length <= 0) { setDropError("Maximum 10 files per party."); break; }
+      toAdd.push({ id: `${file.name}-${file.size}-${Date.now()}`, file, progress: 0, status: "pending" });
     }
-    if (file.size > MAX_SIZE_MB * 1024 * 1024) {
-      setFileError(`File must be smaller than ${MAX_SIZE_MB} MB.`);
-      return;
-    }
+    if (toAdd.length) setPending((prev) => [...prev, ...toAdd]);
+  }, [slotsLeft]);
 
-    setUploading(true);
-    try {
-      const ev = await uploadDisputeEvidence(jobId!, file);
-      setDetail((prev) =>
-        prev ? { ...prev, evidence: [...prev.evidence, ev] } : prev
-      );
-      success("Evidence uploaded to IPFS.");
-      if (fileRef.current) fileRef.current.value = "";
-    } catch (err: any) {
-      info(err?.response?.data?.error || err?.message || "Upload failed. Please try again.");
-    } finally {
-      setUploading(false);
+  const uploadPending = useCallback(async () => {
+    if (!jobId) return;
+    const queue = pendingFiles.filter((f) => f.status === "pending");
+    for (const pf of queue) {
+      setPending((prev) => prev.map((f) => f.id === pf.id ? { ...f, status: "uploading" } : f));
+      try {
+        const ev = await uploadDisputeEvidence(jobId, pf.file, (pct) =>
+          setPending((prev) => prev.map((f) => f.id === pf.id ? { ...f, progress: pct } : f))
+        );
+        setDetail((prev) => prev ? { ...prev, evidence: [...prev.evidence, ev] } : prev);
+        setPending((prev) => prev.map((f) => f.id === pf.id ? { ...f, status: "done", progress: 100 } : f));
+      } catch (err: unknown) {
+        const msg = (err as { response?: { data?: { error?: string } }; message?: string })?.response?.data?.error
+          ?? (err instanceof Error ? err.message : "Upload failed.");
+        setPending((prev) => prev.map((f) => f.id === pf.id ? { ...f, status: "error", errorMsg: msg } : f));
+      }
     }
+    const doneCount = pendingFiles.filter((f) => f.status === "done").length + queue.length;
+    if (doneCount > 0) success(`${doneCount} file(s) uploaded to IPFS.`);
+    // Remove done files from queue after a short delay
+    setTimeout(() => setPending((prev) => prev.filter((f) => f.status !== "done")), 1500);
+  }, [jobId, pendingFiles, success]);
+
+  const removeFile = (id: string) => setPending((prev) => prev.filter((f) => f.id !== id));
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setIsDragOver(true); };
+  const handleDragLeave = () => setIsDragOver(false);
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    enqueueFiles(Array.from(e.dataTransfer.files));
+  };
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    enqueueFiles(Array.from(e.target.files ?? []));
+    if (fileRef.current) fileRef.current.value = "";
   };
 
   if (loading) {
@@ -136,9 +176,11 @@ export default function DisputePage({ publicKey }: PageProps) {
 
   const { job, evidence } = detail;
   const isParty = publicKey === job.client_address || publicKey === job.freelancer_address;
-  const myEvidence = evidence.filter((ev) => ev.uploaderAddress === publicKey);
+  const myEvidence         = evidence.filter((ev) => ev.uploaderAddress === publicKey);
   const clientEvidence     = evidence.filter((ev) => ev.uploaderAddress === job.client_address);
   const freelancerEvidence = evidence.filter((ev) => ev.uploaderAddress === job.freelancer_address);
+  const pendingCount = pendingFiles.filter((f) => f.status !== "error").length;
+  const totalCount = myEvidence.length + pendingCount;
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 animate-fade-in space-y-8">
@@ -172,39 +214,98 @@ export default function DisputePage({ publicKey }: PageProps) {
         </div>
       </div>
 
-      {/* Upload evidence */}
+      {/* Upload evidence — drag-and-drop (#289) */}
       {isParty && (
-        <div className="card space-y-3 max-w-lg">
+        <div className="card space-y-4 max-w-lg">
           <p className="font-medium text-amber-100 text-sm">
-            Upload evidence ({myEvidence.length}/10 files)
+            Upload evidence ({totalCount}/10 files)
           </p>
           <p className="text-xs text-amber-800">
-            Images, PDFs, or plain text · Max {MAX_SIZE_MB} MB per file
+            Images, PDFs, or plain text · Max {MAX_SIZE_MB} MB per file · Max 10 files
           </p>
-          {fileError && <p className="text-sm text-red-400">{fileError}</p>}
-          <div className="flex gap-3 items-center">
+
+          {/* Drop zone */}
+          <div
+            ref={dropRef}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={() => fileRef.current?.click()}
+            role="button"
+            aria-label="Upload evidence files — click or drag and drop"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === "Enter" && fileRef.current?.click()}
+            className={clsx(
+              "flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed py-8 cursor-pointer transition-colors",
+              isDragOver ? "border-market-400 bg-market-500/10" : "border-amber-900/40 hover:border-market-500/50",
+              totalCount >= 10 && "pointer-events-none opacity-50"
+            )}
+          >
+            <svg className="w-8 h-8 text-amber-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M12 12V4m0 0L8 8m4-4l4 4" />
+            </svg>
+            <p className="text-sm text-amber-700">
+              {isDragOver ? "Drop files here" : "Drag files here, or click to browse"}
+            </p>
             <input
               ref={fileRef}
               type="file"
               accept={ALLOWED_TYPES.join(",")}
+              multiple
               className="hidden"
               id="evidence-upload"
-              onChange={handleUpload}
-              disabled={uploading || myEvidence.length >= 10}
+              onChange={handleFileInput}
+              aria-label="Choose evidence files"
             />
-            <label
-              htmlFor="evidence-upload"
-              className={clsx(
-                "btn-primary text-sm cursor-pointer",
-                (uploading || myEvidence.length >= 10) && "opacity-50 pointer-events-none"
-              )}
-            >
-              {uploading ? "Uploading to IPFS…" : "Choose file"}
-            </label>
-            {myEvidence.length >= 10 && (
-              <p className="text-xs text-amber-800">Maximum files reached.</p>
-            )}
           </div>
+
+          {(dropError) && <p className="text-sm text-red-400">{dropError}</p>}
+
+          {/* Pending file list */}
+          {pendingFiles.length > 0 && (
+            <ul className="space-y-2" aria-label="Files queued for upload">
+              {pendingFiles.map((pf) => (
+                <li key={pf.id} className="rounded-lg bg-amber-900/20 border border-amber-900/30 px-3 py-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-xs text-amber-100 truncate">{pf.file.name}</p>
+                      <p className="text-[10px] text-amber-800">{(pf.file.size / 1024).toFixed(1)} KB</p>
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      {pf.status === "uploading" && (
+                        <span className="text-[10px] text-market-400">{pf.progress}%</span>
+                      )}
+                      {pf.status === "done" && <span className="text-[10px] text-green-400">✓ Done</span>}
+                      {pf.status === "error" && <span className="text-[10px] text-red-400" title={pf.errorMsg}>✗ Failed</span>}
+                      {pf.status !== "uploading" && pf.status !== "done" && (
+                        <button
+                          type="button"
+                          onClick={() => removeFile(pf.id)}
+                          aria-label={`Remove ${pf.file.name}`}
+                          className="text-amber-700 hover:text-red-400 transition-colors text-xs"
+                        >✕</button>
+                      )}
+                    </div>
+                  </div>
+                  {pf.status === "uploading" && (
+                    <div className="mt-1.5 h-1 rounded-full bg-amber-900/40 overflow-hidden" role="progressbar" aria-valuenow={pf.progress} aria-valuemin={0} aria-valuemax={100} aria-label={`Uploading ${pf.file.name}`}>
+                      <div className="h-full bg-market-400 transition-all" style={{ width: `${pf.progress}%` }} />
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {pendingFiles.some((f) => f.status === "pending") && (
+            <button
+              type="button"
+              onClick={uploadPending}
+              className="btn-primary text-sm w-full"
+            >
+              Upload {pendingFiles.filter((f) => f.status === "pending").length} file(s) to IPFS
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Closes #289
Closes #290
Closes #291
Closes #287

## What changed

### #289 — Drag-and-drop evidence upload

**`frontend/pages/disputes/[jobId].tsx`**
- Replaced single-file basic `<input>` with a full drag-and-drop upload zone using HTML5 `dragover`/`dragleave`/`drop` events (no library)
- Drop zone has dashed border, cloud-upload icon, and highlights on drag-over
- Multi-file support: all dropped/selected files are queued as `PendingFile[]` before upload
- Per-file status display: pending → uploading (with live % progress bar) → done ✓ / error ✗
- Remove button per queued file (before upload starts)
- Validation per file: allowed MIME types, 5 MB size limit, 10-file per-party cap
- "Upload N file(s) to IPFS" button starts uploads sequentially

**`frontend/lib/api.ts`**
- Added optional `onProgress?: (pct: number) => void` parameter to `uploadDisputeEvidence`; wired to axios `onUploadProgress` for real per-file progress

### #290 — Redis caching

**`backend/src/services/cacheService.js`** (new)
- Thin wrapper over `ioredis` with graceful degradation: all methods catch errors silently and fall through to the DB
- `get(key)` / `set(key, value, ttlSeconds)` / `del(key)` / `delPattern(pattern)` — scan-based key glob delete for invalidation
- `jobListKey(queryParams)` — deterministic sorted cache key for job list queries
- `profileKey(publicKey)` — profile cache key
- TTL constants: `JOBS_LIST = 30s`, `PROFILE = 300s`

**`backend/src/routes/jobs.js`**
- `GET /api/jobs`: cache lookup before DB; sets `X-Cache: HIT` or `MISS` header
- `POST /api/jobs`: invalidates `jobs:list:*` pattern after successful create

**`backend/src/routes/profiles.js`**
- `GET /api/profiles/:publicKey`: cache lookup with `X-Cache` header
- `POST /api/profiles`: invalidates the profile key on successful upsert

**`docker-compose.yml`** — added `redis:7-alpine` service; wired `REDIS_URL` into backend env
**`backend/package.json`** — added `ioredis@^5.3.2`

### #291 — Cursor pagination backward-compat deprecation

**`backend/src/routes/jobs.js`**
- The keyset/cursor pagination was already fully implemented in `jobService.js` and the frontend already uses `nextCursor` with a Load More button
- Added: when `?page` is passed without `?cursor`, the response now sets `Deprecation: true`, `Link: </api/jobs>; rel="deprecation"`, `Sunset: 2025-12-31` headers and includes `_deprecation` in the JSON body
- No existing behaviour changed; old clients that pass `page` still get results

### #287 — Accessibility

**`frontend/components/Navbar.tsx`**
- Added skip-to-main-content link as the very first element: visually hidden (`sr-only`), visible on keyboard focus (`focus:not-sr-only`)

**`frontend/pages/_app.tsx`**
- Added `id="main-content"` to `<main>` — target for the skip link

**`frontend/components/ShareJobModal.tsx`**
- Added `role="dialog" aria-modal="true" aria-label` to modal container
- Keyboard focus trap: Tab/Shift+Tab cycle through focusable elements; Escape closes modal
- Backdrop click to close
- Note: color contrast ratio fixes require design system changes and are tracked separately

## How to test

- **Evidence upload:** Go to `/disputes/<jobId>`, drag multiple files onto the zone — verify progress bars, remove button, and IPFS upload
- **Redis:** `docker-compose up` → hit `GET /api/jobs` twice → first response has `X-Cache: MISS`, second `X-Cache: HIT`; `POST /api/jobs` clears cache
- **Deprecation:** `GET /api/jobs?page=2` → response headers include `Deprecation: true`
- **Skip link:** Tab once from browser address bar on any page → skip link appears → Enter jumps to `#main-content`
- **Modal focus trap:** Open Share Job modal → Tab cycles through buttons without leaving the modal; Escape closes it