### PR TITLE
Add freelancer tier progression

### DIFF
--- a/backend/src/routes/applications.js
+++ b/backend/src/routes/applications.js
@@ -14,6 +14,7 @@ const {
   getApplicationsForFreelancer, acceptApplication,
   withdrawApplication,
 } = require("../services/applicationService");
+const { FREELANCER_TIERS } = require("../services/profileService");
 const { logContractInteraction } = require("../services/contractAuditService");
 const { notifyEscrowEvent, EVENT_TYPES } = require("../services/notificationService");
 const { getJob } = require("../services/jobService");
@@ -58,7 +59,14 @@ const { getJob } = require("../services/jobService");
 // GET /api/applications/job/:jobId
 router.get("/job/:jobId", generalApplicationRateLimiter, async (req, res, next) => {
   try {
-    const applications = await getApplicationsForJob(req.params.jobId);
+    const tier = typeof req.query.tier === "string" ? req.query.tier : null;
+    if (tier && !Object.values(FREELANCER_TIERS).includes(tier)) {
+      const e = new Error("Invalid freelancer tier filter");
+      e.status = 400;
+      throw e;
+    }
+
+    const applications = await getApplicationsForJob(req.params.jobId, { tier });
     res.json({ success: true, data: applications });
   } catch (e) {
     next(e);

--- a/backend/src/routes/escrow.js
+++ b/backend/src/routes/escrow.js
@@ -10,7 +10,7 @@ const escrowActionRateLimiter = createRateLimiter(30, 1);
 
 const router = express.Router();
 const pool = require("../db/pool");
-const { getJob } = require("../services/jobService");
+const { getJob, updateJobStatus } = require("../services/jobService");
 const { logContractInteraction } = require("../services/contractAuditService");
 const {
   notifyEscrowEvent,
@@ -63,6 +63,7 @@ router.post("/:jobId/release", async (req, res, next) => {
       amountXlm,
       contractTxHash || null,
     );
+    await updateJobStatus(jobId, "completed");
 
     res.json({
       success: true,

--- a/backend/src/services/applicationService.js
+++ b/backend/src/services/applicationService.js
@@ -63,16 +63,24 @@ function validatePublicKey(key) {
  */
 function rowToApp(row) {
   const completedJobs = row.completed_jobs ?? 0;
+  const totalJobs = row.total_jobs ?? completedJobs;
   const freelancerRating =
     row.avg_rating !== null && row.avg_rating !== undefined
       ? parseFloat(row.avg_rating)
       : null;
+  const totalEarnedXlm = row.total_earned_xlm ?? 0;
 
   return {
     id: row.id,
     jobId: row.job_id,
     freelancerAddress: row.freelancer_address,
-    freelancerTier: calculateFreelancerTier(completedJobs, freelancerRating),
+    freelancerTier: calculateFreelancerTier({
+      completedJobs,
+      totalJobs,
+      rating: freelancerRating,
+      totalEarnedXlm,
+      createdAt: row.profile_created_at,
+    }),
     proposal: row.proposal,
     bidAmount: row.bid_amount,
     currency: row.currency || "XLM",
@@ -236,25 +244,31 @@ async function submitApplication({
  * @param {number|string} jobId - The ID of the job.
  * @returns {Promise<Object[]>} An array of application objects ordered by creation date ascending.
  */
-async function getApplicationsForJob(jobId) {
+async function getApplicationsForJob(jobId, filters = {}) {
   const { rows } = await pool.query(
     `SELECT a.*,
             COALESCE(p.completed_jobs, 0) AS completed_jobs,
+            COALESCE(p.total_earned_xlm, 0) AS total_earned_xlm,
+            p.created_at AS profile_created_at,
+            COUNT(DISTINCT fj.id)::int AS total_jobs,
             ROUND(AVG(r.stars)::numeric, 2) AS avg_rating
      FROM applications a
      LEFT JOIN profiles p ON p.public_key = a.freelancer_address
      LEFT JOIN ratings r ON r.rated_address = a.freelancer_address
+     LEFT JOIN jobs fj ON fj.freelancer_address = a.freelancer_address
      WHERE a.job_id = $1
        AND NOT EXISTS (
          SELECT 1 FROM profiles cp
          WHERE cp.public_key = (SELECT client_address FROM jobs WHERE id = $1)
            AND a.freelancer_address = ANY(cp.blocked_addresses)
        )
-     GROUP BY a.id, p.completed_jobs
+     GROUP BY a.id, p.completed_jobs, p.total_earned_xlm, p.created_at
      ORDER BY a.created_at ASC`,
     [jobId],
   );
-  return rows.map(rowToApp);
+  const applications = rows.map(rowToApp);
+  if (!filters.tier) return applications;
+  return applications.filter((application) => application.freelancerTier === filters.tier);
 }
 
 /**
@@ -269,12 +283,16 @@ async function getApplicationsForFreelancer(freelancerAddress) {
   const { rows } = await pool.query(
     `SELECT a.*,
             COALESCE(p.completed_jobs, 0) AS completed_jobs,
+            COALESCE(p.total_earned_xlm, 0) AS total_earned_xlm,
+            p.created_at AS profile_created_at,
+            COUNT(DISTINCT fj.id)::int AS total_jobs,
             ROUND(AVG(r.stars)::numeric, 2) AS avg_rating
      FROM applications a
      LEFT JOIN profiles p ON p.public_key = a.freelancer_address
      LEFT JOIN ratings r ON r.rated_address = a.freelancer_address
+     LEFT JOIN jobs fj ON fj.freelancer_address = a.freelancer_address
      WHERE a.freelancer_address = $1
-     GROUP BY a.id, p.completed_jobs
+     GROUP BY a.id, p.completed_jobs, p.total_earned_xlm, p.created_at
      ORDER BY a.created_at DESC`,
     [freelancerAddress],
   );

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const pool = require("../db/pool");
+const { refreshFreelancerTier } = require("./profileService");
 
 /**
  * Camel-cased job record returned by this service.
@@ -581,7 +582,12 @@ async function updateJobStatus(id, status) {
     throw e;
   }
 
-  return rowToJob(rows[0]);
+  const job = rowToJob(rows[0]);
+  if (status === "completed" && job.freelancerAddress) {
+    await refreshFreelancerTier(job.freelancerAddress);
+  }
+
+  return job;
 }
 
 /**

--- a/backend/src/services/profileService.js
+++ b/backend/src/services/profileService.js
@@ -12,6 +12,12 @@ const VALID_PROFILE_ROLES = ["client", "freelancer", "both"];
 const VALID_PORTFOLIO_TYPES = ["github", "live", "stellar_tx", "file"];
 const VALID_AVAILABILITY_STATUSES = ["available", "busy", "unavailable"];
 const MAX_PORTFOLIO_ITEMS = 10;
+const FREELANCER_TIERS = {
+  NEWCOMER: "Newcomer",
+  RISING_TALENT: "Rising Talent",
+  TOP_RATED: "Top Rated",
+  EXPERT: "Expert",
+};
 
 /**
  * Camel-cased profile record returned by this service.
@@ -266,7 +272,7 @@ async function getProfile(publicKey) {
   const profile = rowToProfile(rows[0]);
   profile.rating = rows[0].avg_rating !== null ? parseFloat(rows[0].avg_rating) : null;
   profile.ratingCount = rows[0].rating_count;
-  profile.tier = calculateFreelancerTier(profile.completedJobs, profile.rating);
+  profile.tier = await calculateTier(publicKey);
 
   // Calculate reputation score (simple formula: higher weight on ratings, lower on time)
   // Max score 100.
@@ -557,16 +563,96 @@ async function verifyIdentity(publicKey, didHash) {
 }
 
 /**
- * Calculate freelancer tier based on completed jobs and rating.
- * @param {number} completedJobs
+ * Calculate freelancer tier from profile and job-history metrics.
+ * @param {Object|number} metrics
  * @param {number|null} rating
  * @returns {string}
  */
-function calculateFreelancerTier(completedJobs, rating) {
-  if (completedJobs >= 25 && (rating || 0) >= 4.5) return "Top Talent";
-  if (completedJobs >= 10 && (rating || 0) >= 4.0) return "Expert";
-  if (completedJobs >= 3 && (rating || 0) >= 3.5) return "Rising Star";
-  return "Newcomer";
+function calculateFreelancerTier(metrics, rating = null) {
+  const source = typeof metrics === "object" && metrics !== null
+    ? metrics
+    : { completedJobs: Number(metrics) || 0, rating };
+
+  const completedJobs = Number(source.completedJobs) || 0;
+  const totalJobs = Math.max(Number(source.totalJobs) || 0, completedJobs);
+  const averageRating = Number(source.rating) || 0;
+  const totalEarnedXlm = Number(source.totalEarnedXlm) || 0;
+  const createdAt = source.createdAt ? new Date(source.createdAt) : null;
+  const accountAgeMs = createdAt && !Number.isNaN(createdAt.getTime())
+    ? Date.now() - createdAt.getTime()
+    : null;
+  const accountAgeDays = accountAgeMs == null ? null : accountAgeMs / (24 * 60 * 60 * 1000);
+  const completionRate = totalJobs > 0 ? completedJobs / totalJobs : 0;
+
+  if (completedJobs >= 20 && averageRating >= 4.8 && totalEarnedXlm >= 500) {
+    return FREELANCER_TIERS.EXPERT;
+  }
+  if (completedJobs >= 5 && averageRating >= 4.5 && completionRate >= 0.9) {
+    return FREELANCER_TIERS.TOP_RATED;
+  }
+  if (completedJobs >= 1 && accountAgeDays !== null && accountAgeDays < 90) {
+    return FREELANCER_TIERS.RISING_TALENT;
+  }
+  return FREELANCER_TIERS.NEWCOMER;
+}
+
+async function calculateTier(publicKey, queryRunner = pool) {
+  validatePublicKey(publicKey);
+
+  const { rows } = await queryRunner.query(
+    `
+    SELECT
+      p.created_at,
+      GREATEST(
+        COALESCE(p.completed_jobs, 0),
+        COALESCE((SELECT COUNT(*) FROM jobs j WHERE j.freelancer_address = p.public_key AND j.status = 'completed'), 0)
+      )::int AS completed_jobs,
+      GREATEST(
+        COALESCE(p.total_earned_xlm::numeric, 0),
+        COALESCE((SELECT SUM(j.budget::numeric) FROM jobs j WHERE j.freelancer_address = p.public_key AND j.status = 'completed'), 0)
+      ) AS total_earned_xlm,
+      COALESCE((SELECT ROUND(AVG(r.stars)::numeric, 2) FROM ratings r WHERE r.rated_address = p.public_key), p.rating) AS avg_rating,
+      COALESCE((SELECT COUNT(*) FROM jobs j WHERE j.freelancer_address = p.public_key), 0)::int AS total_jobs
+    FROM profiles p
+    WHERE p.public_key = $1
+    `,
+    [publicKey],
+  );
+
+  if (!rows.length) return FREELANCER_TIERS.NEWCOMER;
+
+  const row = rows[0];
+  return calculateFreelancerTier({
+    completedJobs: row.completed_jobs,
+    totalJobs: row.total_jobs,
+    rating: row.avg_rating,
+    totalEarnedXlm: row.total_earned_xlm,
+    createdAt: row.created_at,
+  });
+}
+
+async function refreshFreelancerTier(publicKey, queryRunner = pool) {
+  validatePublicKey(publicKey);
+
+  await queryRunner.query(
+    `
+    UPDATE profiles
+    SET completed_jobs = stats.completed_jobs,
+        total_earned_xlm = stats.total_earned_xlm,
+        rating = stats.avg_rating,
+        updated_at = NOW()
+    FROM (
+      SELECT
+        COALESCE((SELECT COUNT(*) FROM jobs j WHERE j.freelancer_address = $1 AND j.status = 'completed'), 0)::int AS completed_jobs,
+        COALESCE((SELECT SUM(j.budget::numeric) FROM jobs j WHERE j.freelancer_address = $1 AND j.status = 'completed'), 0)::numeric(20,7) AS total_earned_xlm,
+        (SELECT ROUND(AVG(r.stars)::numeric, 2) FROM ratings r WHERE r.rated_address = $1) AS avg_rating
+    ) stats
+    WHERE profiles.public_key = $1
+    `,
+    [publicKey],
+  );
+
+  return calculateTier(publicKey, queryRunner);
 }
 
 async function getClientSpendingAnalytics(publicKey) {
@@ -772,7 +858,10 @@ module.exports = {
   endorseSkill,
   getClientSpendingAnalytics,
   getClientReputation,
+  calculateTier,
   calculateFreelancerTier,
+  refreshFreelancerTier,
+  FREELANCER_TIERS,
   getProfileStats,
   getResponseTime,
   isBlocked,

--- a/backend/src/services/profileService.test.js
+++ b/backend/src/services/profileService.test.js
@@ -9,6 +9,7 @@ const {
   updateAvailability,
   getProfileStats,
   getResponseTime,
+  calculateFreelancerTier,
   MAX_PORTFOLIO_ITEMS,
 } = require("./profileService");
 
@@ -124,31 +125,38 @@ describe("profileService", () => {
 
   describe("getProfile", () => {
     it("returns portfolioItems from the profile row", async () => {
-      pool.query.mockResolvedValueOnce({
-        rows: [
-          {
-            public_key: publicKey,
-            display_name: "Jane Doe",
-            bio: "Freelancer bio",
-            skills: ["React"],
-            portfolio_items: [
-              { title: "Repo", url: "https://github.com/example/repo", type: "github" },
-            ],
-            availability: {
-              status: "busy",
-              availableFrom: "2026-06-01T00:00:00.000Z",
-              availableUntil: "2026-06-30T00:00:00.000Z",
-            },
-            role: "freelancer",
+      const profileRow = {
+        public_key: publicKey,
+        display_name: "Jane Doe",
+        bio: "Freelancer bio",
+        skills: ["React"],
+        portfolio_items: [
+          { title: "Repo", url: "https://github.com/example/repo", type: "github" },
+        ],
+        availability: {
+          status: "busy",
+          availableFrom: "2026-06-01T00:00:00.000Z",
+          availableUntil: "2026-06-30T00:00:00.000Z",
+        },
+        role: "freelancer",
+        completed_jobs: 3,
+        total_earned_xlm: "150.0000000",
+        avg_rating: "4.80",
+        rating_count: 2,
+        created_at: "2026-04-23T00:00:00.000Z",
+        updated_at: "2026-04-23T00:00:00.000Z",
+      };
+      pool.query
+        .mockResolvedValueOnce({ rows: [profileRow] })
+        .mockResolvedValueOnce({
+          rows: [{
+            created_at: profileRow.created_at,
             completed_jobs: 3,
+            total_jobs: 3,
             total_earned_xlm: "150.0000000",
             avg_rating: "4.80",
-            rating_count: 2,
-            created_at: "2026-04-23T00:00:00.000Z",
-            updated_at: "2026-04-23T00:00:00.000Z",
-          },
-        ],
-      });
+          }],
+        });
 
       const profile = await getProfile(publicKey);
 
@@ -162,6 +170,29 @@ describe("profileService", () => {
       });
       expect(profile.rating).toBe(4.8);
       expect(profile.ratingCount).toBe(2);
+      expect(profile.tier).toBe("Rising Talent");
+    });
+  });
+
+  describe("calculateFreelancerTier", () => {
+    it("returns Expert for high volume, rating, and earnings", () => {
+      expect(calculateFreelancerTier({
+        completedJobs: 20,
+        totalJobs: 20,
+        rating: 4.8,
+        totalEarnedXlm: 500,
+        createdAt: "2025-01-01T00:00:00.000Z",
+      })).toBe("Expert");
+    });
+
+    it("returns Top Rated for strong rating and completion rate", () => {
+      expect(calculateFreelancerTier({
+        completedJobs: 9,
+        totalJobs: 10,
+        rating: 4.5,
+        totalEarnedXlm: 300,
+        createdAt: "2025-01-01T00:00:00.000Z",
+      })).toBe("Top Rated");
     });
   });
 

--- a/backend/src/services/ratingService.js
+++ b/backend/src/services/ratingService.js
@@ -4,6 +4,7 @@
 "use strict";
 
 const pool = require("../db/pool");
+const { refreshFreelancerTier } = require("./profileService");
 
 async function createRating({ jobId, raterAddress, ratedAddress, stars, review }) {
   const client = await pool.connect();
@@ -24,19 +25,10 @@ async function createRating({ jobId, raterAddress, ratedAddress, stars, review }
       throw e;
     }
 
-    // Recalculate and persist average rating on the profile
-    await client.query(
-      `UPDATE profiles
-       SET rating = (
-         SELECT ROUND(AVG(stars)::numeric, 2)
-         FROM ratings WHERE rated_address = $1
-       )
-       WHERE public_key = $1`,
-      [ratedAddress]
-    );
+    const freelancerTier = await refreshFreelancerTier(ratedAddress, client);
 
     await client.query("COMMIT");
-    return rows[0];
+    return { ...rows[0], freelancer_tier: freelancerTier };
   } catch (e) {
     await client.query("ROLLBACK");
     throw e;

--- a/frontend/__tests__/__snapshots__/components.snapshot.test.tsx.snap
+++ b/frontend/__tests__/__snapshots__/components.snapshot.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`component snapshots FreelancerTierBadge Expert 1`] = `
 <span
-  class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide border-emerald-400/25 bg-emerald-400/10 text-emerald-300"
+  class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide border-amber-400/30 bg-amber-400/10 text-amber-200"
 >
   Expert
 </span>
@@ -16,19 +16,19 @@ exports[`component snapshots FreelancerTierBadge Newcomer 1`] = `
 </span>
 `;
 
-exports[`component snapshots FreelancerTierBadge Rising Star 1`] = `
+exports[`component snapshots FreelancerTierBadge Rising Talent 1`] = `
 <span
   class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide border-sky-400/25 bg-sky-400/10 text-sky-300"
 >
-  Rising Star
+  Rising Talent
 </span>
 `;
 
-exports[`component snapshots FreelancerTierBadge Top Talent 1`] = `
+exports[`component snapshots FreelancerTierBadge Top Rated 1`] = `
 <span
-  class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide border-amber-400/30 bg-amber-400/10 text-amber-200"
+  class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide border-emerald-400/25 bg-emerald-400/10 text-emerald-300"
 >
-  Top Talent
+  Top Rated
 </span>
 `;
 

--- a/frontend/__tests__/components.snapshot.test.tsx
+++ b/frontend/__tests__/components.snapshot.test.tsx
@@ -135,9 +135,9 @@ describe("component snapshots", () => {
 
   it.each([
     "Newcomer",
-    "Rising Star",
+    "Rising Talent",
+    "Top Rated",
     "Expert",
-    "Top Talent",
   ] as const)("FreelancerTierBadge %s", (tier) => {
     const { container } = render(<FreelancerTierBadge tier={tier} />);
     expect(container.firstChild).toMatchSnapshot();

--- a/frontend/components/FreelancerTierBadge.tsx
+++ b/frontend/components/FreelancerTierBadge.tsx
@@ -3,9 +3,9 @@ import type { FreelancerTier } from "@/utils/types";
 
 const tierClassNames: Record<FreelancerTier, string> = {
   Newcomer: "border-slate-400/20 bg-slate-400/10 text-slate-200",
-  "Rising Star": "border-sky-400/25 bg-sky-400/10 text-sky-300",
-  Expert: "border-emerald-400/25 bg-emerald-400/10 text-emerald-300",
-  "Top Talent": "border-amber-400/30 bg-amber-400/10 text-amber-200",
+  "Rising Talent": "border-sky-400/25 bg-sky-400/10 text-sky-300",
+  "Top Rated": "border-emerald-400/25 bg-emerald-400/10 text-emerald-300",
+  Expert: "border-amber-400/30 bg-amber-400/10 text-amber-200",
 };
 
 interface FreelancerTierBadgeProps {

--- a/frontend/components/RealtimeBidComparison.tsx
+++ b/frontend/components/RealtimeBidComparison.tsx
@@ -5,7 +5,8 @@
 import { useEffect, useState, useRef } from "react";
 import { formatXLM, shortenAddress, timeAgo } from "@/utils/format";
 import { accountUrl } from "@/lib/stellar";
-import type { Application } from "@/utils/types";
+import FreelancerTierBadge from "@/components/FreelancerTierBadge";
+import type { Application, FreelancerTier } from "@/utils/types";
 
 interface RealtimeBidComparisonProps {
   jobId: string;
@@ -26,6 +27,8 @@ function badgeClass(status: string) {
   return "bg-market-500/10 text-market-400 border-market-500/20";
 }
 
+const tierOptions: FreelancerTier[] = ["Rising Talent", "Top Rated", "Expert"];
+
 export default function RealtimeBidComparison({ 
   jobId, 
   initialApplications, 
@@ -36,6 +39,7 @@ export default function RealtimeBidComparison({
   const [newBidsCount, setNewBidsCount] = useState(0);
   const [isVisible, setIsVisible] = useState(true);
   const [highlightedBids, setHighlightedBids] = useState<Set<string>>(new Set());
+  const [tierFilter, setTierFilter] = useState<FreelancerTier | "">("");
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -145,8 +149,12 @@ export default function RealtimeBidComparison({
     }
   }, []);
 
+  const visibleApplications = tierFilter
+    ? applications.filter((application) => application.freelancerTier === tierFilter)
+    : applications;
+
   // Sort applications by bid amount (lowest first) and creation date
-  const sortedApplications = [...applications].sort((a, b) => {
+  const sortedApplications = [...visibleApplications].sort((a, b) => {
     const bidDiff = parseFloat(a.bidAmount) - parseFloat(b.bidAmount);
     if (bidDiff !== 0) return bidDiff;
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -187,7 +195,20 @@ export default function RealtimeBidComparison({
         </div>
 
         {applications.length > 0 && (
-          <div className="flex items-center gap-4 text-sm">
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            {isClient && (
+              <select
+                value={tierFilter}
+                onChange={(event) => setTierFilter(event.target.value as FreelancerTier | "")}
+                className="input-field py-2 text-xs"
+                aria-label="Filter applications by freelancer tier"
+              >
+                <option value="">All tiers</option>
+                {tierOptions.map((tier) => (
+                  <option key={tier} value={tier}>{tier}</option>
+                ))}
+              </select>
+            )}
             <div className="text-amber-800">
               Avg: <span className="font-mono text-market-400">{formatXLM(averageBid.toString())}</span>
             </div>
@@ -205,6 +226,10 @@ export default function RealtimeBidComparison({
           {wsRef.current?.readyState === WebSocket.OPEN && (
             <p className="text-xs text-green-400 mt-2">🔴 Live updates enabled</p>
           )}
+        </div>
+      ) : sortedApplications.length === 0 ? (
+        <div className="border border-dashed border-market-500/20 rounded-xl p-8 text-center">
+          <p className="text-amber-800 text-sm">No applications match the selected tier.</p>
         </div>
       ) : (
         <div className="space-y-4">
@@ -236,6 +261,7 @@ export default function RealtimeBidComparison({
                     >
                       {shortenAddress(application.freelancerAddress)} ↗
                     </a>
+                    <FreelancerTierBadge tier={application.freelancerTier} className="px-2 py-0.5" />
 
                     {index === 0 && (
                       <span className="text-xs bg-green-500/20 text-green-400 px-2 py-1 rounded-full border border-green-500/30">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -425,9 +425,10 @@ export async function expireOldJobs() {
 
 // ─── Applications ─────────────────────────────────────────────────────────────
 
-export async function fetchApplications(jobId: string) {
+export async function fetchApplications(jobId: string, tier?: string) {
   const { data } = await api.get<{ success: boolean; data: Application[] }>(
     `/api/applications/job/${jobId}`,
+    { params: tier ? { tier } : undefined },
   );
   return data.data;
 }

--- a/frontend/utils/types.ts
+++ b/frontend/utils/types.ts
@@ -14,9 +14,9 @@ export type Currency = "XLM" | "USDC";
 export type JobVisibility = "public" | "private" | "invite_only";
 export type FreelancerTier =
   | "Newcomer"
-  | "Rising Star"
-  | "Expert"
-  | "Top Talent";
+  | "Rising Talent"
+  | "Top Rated"
+  | "Expert";
 export type AvailabilityStatus = "available" | "busy" | "unavailable";
 export type PortfolioItemType = "link" | "image" | "pdf" | "github" | "live" | "stellar_tx" | "file";
 


### PR DESCRIPTION
Summary
- Implemented freelancer tier progression using the issue tiers: Rising Talent, Top Rated, and Expert.
- Added backend tier calculation from profile age, completed jobs, ratings, completion rate, and earnings.
- Wired tier refreshes into rating submission and job completion, and surfaced tiers in profile/application responses.
- Updated freelancer tier badges, applicant cards, and applicant tier filtering in the job application list.

Issue
- Closes #279

Changes
- Added calculateTier(publicKey), calculateFreelancerTier(metrics), and refreshFreelancerTier(publicKey) in profileService.
- Refreshes denormalized freelancer stats and recalculates tier after rating submission and when a job is marked completed.
- Marks escrow release as completed through updateJobStatus so local completion hooks run.
- Enriched application responses with tier inputs and added optional ?tier= filtering on GET /api/applications/job/:jobId.
- Updated FreelancerTierBadge, shared TypeScript tier labels, application-card display, and client-side tier filter UI.
- Updated profile and badge snapshot tests for the new tier labels.

Validation
- Ran: npm ci in backend (failed before tests because package-lock.json is out of sync with package.json; missing optional resolver packages including fsevents and @unrs/resolver bindings).
- Ran: npm install --package-lock=false --no-audit --no-fund in backend.
- Ran: node --check on changed backend route/service files.
- Ran: npm run test:unit -- --runTestsByPath src\\services\\profileService.test.js src\\services\\applicationService.test.js --runInBand (passed: 17 tests).
- Ran: npx eslint src\\services\\profileService.js src\\services\\ratingService.js src\\services\\applicationService.js src\\routes\\applications.js src\\routes\\escrow.js src\\services\\profileService.test.js (passed).
- Ran: npm run lint in backend (failed on pre-existing untouched backend/src/services/jobService.js:724 no-unused-vars for rows).
- Ran: npm install --package-lock=false --no-audit --no-fund in frontend.
- Ran: npm test -- --runTestsByPath __tests__\\components.snapshot.test.tsx -u --runInBand (passed: 13 tests; snapshots updated for new tier labels).
- Ran: npm run lint in frontend (passed with existing warnings).
- Ran: npm run type-check in frontend (failed on pre-existing untouched pages/dashboard.tsx duplicate handleResetContractMock and pages/jobs/[id].tsx missing releaseMilestone/disputeMilestone).
- Ran: git diff --check (passed; Git reported CRLF normalization warnings only).

Notes
- No lockfiles were modified.
- This checkout does not contain a persisted tier column, so tier is calculated and refreshed from existing profile/job/rating fields.