### PR TITLE
Validate dispute evidence IPFS CIDs

### DIFF
--- a/backend/src/routes/disputes.js
+++ b/backend/src/routes/disputes.js
@@ -20,6 +20,7 @@ const pool       = require("../db/pool");
 const { createRateLimiter } = require("../middleware/rateLimiter");
 const { verifyJWT }         = require("../middleware/auth");
 const ipfsService            = require("../services/ipfsService");
+const { validateIpfsCid }    = require("../services/disputeService");
 
 const MAX_FILES_PER_PARTY = 10;
 const MAX_FILE_SIZE       = 5 * 1024 * 1024; // 5 MB
@@ -146,12 +147,14 @@ router.post(
         throw e;
       }
 
+      const ipfsCid = validateIpfsCid(ipfsResult?.cid);
+
       const { rows } = await pool.query(
         `INSERT INTO dispute_evidence
            (job_id, uploader_address, file_name, file_size, mime_type, ipfs_cid)
          VALUES ($1, $2, $3, $4, $5, $6)
          RETURNING *`,
-        [jobId, uploaderAddress, req.file.originalname, req.file.size, req.file.mimetype, ipfsResult.cid]
+        [jobId, uploaderAddress, req.file.originalname, req.file.size, req.file.mimetype, ipfsCid]
       );
 
       const ev = rows[0];

