### PR TITLE
Enforce admin role server side

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -34,6 +34,18 @@ async function verifyJWT(req, res, next) {
   }
 }
 
+function requireAdminRole(req, res, next) {
+  if (!req.user) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.user.role !== "admin") {
+    return res.status(403).json({ error: "Forbidden: Admin access required" });
+  }
+
+  return next();
+}
+
 async function requireAdmin2FA(req, res, next) {
   if (req.user?.role !== "admin") return next();
 
@@ -51,4 +63,4 @@ async function requireAdmin2FA(req, res, next) {
   }
 }
 
-module.exports = { verifyJWT, requireAdmin2FA, JWT_SECRET, requireJwtSecret };
+module.exports = { verifyJWT, requireAdminRole, requireAdmin2FA, JWT_SECRET, requireJwtSecret };

--- a/backend/src/middleware/auth.test.js
+++ b/backend/src/middleware/auth.test.js
@@ -2,6 +2,14 @@
 
 const { spawnSync } = require("child_process");
 const path = require("path");
+const { requireAdminRole } = require("./auth");
+
+function createMockResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+}
 
 describe("JWT secret configuration", () => {
   it("exits with a fatal error when JWT_SECRET is missing", () => {
@@ -21,5 +29,47 @@ describe("JWT secret configuration", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("FATAL: JWT_SECRET environment variable is required");
+  });
+});
+
+describe("requireAdminRole", () => {
+  afterEach(() => {
+    delete process.env.ADMIN_WALLET_ADDRESSES;
+  });
+
+  it("allows a verified JWT with an admin role", () => {
+    const req = { user: { publicKey: "GADMIN", role: "admin" } };
+    const res = createMockResponse();
+    const next = jest.fn();
+
+    requireAdminRole(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-admin JWT even when the public key is listed as an admin address", () => {
+    process.env.ADMIN_WALLET_ADDRESSES = "GADMIN";
+    const req = { user: { publicKey: "GADMIN", role: "user" } };
+    const res = createMockResponse();
+    const next = jest.fn();
+
+    requireAdminRole(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Forbidden: Admin access required" });
+  });
+
+  it("rejects requests without a verified user", () => {
+    const req = {};
+    const res = createMockResponse();
+    const next = jest.fn();
+
+    requireAdminRole(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
   });
 });

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -7,22 +7,9 @@
 const express = require("express");
 const router = express.Router();
 const pool = require("../db/pool");
-const { verifyJWT, requireAdmin2FA } = require("../middleware/auth");
+const { verifyJWT, requireAdminRole, requireAdmin2FA } = require("../middleware/auth");
 const { updateJobStatus } = require("../services/jobService");
 const { logContractInteraction } = require("../services/contractAuditService");
-
-// ── Admin Role Guard ───────────────────────────────────────────────────────────
-function requireAdmin(req, res, next) {
-  if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-  const adminAddresses = (process.env.ADMIN_WALLET_ADDRESSES || "")
-    .split(",")
-    .map((a) => a.trim())
-    .filter(Boolean);
-  if (!adminAddresses.includes(req.user.publicKey) && req.user.role !== "admin") {
-    return res.status(403).json({ error: "Forbidden: Admin access required" });
-  }
-  next();
-}
 
 // Helper: log admin action
 async function logAdminAction({ action, adminAddress, targetId, targetType, details }) {
@@ -44,7 +31,7 @@ async function logAdminAction({ action, adminAddress, targetId, targetType, deta
 }
 
 // ── GET /api/admin/metrics — platform analytics dashboard ─────────────────────
-router.get("/metrics", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.get("/metrics", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { period = "30d" } = req.query;
     
@@ -184,7 +171,7 @@ router.get("/metrics", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res
 });
 
 // ── GET /api/admin/reports/jobs — list all flagged/reported jobs ───────────────
-router.get("/reports/jobs", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.get("/reports/jobs", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { rows } = await pool.query(
       `SELECT jr.id, jr.job_id, jr.reporter_address, jr.category, jr.description,
@@ -202,7 +189,7 @@ router.get("/reports/jobs", verifyJWT, requireAdmin, requireAdmin2FA, async (req
 });
 
 // ── GET /api/admin/disputes — list all open disputes ─────────────────────────
-router.get("/disputes", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.get("/disputes", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { rows } = await pool.query(
       `SELECT e.job_id, e.status AS escrow_status, e.created_at AS escrow_created_at,
@@ -221,7 +208,7 @@ router.get("/disputes", verifyJWT, requireAdmin, requireAdmin2FA, async (req, re
 });
 
 // ── GET /api/admin/reported-wallets — list reported user addresses ─────────────
-router.get("/reported-wallets", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.get("/reported-wallets", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { rows } = await pool.query(
       `SELECT reporter_address AS reported_address, COUNT(*) AS report_count,
@@ -239,7 +226,7 @@ router.get("/reported-wallets", verifyJWT, requireAdmin, requireAdmin2FA, async 
 });
 
 // ── GET /api/admin/logs — admin action audit log ───────────────────────────────
-router.get("/logs", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res) => {
+router.get("/logs", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res) => {
   try {
     const { rows } = await pool.query(
       `SELECT id, action, actor_address, target, reason, metadata, created_at
@@ -254,7 +241,7 @@ router.get("/logs", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res) =
 });
 
 // ── PATCH /api/admin/disputes/:jobId/resolve — mark dispute resolved ───────────
-router.patch("/disputes/:jobId/resolve", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.patch("/disputes/:jobId/resolve", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { jobId } = req.params;
     const { resolution, releaseTo } = req.body; // releaseTo: 'client' | 'freelancer'
@@ -298,7 +285,7 @@ router.patch("/disputes/:jobId/resolve", verifyJWT, requireAdmin, requireAdmin2F
 });
 
 // ── PATCH /api/admin/jobs/:jobId/cancel — cancel a flagged job ─────────────────
-router.patch("/jobs/:jobId/cancel", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.patch("/jobs/:jobId/cancel", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { jobId } = req.params;
     const { reason } = req.body;
@@ -320,7 +307,7 @@ router.patch("/jobs/:jobId/cancel", verifyJWT, requireAdmin, requireAdmin2FA, as
 });
 
 // ── POST /api/admin/wallets/:address/freeze — freeze a wallet ─────────────────
-router.post("/wallets/:address/freeze", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.post("/wallets/:address/freeze", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { address } = req.params;
     const { reason } = req.body;
@@ -351,7 +338,7 @@ router.post("/wallets/:address/freeze", verifyJWT, requireAdmin, requireAdmin2FA
 });
 
 // ── DELETE /api/admin/wallets/:address/freeze — unfreeze a wallet ─────────────
-router.delete("/wallets/:address/freeze", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.delete("/wallets/:address/freeze", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { address } = req.params;
     await pool.query("DELETE FROM frozen_wallets WHERE address = $1", [address]);
@@ -371,7 +358,7 @@ router.delete("/wallets/:address/freeze", verifyJWT, requireAdmin, requireAdmin2
 });
 
 // ── GET /api/admin/wallets/frozen — list frozen wallets ───────────────────────
-router.get("/wallets/frozen", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res) => {
+router.get("/wallets/frozen", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res) => {
   try {
     const { rows } = await pool.query(
       "SELECT address, reason, frozen_by, created_at FROM frozen_wallets ORDER BY created_at DESC"
@@ -383,7 +370,7 @@ router.get("/wallets/frozen", verifyJWT, requireAdmin, requireAdmin2FA, async (r
 });
 
 // ── GET /api/admin/jobs/expired — list expired jobs ───────────────────────────
-router.get("/jobs/expired", verifyJWT, requireAdmin, async (req, res, next) => {
+router.get("/jobs/expired", verifyJWT, requireAdminRole, async (req, res, next) => {
   try {
     const { rows } = await pool.query(
       `SELECT id, title, client_address, budget, currency, status, expires_at, created_at
@@ -399,7 +386,7 @@ router.get("/jobs/expired", verifyJWT, requireAdmin, async (req, res, next) => {
 });
 
 // ── POST /api/admin/jobs/:jobId/reactivate — reactivate expired job ───────────
-router.post("/jobs/:jobId/reactivate", verifyJWT, requireAdmin, requireAdmin2FA, async (req, res, next) => {
+router.post("/jobs/:jobId/reactivate", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {
     const { jobId } = req.params;
     const { rows } = await pool.query(

--- a/backend/src/routes/admin2fa.js
+++ b/backend/src/routes/admin2fa.js
@@ -7,7 +7,7 @@ const express = require("express");
 const QRCode = require("qrcode");
 const speakeasy = require("speakeasy");
 const pool = require("../db/pool");
-const { verifyJWT } = require("../middleware/auth");
+const { verifyJWT, requireAdminRole } = require("../middleware/auth");
 const { signAccessToken } = require("../services/authTokens");
 const { encrypt } = require("../utils/encryption");
 const {
@@ -21,23 +21,12 @@ const {
 
 const router = express.Router();
 
-function requireAdminWallet(req, res, next) {
-  const adminAddresses = (process.env.ADMIN_WALLET_ADDRESSES || "")
-    .split(",")
-    .map((a) => a.trim())
-    .filter(Boolean);
-  if (!adminAddresses.includes(req.user.publicKey) && req.user.role !== "admin") {
-    return res.status(403).json({ success: false, error: "Admin access required" });
-  }
-  next();
-}
-
 function issueAdminToken(publicKey, twoFaVerified) {
   return signAccessToken({ publicKey, role: "admin", "2fa_verified": twoFaVerified });
 }
 
 // POST /api/admin/2fa/setup — generate TOTP secret and QR code
-router.post("/setup", verifyJWT, requireAdminWallet, async (req, res, next) => {
+router.post("/setup", verifyJWT, requireAdminRole, async (req, res, next) => {
   try {
     const { publicKey } = req.user;
     await ensureAdminProfile(publicKey);
@@ -68,7 +57,7 @@ router.post("/setup", verifyJWT, requireAdminWallet, async (req, res, next) => {
 });
 
 // POST /api/admin/2fa/verify — verify TOTP, enable 2FA (setup), upgrade JWT
-router.post("/verify", verifyJWT, requireAdminWallet, async (req, res, next) => {
+router.post("/verify", verifyJWT, requireAdminRole, async (req, res, next) => {
   try {
     const { publicKey } = req.user;
     const { token, setup } = req.body;
@@ -127,7 +116,7 @@ router.post("/verify", verifyJWT, requireAdminWallet, async (req, res, next) => 
 });
 
 // GET /api/admin/2fa/status
-router.get("/status", verifyJWT, requireAdminWallet, async (req, res, next) => {
+router.get("/status", verifyJWT, requireAdminRole, async (req, res, next) => {
   try {
     const status = await get2FAStatus(req.user.publicKey);
     res.json({

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -1,6 +1,6 @@
 /**
  * pages/admin.tsx
- * Admin moderation dashboard — gated to admin wallet addresses only.
+ * Admin moderation dashboard gated by the server-issued admin JWT role.
  * Non-admin wallets are immediately redirected to /jobs.
  */
 import { useEffect, useState, useCallback } from "react";
@@ -15,22 +15,38 @@ import {
   adminCancelJob,
   freezeWallet,
   unfreezeWallet,
+  fetchAdmin2FAStatus,
+  getJwtToken,
 } from "@/lib/api";
 import { shortenAddress, timeAgo } from "@/utils/format";
 import AdminAnalytics from "@/components/AdminAnalytics";
 import Admin2FAModal from "@/components/Admin2FAModal";
-import { fetchAdmin2FAStatus } from "@/lib/api";
-
-// Wallet addresses with admin access — can also be overridden by env var
-const ADMIN_ADDRESSES = (
-  process.env.NEXT_PUBLIC_ADMIN_ADDRESSES || ""
-).split(",").map((a) => a.trim()).filter(Boolean);
 
 interface AdminPageProps {
   publicKey: string | null;
 }
 
 type ActiveTab = "analytics" | "disputes" | "reports" | "wallets" | "logs";
+type AdminState = "checking" | "authorized" | "denied";
+
+function getJwtRole() {
+  if (typeof window === "undefined") return null;
+
+  const token = getJwtToken();
+  if (!token) return null;
+
+  try {
+    const encodedPayload = token.split(".")[1] || "";
+    const base64Payload = encodedPayload
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+      .padEnd(Math.ceil(encodedPayload.length / 4) * 4, "=");
+    const payload = JSON.parse(window.atob(base64Payload));
+    return typeof payload.role === "string" ? payload.role : null;
+  } catch {
+    return null;
+  }
+}
 
 function Badge({ label, color }: { label: string; color: "red" | "amber" | "emerald" | "blue" | "gray" }) {
   const colorMap = {
@@ -102,15 +118,41 @@ export default function AdminDashboard({ publicKey }: AdminPageProps) {
   const [freezeReason, setFreezeReason] = useState("");
 
   const [twoFaState, setTwoFaState] = useState<"loading" | "setup" | "verify" | "ready">("loading");
+  const [adminState, setAdminState] = useState<AdminState>("checking");
 
-  const isAdmin = Boolean(publicKey && ADMIN_ADDRESSES.includes(publicKey));
+  const isAdmin = adminState === "authorized";
 
   useEffect(() => {
-    if (!publicKey) return;
-    if (!isAdmin) {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    let attempts = 0;
+
+    function verifyAdminToken() {
+      if (!publicKey) {
+        setAdminState("checking");
+        return;
+      }
+
+      if (getJwtRole() === "admin") {
+        setAdminState("authorized");
+        return;
+      }
+
+      if (!getJwtToken() && attempts < 20) {
+        attempts += 1;
+        timeout = setTimeout(verifyAdminToken, 250);
+        return;
+      }
+
+      setAdminState("denied");
       router.replace("/jobs");
     }
-  }, [publicKey, isAdmin, router]);
+
+    verifyAdminToken();
+
+    return () => {
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [publicKey, router]);
 
   useEffect(() => {
     if (!isAdmin || !publicKey) return;
@@ -219,10 +261,18 @@ export default function AdminDashboard({ publicKey }: AdminPageProps) {
     );
   }
 
-  if (!isAdmin) {
+  if (adminState === "checking") {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <p className="text-red-400">Access denied. Admin wallets only.</p>
+        <p className="text-amber-800">Verifying admin session...</p>
+      </div>
+    );
+  }
+
+  if (adminState === "denied") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-red-400">Access denied. Admin role required.</p>
       </div>
     );
   }


### PR DESCRIPTION
Summary
- Enforces admin API authorization from the verified JWT role claim instead of route-local wallet address checks.
- Removes the frontend NEXT_PUBLIC_ADMIN_ADDRESSES gate and checks the issued JWT role before loading admin data.
- Reuses the same admin role middleware for admin 2FA endpoints and adds unit coverage for the bypass case.

Issue
- Closes #275

Changes
- Added requireAdminRole middleware that requires req.user.role === admin after JWT verification.
- Updated admin moderation and admin 2FA routes to use the shared role guard.
- Removed client-side admin wallet address environment usage from the admin page.
- Added a frontend JWT role gate so non-admin sessions redirect before admin API requests are made.
- Added middleware tests proving an env-listed wallet with a non-admin JWT is rejected.

Validation
- Ran: npm ci in backend (failed before tests because package-lock.json is out of sync with package.json; missing optional resolver packages including fsevents and @unrs/resolver bindings).
- Ran: npm install --package-lock=false --no-audit --no-fund in backend.
- Ran: npm run test:unit -- --runTestsByPath src\\middleware\\auth.test.js --runInBand (passed: 4 tests).
- Ran: npm run lint in backend (failed on pre-existing untouched backend/src/services/jobService.js:718 no-unused-vars for rows).
- Ran: npm install --package-lock=false --no-audit --no-fund in frontend.
- Ran: npm run lint in frontend (passed with existing warnings).
- Ran: npm run type-check in frontend (failed on pre-existing untouched pages/dashboard.tsx duplicate handleResetContractMock and pages/jobs/[id].tsx missing releaseMilestone/disputeMilestone).
- Ran: git diff --check (passed; Git reported CRLF normalization warnings only).
- Ran: rg -n NEXT_PUBLIC_ADMIN|ADMIN_ADDRESSES|requireAdminWallet|requireAdmin\\b backend frontend (no matches).

Notes
- ADMIN_WALLET_ADDRESSES remains server-side only for assigning the admin role during auth token issuance.
- No lockfiles were modified.