### PR TITLE
Require PriceContext provider for app pages

### DIFF
--- a/frontend/__tests__/price-context.test.tsx
+++ b/frontend/__tests__/price-context.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { PriceProvider, usePriceContext } from "@/contexts/PriceContext";
+
+function PriceProbe() {
+  const { xlmPriceUsd, priceLoading, currencyMode } = usePriceContext();
+
+  return (
+    <div>
+      <span data-testid="price">{xlmPriceUsd ?? "none"}</span>
+      <span data-testid="loading">{String(priceLoading)}</span>
+      <span data-testid="currency">{currencyMode}</span>
+    </div>
+  );
+}
+
+function OutsideProviderProbe() {
+  usePriceContext();
+  return null;
+}
+
+describe("PriceContext", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as Partial<typeof globalThis>).fetch;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it("throws a descriptive error outside PriceProvider", () => {
+    expect(() => render(<OutsideProviderProbe />)).toThrow(
+      "usePriceContext must be used within a PriceProvider",
+    );
+  });
+
+  it("provides live XLM/USD price values inside PriceProvider", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ stellar: { usd: 0.12 } }),
+    } as Response);
+
+    render(
+      <PriceProvider>
+        <PriceProbe />
+      </PriceProvider>,
+    );
+
+    expect(screen.getByTestId("currency")).toHaveTextContent("XLM");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("price")).toHaveTextContent("0.12");
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+  });
+});

--- a/frontend/contexts/PriceContext.tsx
+++ b/frontend/contexts/PriceContext.tsx
@@ -2,7 +2,7 @@
  * contexts/PriceContext.tsx
  * Fetches XLM/USD price once on mount and shares it across the app.
  * Includes a global XLM/USD currency toggle.
- * Fails silently — components receive null if price is unavailable.
+ * Components must be rendered under PriceProvider.
  */
 import React, { createContext, useContext, useEffect, useState } from "react";
 
@@ -17,12 +17,7 @@ interface PriceContextValue {
   setCurrencyMode: (mode: CurrencyMode) => void;
 }
 
-const PriceContext = createContext<PriceContextValue>({
-  xlmPriceUsd: null,
-  priceLoading: true,
-  currencyMode: "XLM",
-  setCurrencyMode: () => {},
-});
+const PriceContext = createContext<PriceContextValue | undefined>(undefined);
 
 export function PriceProvider({ children }: { children: React.ReactNode }) {
   const [xlmPriceUsd, setXlmPriceUsd] = useState<number | null>(null);
@@ -73,5 +68,11 @@ export function PriceProvider({ children }: { children: React.ReactNode }) {
 }
 
 export function usePriceContext() {
-  return useContext(PriceContext);
+  const context = useContext(PriceContext);
+
+  if (!context) {
+    throw new Error("usePriceContext must be used within a PriceProvider");
+  }
+
+  return context;
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -168,8 +168,8 @@ function App({ Component, pageProps }: AppProps) {
 
   return (
     <>
-      <ToastProvider>
-        <PriceProvider>
+      <PriceProvider>
+        <ToastProvider>
           <Head>
             <title>
               Stellar MarketPay — Decentralised Freelance Marketplace
@@ -227,8 +227,8 @@ function App({ Component, pageProps }: AppProps) {
               onClose={handleCloseShortcutsModal}
             />
           </div>
-        </PriceProvider>
-      </ToastProvider>
+        </ToastProvider>
+      </PriceProvider>
     </>
   );
 }

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -129,6 +129,14 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   const { xlmPriceUsd } = usePriceContext();
   const { progress, checklistItems } = useOnboarding(publicKey);
 
+  const handleResetContractMock = async () => {
+    if (!IS_CONTRACT_MOCK_DEV_MODE) return;
+
+    const { clearMockData } = await import("@/lib/contractMock");
+    clearMockData();
+    success("Mock contract data reset");
+  };
+
   // ── Bulk selection state ──────────────────────────────────────────────────
   const [selectedJobIds, setSelectedJobIds] = useState<Set<string>>(new Set());
   const [bulkLoading, setBulkLoading] = useState(false);


### PR DESCRIPTION
﻿Summary
- Ensured the shared `PriceProvider` wraps the full Next.js app shell so pages and layout components receive the same XLM/USD context.
- Changed `usePriceContext` to fail loudly with a descriptive error when it is used outside the provider instead of returning default null values.
- Added frontend coverage for both the missing-provider error and live XLM/USD price propagation.

Issue
- Closes #264

Changes
- Moved `PriceProvider` to the top-level app wrapper in `frontend/pages/_app.tsx`.
- Changed `PriceContext` to initialize as undefined and made `usePriceContext()` throw `usePriceContext must be used within a PriceProvider` outside the provider tree.
- Added `frontend/__tests__/price-context.test.tsx` to verify provider enforcement and fetched XLM/USD values.
- Added the missing mock contract reset handler in `dashboard.tsx` so frontend type-check passes for the page that consumes `PriceContext`.

Validation
- `npm.cmd ci`
- `npm.cmd test -- --runTestsByPath __tests__/price-context.test.tsx --runInBand`
- `npm.cmd test -- --runInBand`
- `npm.cmd run type-check`
- `npm.cmd run lint`
- `git diff --check`

Notes
- `npm run lint` exits successfully with existing warnings in unrelated files.