--- a/backend/src/services/disputeService.js
+++ b/backend/src/services/disputeService.js
@@ -5,6 +5,17 @@ const ipfsService = require("./ipfsService");
 
 const MAX_EVIDENCE_FILES = 10;
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
+const IPFS_CID_PATTERN = /^(?:Qm[1-9A-HJ-NP-Za-km-z]{44}|bafy[a-z2-7]{55})$/;
+
+function validateIpfsCid(cid) {
+  if (typeof cid !== "string" || !IPFS_CID_PATTERN.test(cid)) {
+    const e = new Error("Invalid IPFS CID returned from upload service");
+    e.status = 422;
+    throw e;
+  }
+
+  return cid;
+}
 
 async function createDispute(jobId, raisedBy) {
   if (!jobId || !raisedBy) {
@@ -111,13 +122,14 @@ async function uploadEvidence(jobId, uploaderAddress, fileBuffer, fileName, mime
   }
 
   const ipfsResult = await ipfsService.uploadFile(fileBuffer, fileName, mimeType);
+  const ipfsCid = validateIpfsCid(ipfsResult?.cid);
 
   const { rows } = await pool.query(
     `INSERT INTO dispute_evidence
        (job_id, uploader_address, file_name, file_size, mime_type, ipfs_cid)
      VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING *`,
-    [jobId, uploaderAddress, fileName, fileBuffer.length, mimeType, ipfsResult.cid],
+    [jobId, uploaderAddress, fileName, fileBuffer.length, mimeType, ipfsCid],
   );
 
   const ev = rows[0];
@@ -251,4 +263,5 @@ module.exports = {
   getDispute,
   MAX_EVIDENCE_FILES,
   MAX_FILE_SIZE,
+  validateIpfsCid,
 };

--- a/backend/src/services/disputeService.test.js
+++ b/backend/src/services/disputeService.test.js
@@ -20,6 +20,7 @@ const {
   getDispute,
   MAX_EVIDENCE_FILES,
   MAX_FILE_SIZE,
+  validateIpfsCid,
 } = require("./disputeService");
 
 const CLIENT_ADDRESS = "GABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABC";
@@ -27,6 +28,8 @@ const FREELANCER_ADDRESS = "GBBCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXY
 const ADMIN_ADDRESS = "GADMIN1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEF";
 const OTHER_ADDRESS = "GCCCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABC";
 const JOB_ID = "job-456";
+const VALID_CID_V0 = "QmYwAPJzv5CZsnAzt8auVZRnApMEfM4kQh6wxbN4p5M6Za";
+const VALID_CID_V1 = `bafy${"a".repeat(55)}`;
 
 function makeJob(overrides = {}) {
   return {
@@ -48,7 +51,7 @@ function makeEvidenceRow(overrides = {}) {
     file_name: "evidence.pdf",
     file_size: 1024,
     mime_type: "application/pdf",
-    ipfs_cid: "QmTest123",
+    ipfs_cid: VALID_CID_V0,
     created_at: new Date().toISOString(),
     ...overrides,
   };
@@ -139,12 +142,12 @@ describe("disputeService", () => {
         .mockResolvedValueOnce({ rows: [{ count: "0" }] })
         .mockResolvedValueOnce({ rows: [makeEvidenceRow()] });
 
-      ipfsService.uploadFile.mockResolvedValue({ cid: "QmTest123" });
+      ipfsService.uploadFile.mockResolvedValue({ cid: VALID_CID_V0 });
 
       const result = await uploadEvidence(JOB_ID, CLIENT_ADDRESS, fileBuffer, fileName, mimeType);
 
       expect(result.success).toBe(true);
-      expect(result.data.ipfsCid).toBe("QmTest123");
+      expect(result.data.ipfsCid).toBe(VALID_CID_V0);
     });
 
     it("rejects evidence upload from non-participant", async () => {
@@ -204,14 +207,47 @@ describe("disputeService", () => {
         .mockResolvedValueOnce({ rows: [makeJob()] })
         .mockResolvedValueOnce({ rows: [{ id: "dispute-1", status: "open" }] })
         .mockResolvedValueOnce({ rows: [{ count: "0" }] })
-        .mockResolvedValueOnce({ rows: [makeEvidenceRow({ ipfs_cid: "QmValidIpfsCid123" })] });
+        .mockResolvedValueOnce({ rows: [makeEvidenceRow({ ipfs_cid: VALID_CID_V1 })] });
 
-      ipfsService.uploadFile.mockResolvedValue({ cid: "QmValidIpfsCid123" });
+      ipfsService.uploadFile.mockResolvedValue({ cid: VALID_CID_V1 });
 
       const result = await uploadEvidence(JOB_ID, CLIENT_ADDRESS, fileBuffer, fileName, mimeType);
 
-      expect(result.data.ipfsCid).toBe("QmValidIpfsCid123");
-      expect(result.data.gatewayUrl).toContain("QmValidIpfsCid123");
+      expect(result.data.ipfsCid).toBe(VALID_CID_V1);
+      expect(result.data.gatewayUrl).toContain(VALID_CID_V1);
+    });
+
+    it.each([
+      ["short CID", "QmTest123"],
+      ["CID with script payload", "<script>alert(1)</script>"],
+      ["CID with special characters", "QmYwAPJzv5CZsnAzt8auVZRnApMEfM4kQh6wxbN4p5M!"],
+      ["non-string CID", null],
+    ])("rejects %s before storing evidence", async (_label, cid) => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [makeJob()] })
+        .mockResolvedValueOnce({ rows: [{ id: "dispute-1", status: "open" }] })
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] });
+
+      ipfsService.uploadFile.mockResolvedValue({ cid });
+
+      await expect(
+        uploadEvidence(JOB_ID, CLIENT_ADDRESS, fileBuffer, fileName, mimeType),
+      ).rejects.toMatchObject({
+        message: "Invalid IPFS CID returned from upload service",
+        status: 422,
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("validateIpfsCid", () => {
+    it.each([VALID_CID_V0, VALID_CID_V1])("accepts valid CID format %s", (cid) => {
+      expect(validateIpfsCid(cid)).toBe(cid);
+    });
+
+    it("rejects a CID with unexpected length", () => {
+      expect(() => validateIpfsCid("bafyshort")).toThrow("Invalid IPFS CID returned from upload service");
     });
   });
 


### PR DESCRIPTION
Summary
- Added IPFS CID validation before dispute evidence CIDs are written to the database.
- The validator accepts only CIDv0 values shaped as Qm plus 44 base58 characters or CIDv1 values shaped as bafy plus 55 base32 characters.
- Invalid upload-service CIDs now raise a 422 error with a descriptive message instead of being stored.

Issue
- Closes #273

Changes
- Added validateIpfsCid in backend/src/services/disputeService.js.
- Applied the validator in the dispute service upload path before DB insert.
- Applied the same validator in backend/src/routes/disputes.js because the multipart evidence route also inserts IPFS CIDs directly.
- Updated dispute service tests to use valid CIDv0/CIDv1 fixtures and added invalid CID cases for short, special-character, script, and non-string responses.

Validation
- Ran: npm ci in backend (failed before tests because package-lock.json is out of sync with package.json; missing optional resolver packages including fsevents and @unrs/resolver bindings).
- Ran: npm install --package-lock=false --no-audit --no-fund in backend.
- Ran: node --check backend/src/services/disputeService.js; node --check backend/src/routes/disputes.js; node --check backend/src/services/disputeService.test.js.
- Ran: npm run test:unit -- --runTestsByPath src\\services\\disputeService.test.js --runInBand (passed: 29 tests).
- Ran: npx eslint src\\services\\disputeService.js src\\routes\\disputes.js src\\services\\disputeService.test.js (passed).
- Ran: npm run lint in backend (failed on pre-existing untouched backend/src/services/jobService.js:718 no-unused-vars for rows).
- Ran: git diff --check (passed; Git reported CRLF normalization warnings only).

Notes
- No lockfiles were modified.
- The full backend lint failure appears pre-existing and unrelated to this change.