### PR TITLE
Add JWT refresh token rotation

### DIFF
--- a/backend/src/routes/admin2fa.js
+++ b/backend/src/routes/admin2fa.js
@@ -4,11 +4,11 @@
 "use strict";
 
 const express = require("express");
-const jwt = require("jsonwebtoken");
 const QRCode = require("qrcode");
 const speakeasy = require("speakeasy");
 const pool = require("../db/pool");
-const { verifyJWT, JWT_SECRET } = require("../middleware/auth");
+const { verifyJWT } = require("../middleware/auth");
+const { signAccessToken } = require("../services/authTokens");
 const { encrypt } = require("../utils/encryption");
 const {
   generateSecret,
@@ -33,11 +33,7 @@ function requireAdminWallet(req, res, next) {
 }
 
 function issueAdminToken(publicKey, twoFaVerified) {
-  return jwt.sign(
-    { publicKey, role: "admin", "2fa_verified": twoFaVerified },
-    JWT_SECRET,
-    { expiresIn: "24h" }
-  );
+  return signAccessToken({ publicKey, role: "admin", "2fa_verified": twoFaVerified });
 }
 
 // POST /api/admin/2fa/setup — generate TOTP secret and QR code

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -3,11 +3,17 @@
  */
 "use strict";
 const express = require("express");
-const jwt = require("jsonwebtoken");
 const { Utils, Keypair } = require("@stellar/stellar-sdk");
-const { JWT_SECRET } = require("../middleware/auth");
 const { ensureAdminProfile, get2FAStatus } = require("../services/twoFactorService");
 const pool = require("../db/pool");
+const {
+  clearAuthCookies,
+  getRefreshTokenFromRequest,
+  issueTokenPair,
+  revokeRefreshToken,
+  rotateRefreshToken,
+  setAuthCookies,
+} = require("../services/authTokens");
 
 const router = express.Router();
 
@@ -168,17 +174,31 @@ router.post("/", async (req, res) => {
       console.warn("[auth] Could not stamp last_login_at:", stampErr.message);
     }
 
-    const token = jwt.sign(payload, JWT_SECRET, { expiresIn: "24h" });
-    res.cookie("jwt", token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "strict",
-      maxAge: 24 * 60 * 60 * 1000,
-    });
-    res.json({ success: true, token });
+    const { accessToken, refreshToken } = issueTokenPair(payload);
+    setAuthCookies(res, accessToken, refreshToken);
+    res.json({ success: true, token: accessToken });
   } catch (e) {
     res.status(401).json({ error: "Unauthorized: " + e.message });
   }
+});
+
+router.post("/refresh", (req, res) => {
+  const refreshToken = getRefreshTokenFromRequest(req);
+  const rotated = rotateRefreshToken(refreshToken);
+
+  if (!rotated) {
+    clearAuthCookies(res);
+    return res.status(401).json({ error: "Unauthorized: Invalid refresh token" });
+  }
+
+  setAuthCookies(res, rotated.accessToken, rotated.refreshToken);
+  return res.json({ success: true, token: rotated.accessToken });
+});
+
+router.post("/logout", (req, res) => {
+  revokeRefreshToken(getRefreshTokenFromRequest(req));
+  clearAuthCookies(res);
+  res.json({ success: true });
 });
 
 module.exports = router;

--- a/backend/src/routes/auth.test.js
+++ b/backend/src/routes/auth.test.js
@@ -64,6 +64,12 @@ const WRONG_KEYPAIR = Keypair.random();
 const CHALLENGE_XDR = "AAAAAFakeChallengeTransactionXDRBase64Encoded==";
 const SIGNED_XDR = "AAAAAFakeSignedChallengeTransactionXDRBase64==";
 
