### PR TITLE
Require JWT secret configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 PORT=4000
 NODE_ENV=development
 DATABASE_URL=postgresql://stellarwork:stellarwork_dev@localhost:5432/stellarwork
+# Required. Server startup fails if JWT_SECRET is unset.
 JWT_SECRET=replace-with-a-long-random-secret
 STELLAR_NETWORK=testnet
 HORIZON_URL=https://horizon-testnet.stellar.org

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -3,10 +3,19 @@
  */
 "use strict";
 const jwt = require("jsonwebtoken");
-const pool = require("../db/pool");
-const { requireEnv } = require("../config/env");
 
-const JWT_SECRET = requireEnv("JWT_SECRET");
+function requireJwtSecret() {
+  if (!process.env.JWT_SECRET) {
+    const message = "FATAL: JWT_SECRET environment variable is required";
+    console.error(message);
+    process.exit(1);
+  }
+
+  return process.env.JWT_SECRET;
+}
+
+const JWT_SECRET = requireJwtSecret();
+const pool = require("../db/pool");
 
 async function verifyJWT(req, res, next) {
   const authHeader = req.headers.authorization;
@@ -42,4 +51,4 @@ async function requireAdmin2FA(req, res, next) {
   }
 }
 
-module.exports = { verifyJWT, requireAdmin2FA, JWT_SECRET };
+module.exports = { verifyJWT, requireAdmin2FA, JWT_SECRET, requireJwtSecret };

--- a/backend/src/middleware/auth.test.js
+++ b/backend/src/middleware/auth.test.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+describe("JWT secret configuration", () => {
+  it("exits with a fatal error when JWT_SECRET is missing", () => {
+    const authModule = path.join(__dirname, "auth.js");
+    const env = {
+      ...process.env,
+      DATABASE_URL: process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/marketpay_test",
+      NODE_ENV: "production",
+    };
+    delete env.JWT_SECRET;
+
+    const result = spawnSync(
+      process.execPath,
+      ["-e", `require(${JSON.stringify(authModule)})`],
+      { env, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("FATAL: JWT_SECRET environment variable is required");
+  });
+});

--- a/backend/src/routes/auth.test.js
+++ b/backend/src/routes/auth.test.js
@@ -109,7 +109,7 @@ describe("SEP-10 Authentication Flow", () => {
       expect(res.body.success).toBe(true);
       expect(res.body).toHaveProperty("token");
 
-      const decoded = jwt.verify(res.body.token, process.env.JWT_SECRET || "test-jwt-secret-with-enough-length-for-ci");
+      const decoded = jwt.verify(res.body.token, process.env.JWT_SECRET);
       expect(decoded.publicKey).toBe(TEST_KEYPAIR.publicKey());
     });
 
@@ -147,7 +147,7 @@ describe("SEP-10 Authentication Flow", () => {
         .send({ transaction: SIGNED_XDR });
 
       expect(res.status).toBe(200);
-      const decoded = jwt.verify(res.body.token, process.env.JWT_SECRET || "test-jwt-secret-with-enough-length-for-ci");
+      const decoded = jwt.verify(res.body.token, process.env.JWT_SECRET);
       expect(decoded.publicKey).toBe(WRONG_KEYPAIR.publicKey());
     });
   });

--- a/backend/src/routes/webauthn.js
+++ b/backend/src/routes/webauthn.js
@@ -21,7 +21,7 @@ const router   = express.Router();
 const pool     = require("../db/pool");
 const jwt      = require("jsonwebtoken");
 const { createRateLimiter } = require("../middleware/rateLimiter");
-const { verifyJWT }         = require("../middleware/auth");
+const { verifyJWT, JWT_SECRET } = require("../middleware/auth");
 
 const {
   generateRegistrationOptions,
@@ -211,8 +211,7 @@ router.post("/login-verify", webauthnRateLimiter, async (req, res, next) => {
       [verification.authenticationInfo.newCounter, credentialId]
     );
 
-    const secret = process.env.JWT_SECRET || "dev-secret";
-    const token  = jwt.sign({ publicKey }, secret, { expiresIn: "7d" });
+    const token  = jwt.sign({ publicKey }, JWT_SECRET, { expiresIn: "7d" });
 
     res.json({ success: true, token });
   } catch (e) { next(e); }

--- a/backend/src/utils/encryption.js
+++ b/backend/src/utils/encryption.js
@@ -4,12 +4,13 @@
 "use strict";
 
 const crypto = require("crypto");
+const { requireEnv } = require("../config/env");
 
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12;
 
 function getEncryptionKey() {
-  const raw = process.env.ENCRYPTION_KEY || process.env.JWT_SECRET || "super_secret_fallback_key";
+  const raw = process.env.ENCRYPTION_KEY || requireEnv("JWT_SECRET");
   return crypto.createHash("sha256").update(raw).digest();
 }
 


### PR DESCRIPTION
﻿Summary
- Removed predictable JWT fallback behavior so the backend fails fast when JWT_SECRET is not configured.
- Added coverage that starts the auth middleware without JWT_SECRET and verifies the process exits with a clear fatal error.
- Updated related JWT signing and encryption paths to rely on the configured secret instead of fallback strings.

Issue
- Closes #261

Changes
- Added a JWT secret startup guard in backend auth middleware that logs `FATAL: JWT_SECRET environment variable is required` and exits with status 1.
- Removed WebAuthn JWT signing fallback to `dev-secret` and signs with the shared configured JWT secret.
- Removed the `super_secret_fallback_key` encryption fallback and requires JWT_SECRET when ENCRYPTION_KEY is absent.
- Documented JWT_SECRET as required in backend/.env.example.
- Added a Jest regression test for missing JWT_SECRET startup behavior and removed fallback use from auth route token verification tests.

Validation
- `npm.cmd ci`
- `npm.cmd run test:unit -- --runTestsByPath src/middleware/auth.test.js --runInBand --detectOpenHandles`
- `npm.cmd run test:unit -- --runTestsByPath src/middleware/auth.test.js src/routes/auth.test.js --runInBand --forceExit`
- `git diff --check`
- `npm.cmd run lint` fails on pre-existing unrelated errors in `backend/src/server.js`: unused `logger` at line 19 and unused `next` at line 297.

Notes
- The existing auth route test starts server/scheduler handles, so the combined focused test run needs `--forceExit` to terminate after assertions pass.