+function getCookie(res, name) {
+  return (res.headers["set-cookie"] || [])
+    .find((cookie) => cookie.startsWith(`${name}=`))
+    ?.split(";")[0];
+}
+
 describe("SEP-10 Authentication Flow", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -111,6 +117,57 @@ describe("SEP-10 Authentication Flow", () => {
 
       const decoded = jwt.verify(res.body.token, process.env.JWT_SECRET);
       expect(decoded.publicKey).toBe(TEST_KEYPAIR.publicKey());
+      expect(decoded.exp - decoded.iat).toBe(15 * 60);
+      expect(getCookie(res, "refreshToken")).toBeTruthy();
+    });
+
+    it("refreshes and rotates access tokens", async () => {
+      Utils.verifyChallengeTx.mockReturnValue(TEST_KEYPAIR.publicKey());
+
+      const loginRes = await request(app)
+        .post("/api/auth")
+        .send({ transaction: SIGNED_XDR });
+      const refreshCookie = getCookie(loginRes, "refreshToken");
+
+      const refreshRes = await request(app)
+        .post("/api/auth/refresh")
+        .set("Cookie", refreshCookie);
+
+      expect(refreshRes.status).toBe(200);
+      expect(refreshRes.body.success).toBe(true);
+      expect(refreshRes.body).toHaveProperty("token");
+      const decoded = jwt.verify(refreshRes.body.token, process.env.JWT_SECRET);
+      expect(decoded.publicKey).toBe(TEST_KEYPAIR.publicKey());
+      expect(decoded.exp - decoded.iat).toBe(15 * 60);
+      expect(getCookie(refreshRes, "refreshToken")).not.toBe(refreshCookie);
+
+      const reusedRes = await request(app)
+        .post("/api/auth/refresh")
+        .set("Cookie", refreshCookie);
+
+      expect(reusedRes.status).toBe(401);
+    });
+
+    it("logout invalidates the refresh token", async () => {
+      Utils.verifyChallengeTx.mockReturnValue(TEST_KEYPAIR.publicKey());
+
+      const loginRes = await request(app)
+        .post("/api/auth")
+        .send({ transaction: SIGNED_XDR });
+      const refreshCookie = getCookie(loginRes, "refreshToken");
+
+      const logoutRes = await request(app)
+        .post("/api/auth/logout")
+        .set("Cookie", refreshCookie);
+
+      expect(logoutRes.status).toBe(200);
+      expect(logoutRes.body.success).toBe(true);
+
+      const refreshRes = await request(app)
+        .post("/api/auth/refresh")
+        .set("Cookie", refreshCookie);
+
+      expect(refreshRes.status).toBe(401);
     });
 
     it("invalid signature: returns 401 for tampered transaction", async () => {

--- a/backend/src/routes/webauthn.js
+++ b/backend/src/routes/webauthn.js
@@ -19,9 +19,9 @@
 const express  = require("express");
 const router   = express.Router();
 const pool     = require("../db/pool");
-const jwt      = require("jsonwebtoken");
 const { createRateLimiter } = require("../middleware/rateLimiter");
-const { verifyJWT, JWT_SECRET } = require("../middleware/auth");
+const { verifyJWT } = require("../middleware/auth");
+const { issueTokenPair, setAuthCookies } = require("../services/authTokens");
 
 const {
   generateRegistrationOptions,
@@ -211,9 +211,10 @@ router.post("/login-verify", webauthnRateLimiter, async (req, res, next) => {
       [verification.authenticationInfo.newCounter, credentialId]
     );
 
-    const token  = jwt.sign({ publicKey }, JWT_SECRET, { expiresIn: "7d" });
+    const { accessToken, refreshToken } = issueTokenPair({ publicKey });
+    setAuthCookies(res, accessToken, refreshToken);
 
-    res.json({ success: true, token });
+    res.json({ success: true, token: accessToken });
   } catch (e) { next(e); }
 });
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,7 +16,7 @@ const nodemailer = require("nodemailer");
 const promClient = require("prom-client");
 const swaggerUi = require('swagger-ui-express');
 const swaggerSpecs = require('./config/swagger');
-const { logger, requestLoggerMiddleware, logError, createServiceLogger } = require('./utils/logger');
+const { requestLoggerMiddleware, logError, createServiceLogger } = require('./utils/logger');
 const { sanitizeMiddleware } = require('./middleware/sanitize');
 const { requireChoice } = require("./config/env");
 
@@ -295,6 +295,8 @@ app.use("/api/events",        eventsRoutes);
 app.use("/api/invitations",   invitationRoutes);
 
 app.use((err, req, res, next) => {
+  void next;
+
   logError(req.logger || serviceLogger, err, {
     method: req.method,
     path: req.path,

--- a/backend/src/services/authTokens.js
+++ b/backend/src/services/authTokens.js
@@ -1,0 +1,115 @@
+"use strict";
+
+const crypto = require("crypto");
+const jwt = require("jsonwebtoken");
+const { JWT_SECRET } = require("../middleware/auth");
+
+const ACCESS_TOKEN_EXPIRES_IN = "15m";
+const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const REFRESH_COOKIE_NAME = "refreshToken";
+const JWT_RESERVED_CLAIMS = new Set(["iat", "exp", "nbf", "jti"]);
+
+const refreshSessions = new Map();
+
+function hashToken(token) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+function normalizePayload(payload) {
+  return Object.fromEntries(
+    Object.entries(payload || {}).filter(([claim]) => !JWT_RESERVED_CLAIMS.has(claim)),
+  );
+}
+
+function signAccessToken(payload) {
+  return jwt.sign(normalizePayload(payload), JWT_SECRET, {
+    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+  });
+}
+
+function createRefreshToken(payload) {
+  const token = crypto.randomBytes(48).toString("base64url");
+  refreshSessions.set(hashToken(token), {
+    payload: normalizePayload(payload),
+    expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
+  });
+  return token;
+}
+
+function issueTokenPair(payload) {
+  return {
+    accessToken: signAccessToken(payload),
+    refreshToken: createRefreshToken(payload),
+  };
+}
+
+function rotateRefreshToken(token) {
+  if (!token) return null;
+
+  const tokenHash = hashToken(token);
+  const session = refreshSessions.get(tokenHash);
+  refreshSessions.delete(tokenHash);
+
+  if (!session || session.expiresAt <= Date.now()) {
+    return null;
+  }
+
+  return issueTokenPair(session.payload);
+}
+
+function revokeRefreshToken(token) {
+  if (token) {
+    refreshSessions.delete(hashToken(token));
+  }
+}
+
+function parseCookieHeader(header) {
+  return String(header || "")
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .reduce((cookies, part) => {
+      const separatorIndex = part.indexOf("=");
+      if (separatorIndex === -1) return cookies;
+      const name = part.slice(0, separatorIndex);
+      const value = part.slice(separatorIndex + 1);
+      cookies[name] = decodeURIComponent(value);
+      return cookies;
+    }, {});
+}
+
+function getRefreshTokenFromRequest(req) {
+  return parseCookieHeader(req.headers.cookie)[REFRESH_COOKIE_NAME] || null;
+}
+
+function getCookieOptions(maxAge) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    maxAge,
+  };
+}
+
+function setAuthCookies(res, accessToken, refreshToken) {
+  res.cookie("jwt", accessToken, getCookieOptions(15 * 60 * 1000));
+  res.cookie(REFRESH_COOKIE_NAME, refreshToken, getCookieOptions(REFRESH_TOKEN_TTL_MS));
+}
+
+function clearAuthCookies(res) {
+  res.clearCookie("jwt", getCookieOptions(0));
+  res.clearCookie(REFRESH_COOKIE_NAME, getCookieOptions(0));
+}
+
+module.exports = {
+  ACCESS_TOKEN_EXPIRES_IN,
+  REFRESH_COOKIE_NAME,
+  clearAuthCookies,
+  getRefreshTokenFromRequest,
+  issueTokenPair,
+  refreshSessions,
+  revokeRefreshToken,
+  rotateRefreshToken,
+  setAuthCookies,
+  signAccessToken,
+};

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -32,21 +32,91 @@ const api = axios.create({
 });
 
 let jwtToken: string | null = null;
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+let refreshPromise: Promise<string | null> | null = null;
+
+const TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
+
+function getJwtExpiryMs(token: string) {
+  try {
+    const encodedPayload = token.split(".")[1] || "";
+    const base64Payload = encodedPayload
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+      .padEnd(Math.ceil(encodedPayload.length / 4) * 4, "=");
+    const payload = JSON.parse(atob(base64Payload));
+    return typeof payload.exp === "number" ? payload.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+function clearRefreshTimer() {
+  if (refreshTimer) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+function scheduleTokenRefresh(token: string) {
+  if (typeof window === "undefined") return;
+
+  const expiryMs = getJwtExpiryMs(token);
+  if (!expiryMs) return;
+
+  const delayMs = Math.max(expiryMs - Date.now() - TOKEN_REFRESH_BUFFER_MS, 0);
+  refreshTimer = setTimeout(() => {
+    refreshAccessToken().catch(() => setJwtToken(null));
+  }, delayMs);
+}
+
+function shouldRefreshToken() {
+  if (!jwtToken) return false;
+  const expiryMs = getJwtExpiryMs(jwtToken);
+  return Boolean(expiryMs && expiryMs - Date.now() <= TOKEN_REFRESH_BUFFER_MS);
+}
 
 export function setJwtToken(token: string | null) {
   jwtToken = token;
+  clearRefreshTimer();
+  if (token) scheduleTokenRefresh(token);
 }
 
 export function getJwtToken() {
   return jwtToken;
 }
 
-api.interceptors.request.use((config: any) => {
+api.interceptors.request.use(async (config: any) => {
+  if (!config.skipAuthRefresh && shouldRefreshToken()) {
+    await refreshAccessToken();
+  }
+
   if (jwtToken) {
     config.headers.Authorization = `Bearer ${jwtToken}`;
   }
   return config;
 });
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config || {};
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !originalRequest.skipAuthRefresh
+    ) {
+      originalRequest._retry = true;
+      const token = await refreshAccessToken();
+      if (token) {
+        originalRequest.headers = originalRequest.headers || {};
+        originalRequest.headers.Authorization = `Bearer ${token}`;
+        return api(originalRequest);
+      }
+    }
+    throw error;
+  },
+);
 
 // ─── Auth ─────────────────────────────────────────────────────────────────────
 
@@ -63,6 +133,38 @@ export async function verifyAuthChallenge(transaction: string) {
     { transaction },
   );
   return data.token;
+}
+
+export async function refreshAccessToken() {
+  if (!refreshPromise) {
+    refreshPromise = api
+      .post<{ success: boolean; token: string }>(
+        "/api/auth/refresh",
+        undefined,
+        { skipAuthRefresh: true } as any,
+      )
+      .then(({ data }) => {
+        setJwtToken(data.token);
+        return data.token;
+      })
+      .catch((error) => {
+        setJwtToken(null);
+        throw error;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+}
+
+export async function logout() {
+  try {
+    await api.post("/api/auth/logout", undefined, { skipAuthRefresh: true } as any);
+  } finally {
+    setJwtToken(null);
+  }
 }
 
 // ─── Jobs ─────────────────────────────────────────────────────────────────────

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -15,6 +15,7 @@ import {
   fetchAuthChallenge,
   verifyAuthChallenge,
   setJwtToken,
+  logout,
   registerReferral,
 } from "@/lib/api";
 import "@/styles/globals.css";
@@ -202,7 +203,10 @@ function App({ Component, pageProps }: AppProps) {
             <Navbar
               publicKey={publicKey}
               onConnect={handleConnect}
-              onDisconnect={() => setPublicKey(null)}
+              onDisconnect={async () => {
+                await logout();
+                setPublicKey(null);
+              }}
             />
             <main id="main-content" className="flex-1">
               <Component

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -129,6 +129,14 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   const { xlmPriceUsd } = usePriceContext();
   const { progress, checklistItems } = useOnboarding(publicKey);
 
+  const handleResetContractMock = async () => {
+    if (!IS_CONTRACT_MOCK_DEV_MODE) return;
+
+    const { clearMockData } = await import("@/lib/contractMock");
+    clearMockData();
+    success("Mock contract data reset");
+  };
+
   // ── Bulk selection state ──────────────────────────────────────────────────
   const [selectedJobIds, setSelectedJobIds] = useState<Set<string>>(new Set());
   const [bulkLoading, setBulkLoading] = useState(false);


### PR DESCRIPTION
﻿Summary
- Added short-lived 15-minute access tokens and HTTP-only refresh tokens with rotation.
- Added refresh and logout endpoints so clients can rotate access tokens and invalidate refresh sessions.
- Updated the frontend API client to refresh tokens before expiry and retry once after a 401.

Issue
- Closes #272

Changes
- Added `backend/src/services/authTokens.js` to centralize access-token signing, refresh-token storage, cookie handling, rotation, and revocation.
- Changed SEP-10 auth and WebAuthn login to issue 15-minute access tokens plus refresh-token cookies.
- Added `POST /api/auth/refresh` to rotate refresh tokens and return a new access token.
- Added `POST /api/auth/logout` to revoke the refresh token and clear auth cookies.
- Updated admin 2FA token upgrades to use the same 15-minute access-token signer.
- Added backend tests for 15-minute expiry, refresh rotation, old-token rejection, and logout invalidation.
- Updated frontend token handling to schedule refresh before expiry, refresh on near-expiry requests, retry once on 401, and call logout on navbar disconnect.
- Included two minimal CI-enabling cleanups already present in related PRs: unused `server.js` lint cleanup and missing dashboard mock-reset handler for frontend type-check.

Validation
- `npm.cmd run test:unit -- --runTestsByPath src/routes/auth.test.js --runInBand --forceExit`
- `npm.cmd test -- --runInBand --forceExit`
- `npm.cmd run lint` in `backend`
- `npm.cmd test -- --runInBand` in `frontend`
- `npm.cmd run type-check` in `frontend`
- `npm.cmd run lint` in `frontend`
- `git diff --check`

Notes
- Refresh tokens are stored in-process and hashed in memory; this satisfies rotation/logout behavior for the current server process without adding a dependency or lockfile change. A shared store such as Redis would be needed for multi-instance deployments.
- Frontend lint exits successfully with existing warnings in unrelated files.
