### PR TITLE
Add in-app notification center

### DIFF
--- a/backend/src/db/migrations/V10__in_app_notifications.down.sql
+++ b/backend/src/db/migrations/V10__in_app_notifications.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_notifications_user_unread;
+DROP INDEX IF EXISTS idx_notifications_user_created_at;
+DROP TABLE IF EXISTS notifications;

--- a/backend/src/db/migrations/V10__in_app_notifications.up.sql
+++ b/backend/src/db/migrations/V10__in_app_notifications.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_address TEXT NOT NULL,
+  type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  read BOOLEAN NOT NULL DEFAULT FALSE,
+  job_id UUID,
+  link_path TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created_at
+  ON notifications (user_address, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_unread
+  ON notifications (user_address, read)
+  WHERE read = FALSE;

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -2,6 +2,11 @@ const express = require("express");
 const router = express.Router();
 const { verifyJWT } = require("../middleware/auth");
 const notificationPreferencesService = require("../services/notificationPreferencesService");
+const {
+  listInAppNotifications,
+  markInAppNotificationRead,
+  markAllInAppNotificationsRead,
+} = require("../services/notificationService");
 const pool = require("../db/pool");
 
 // ─── Authenticated preference endpoints ───────────────────────────────────────
@@ -41,6 +46,39 @@ router.patch("/preferences", verifyJWT, async (req, res, next) => {
       req.user.publicKey
     );
     res.json({ success: true, data: updated });
+  } catch (e) {
+    next(e);
+  }
+});
+
+router.get("/", verifyJWT, async (req, res, next) => {
+  try {
+    const result = await listInAppNotifications(req.user.publicKey, {
+      limit: req.query.limit,
+      cursor: req.query.cursor,
+    });
+    res.json({ success: true, data: result });
+  } catch (e) {
+    next(e);
+  }
+});
+
+router.patch("/read-all", verifyJWT, async (req, res, next) => {
+  try {
+    const result = await markAllInAppNotificationsRead(req.user.publicKey);
+    res.json({ success: true, data: result });
+  } catch (e) {
+    next(e);
+  }
+});
+
+router.patch("/:id/read", verifyJWT, async (req, res, next) => {
+  try {
+    const notification = await markInAppNotificationRead(
+      req.params.id,
+      req.user.publicKey,
+    );
+    res.json({ success: true, data: notification });
   } catch (e) {
     next(e);
   }

--- a/backend/src/services/applicationService.js
+++ b/backend/src/services/applicationService.js
@@ -8,6 +8,7 @@
 const pool = require("../db/pool");
 const { getJob, assignFreelancer } = require("./jobService");
 const { calculateFreelancerTier, isBlocked } = require("./profileService");
+const { createJobNotification, EVENT_TYPES } = require("./notificationService");
 
 /**
  * Camel-cased application record returned by this service.
@@ -227,6 +228,14 @@ async function submitApplication({
     [jobId],
   );
 
+  await createJobNotification({
+    userAddress: job.clientAddress,
+    type: EVENT_TYPES.APPLICATION_RECEIVED,
+    title: "New application received",
+    body: `${freelancerAddress.slice(0, 6)}...${freelancerAddress.slice(-4)} applied to "${job.title}".`,
+    jobId,
+  });
+
   return rowToApp(appRow);
 }
 
@@ -324,12 +333,37 @@ async function acceptApplication(applicationId, clientAddress) {
       [applicationId],
     );
 
-    await client.query(
+    const { rows: rejectedApplications } = await client.query(
       `UPDATE applications
        SET status = 'rejected'
-       WHERE job_id = $1 AND id <> $2 AND status = 'pending'`,
+       WHERE job_id = $1 AND id <> $2 AND status = 'pending'
+       RETURNING freelancer_address`,
       [app.job_id, applicationId],
     );
+
+    await createJobNotification(
+      {
+        userAddress: app.freelancer_address,
+        type: EVENT_TYPES.APPLICATION_ACCEPTED,
+        title: "Application accepted",
+        body: `Your application for "${job.title}" was accepted.`,
+        jobId: app.job_id,
+      },
+      client,
+    );
+
+    for (const rejected of rejectedApplications) {
+      await createJobNotification(
+        {
+          userAddress: rejected.freelancer_address,
+          type: EVENT_TYPES.APPLICATION_REJECTED,
+          title: "Application rejected",
+          body: `Your application for "${job.title}" was not selected.`,
+          jobId: app.job_id,
+        },
+        client,
+      );
+    }
 
     await client.query("COMMIT");
 

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const pool = require("../db/pool");
+const { createJobNotification, EVENT_TYPES } = require("./notificationService");
 
 /**
  * Camel-cased job record returned by this service.
@@ -745,7 +746,23 @@ async function raiseDispute(jobId, { reason, description, raisedBy }) {
     throw e;
   }
 
-  return rowToJob(rows[0]);
+  const job = rowToJob(rows[0]);
+  const recipients = new Set(
+    [job.clientAddress, job.freelancerAddress].filter(Boolean),
+  );
+
+  for (const userAddress of recipients) {
+    await createJobNotification({
+      userAddress,
+      type: EVENT_TYPES.DISPUTE_OPENED,
+      title: "Dispute filed",
+      body: `${raisedBy.slice(0, 6)}...${raisedBy.slice(-4)} filed a dispute for "${job.title}".`,
+      jobId,
+      linkPath: `/disputes/${jobId}`,
+    });
+  }
+
+  return job;
 }
 
 async function resolveDispute(jobId) {

--- a/backend/src/services/messageService.js
+++ b/backend/src/services/messageService.js
@@ -13,6 +13,7 @@
 
 const pool = require("../db/pool");
 const { uploadMessage } = require("./ipfsService");
+const { createJobNotification, EVENT_TYPES } = require("./notificationService");
 
 /* ─── helpers ────────────────────────────────────────────────────────────────── */
 
@@ -152,6 +153,17 @@ async function createMessage({ jobId, senderAddress, content, contractTxHash }) 
        VALUES ($1, $2, $3, $4, $5, $6)
        RETURNING *`,
       [jobId, senderAddress, receiverAddress, trimmedContent, ipfsCid, contractTxHash || null]
+    );
+
+    await createJobNotification(
+      {
+        userAddress: receiverAddress,
+        type: EVENT_TYPES.NEW_MESSAGE,
+        title: "New message",
+        body: `${senderAddress.slice(0, 6)}...${senderAddress.slice(-4)} sent you a message.`,
+        jobId,
+      },
+      client,
     );
 
     await client.query("COMMIT");

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -18,10 +18,38 @@ const EVENT_TYPES = {
   ESCROW_RELEASED: "escrow_released",
   REFUND_ISSUED: "refund_issued",
   DISPUTE_OPENED: "dispute_opened",
+  APPLICATION_RECEIVED: "application_received",
   APPLICATION_ACCEPTED: "application_accepted",
+  APPLICATION_REJECTED: "application_rejected",
+  NEW_MESSAGE: "new_message",
   JOB_COMPLETED: "job_completed",
   JOB_INVITED: "job_invited",
 };
+
+function rowToInAppNotification(row) {
+  return {
+    id: row.id,
+    userAddress: row.user_address,
+    type: row.type,
+    title: row.title,
+    body: row.body,
+    read: row.read,
+    jobId: row.job_id,
+    linkPath: row.link_path || (row.job_id ? `/jobs/${row.job_id}` : "/notifications"),
+    createdAt: row.created_at,
+  };
+}
+
+function clampLimit(value, fallback = 20, max = 50) {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.min(Math.max(parsed, 1), max);
+}
+
+function shortAddress(address) {
+  if (!address || address.length < 12) return address || "A user";
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
 
 /**
  * Queue a notification for a user
@@ -44,6 +72,111 @@ async function queueNotification({ recipientAddress, notificationType, eventType
   );
 
   return rows[0];
+}
+
+async function createInAppNotification(
+  { userAddress, type, title, body, jobId = null, linkPath = null },
+  queryRunner = pool,
+) {
+  if (!userAddress) return null;
+
+  const { rows } = await queryRunner.query(
+    `INSERT INTO notifications
+      (user_address, type, title, body, read, job_id, link_path, created_at)
+     VALUES ($1, $2, $3, $4, FALSE, $5, $6, NOW())
+     RETURNING *`,
+    [userAddress, type, title, body, jobId, linkPath],
+  );
+
+  return rowToInAppNotification(rows[0]);
+}
+
+async function listInAppNotifications(userAddress, { limit = 20, cursor = null } = {}) {
+  const safeLimit = clampLimit(limit);
+  const params = [userAddress];
+  let cursorClause = "";
+
+  if (cursor) {
+    params.push(cursor);
+    cursorClause = `AND created_at < $${params.length}`;
+  }
+
+  params.push(safeLimit);
+  const limitPlaceholder = `$${params.length}`;
+
+  const [{ rows }, unreadResult] = await Promise.all([
+    pool.query(
+      `SELECT *
+       FROM notifications
+       WHERE user_address = $1
+         ${cursorClause}
+       ORDER BY created_at DESC, id DESC
+       LIMIT ${limitPlaceholder}`,
+      params,
+    ),
+    pool.query(
+      `SELECT COUNT(*)::int AS count
+       FROM notifications
+       WHERE user_address = $1 AND read = FALSE`,
+      [userAddress],
+    ),
+  ]);
+
+  return {
+    notifications: rows.map(rowToInAppNotification),
+    unreadCount: unreadResult.rows[0]?.count || 0,
+    nextCursor: rows.length === safeLimit ? rows[rows.length - 1].created_at : null,
+  };
+}
+
+async function markInAppNotificationRead(id, userAddress) {
+  const { rows } = await pool.query(
+    `UPDATE notifications
+     SET read = TRUE
+     WHERE id = $1 AND user_address = $2
+     RETURNING *`,
+    [id, userAddress],
+  );
+
+  if (!rows.length) {
+    const e = new Error("Notification not found");
+    e.status = 404;
+    throw e;
+  }
+
+  return rowToInAppNotification(rows[0]);
+}
+
+async function markAllInAppNotificationsRead(userAddress) {
+  const { rowCount } = await pool.query(
+    `UPDATE notifications
+     SET read = TRUE
+     WHERE user_address = $1 AND read = FALSE`,
+    [userAddress],
+  );
+
+  return { updatedCount: rowCount };
+}
+
+async function createJobNotification({
+  userAddress,
+  type,
+  title,
+  body,
+  jobId,
+  linkPath,
+}, queryRunner = pool) {
+  return createInAppNotification(
+    {
+      userAddress,
+      type,
+      title,
+      body,
+      jobId,
+      linkPath: linkPath || `/jobs/${jobId}`,
+    },
+    queryRunner,
+  );
 }
 
 /**
@@ -185,6 +318,63 @@ function generateEmailContent(eventType, data) {
     subject: `Notification: ${jobTitle}`,
     text: `An event occurred for "${jobTitle}".\n\nJob: ${jobUrl}`,
     html: `<h2>Notification</h2><p>An event occurred for "<strong>${jobTitle}</strong>".</p><p><a href="${jobUrl}">View Job</a></p>`,
+  };
+}
+
+function generateInAppContent(eventType, data) {
+  const { jobTitle, jobId, amount, currency, actorAddress } = data;
+  const jobLabel = jobTitle || "this job";
+  const amountLabel = amount ? ` (${amount} ${currency || "XLM"})` : "";
+
+  const templates = {
+    [EVENT_TYPES.ESCROW_CREATED]: {
+      title: "Escrow created",
+      body: `Escrow was created for "${jobLabel}"${amountLabel}.`,
+    },
+    [EVENT_TYPES.WORK_STARTED]: {
+      title: "Work started",
+      body: `Work has started on "${jobLabel}".`,
+    },
+    [EVENT_TYPES.ESCROW_RELEASED]: {
+      title: "Payment released",
+      body: `Payment was released for "${jobLabel}"${amountLabel}.`,
+    },
+    [EVENT_TYPES.REFUND_ISSUED]: {
+      title: "Refund issued",
+      body: `A refund was issued for "${jobLabel}"${amountLabel}.`,
+    },
+    [EVENT_TYPES.DISPUTE_OPENED]: {
+      title: "Dispute filed",
+      body: `A dispute was filed for "${jobLabel}".`,
+    },
+    [EVENT_TYPES.APPLICATION_RECEIVED]: {
+      title: "New application received",
+      body: `${shortAddress(actorAddress)} applied to "${jobLabel}".`,
+    },
+    [EVENT_TYPES.APPLICATION_ACCEPTED]: {
+      title: "Application accepted",
+      body: `Your application for "${jobLabel}" was accepted.`,
+    },
+    [EVENT_TYPES.APPLICATION_REJECTED]: {
+      title: "Application rejected",
+      body: `Your application for "${jobLabel}" was not selected.`,
+    },
+    [EVENT_TYPES.NEW_MESSAGE]: {
+      title: "New message",
+      body: `${shortAddress(actorAddress)} sent you a message about "${jobLabel}".`,
+    },
+    [EVENT_TYPES.JOB_COMPLETED]: {
+      title: "Job completed",
+      body: `"${jobLabel}" was marked complete.`,
+    },
+  };
+
+  return {
+    ...(templates[eventType] || {
+      title: "New notification",
+      body: `There is an update for "${jobLabel}".`,
+    }),
+    linkPath: jobId ? `/jobs/${jobId}` : "/notifications",
   };
 }
 
@@ -335,6 +525,16 @@ async function notifyEscrowEvent({ eventType, jobId, clientAddress, freelancerAd
   if (freelancerAddress) recipients.push(freelancerAddress);
 
   for (const recipient of recipients) {
+    const inAppContent = generateInAppContent(eventType, { ...data, jobId });
+    await createInAppNotification({
+      userAddress: recipient,
+      type: eventType,
+      title: inAppContent.title,
+      body: inAppContent.body,
+      jobId,
+      linkPath: inAppContent.linkPath,
+    });
+
     // Queue email notification
     await queueNotification({
       recipientAddress: recipient,
@@ -359,9 +559,15 @@ async function notifyEscrowEvent({ eventType, jobId, clientAddress, freelancerAd
 
 module.exports = {
   queueNotification,
+  createInAppNotification,
+  createJobNotification,
+  listInAppNotifications,
+  markInAppNotificationRead,
+  markAllInAppNotificationsRead,
   getUserPreferences,
   processPendingNotifications,
   notifyEscrowEvent,
   generateEmailContent,
+  generateInAppContent,
   EVENT_TYPES,
 };

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "@/lib/i18n";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import FaucetButton from "@/components/FaucetButton";
 import { usePriceContext } from "@/contexts/PriceContext";
+import NotificationBell from "@/components/NotificationBell";
 
 interface NavbarProps {
   publicKey: string | null;
@@ -220,6 +221,7 @@ export default function Navbar({ publicKey, onConnect, onDisconnect }: NavbarPro
         <div className="flex items-center gap-2 flex-shrink-0">
           {publicKey ? (
             <>
+              <NotificationBell publicKey={publicKey} />
               <button
                 onClick={() => router.push("/dashboard/transactions")}
                 className="flex items-center gap-1.5 address-tag cursor-pointer hover:opacity-80 transition-opacity"

--- a/frontend/components/NotificationBell.tsx
+++ b/frontend/components/NotificationBell.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/router";
+import clsx from "clsx";
+import {
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from "@/lib/api";
+import { timeAgo } from "@/utils/format";
+import type { NotificationItem } from "@/utils/types";
+
+interface NotificationBellProps {
+  publicKey: string;
+}
+
+function resolveNotificationHref(notification: NotificationItem) {
+  return notification.linkPath || (notification.jobId ? `/jobs/${notification.jobId}` : "/notifications");
+}
+
+export default function NotificationBell({ publicKey }: NotificationBellProps) {
+  const router = useRouter();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadNotifications() {
+      setLoading(true);
+      try {
+        const result = await fetchNotifications({ limit: 10 });
+        if (!active) return;
+        setNotifications(result.notifications);
+        setUnreadCount(result.unreadCount);
+      } catch {
+        if (!active) return;
+        setNotifications([]);
+        setUnreadCount(0);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    loadNotifications();
+    const intervalId = window.setInterval(loadNotifications, 30000);
+    return () => {
+      active = false;
+      window.clearInterval(intervalId);
+    };
+  }, [publicKey]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (!panelRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    if (open) document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  async function handleNotificationClick(notification: NotificationItem) {
+    if (!notification.read) {
+      setNotifications((items) =>
+        items.map((item) =>
+          item.id === notification.id ? { ...item, read: true } : item,
+        ),
+      );
+      setUnreadCount((count) => Math.max(count - 1, 0));
+      await markNotificationRead(notification.id).catch(() => undefined);
+    }
+    setOpen(false);
+    router.push(resolveNotificationHref(notification));
+  }
+
+  async function handleMarkAllRead() {
+    await markAllNotificationsRead();
+    setNotifications((items) => items.map((item) => ({ ...item, read: true })));
+    setUnreadCount(0);
+  }
+
+  return (
+    <div className="relative" ref={panelRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="relative p-2 rounded-lg text-amber-700 hover:text-amber-300 hover:bg-market-500/8 transition-colors"
+        aria-label="Notifications"
+        title="Notifications"
+      >
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.4-1.4A2 2 0 0118 14.2V11a6 6 0 10-12 0v3.2c0 .5-.2 1-.6 1.4L4 17h5m6 0a3 3 0 11-6 0m6 0H9" />
+        </svg>
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 min-w-[1.1rem] h-[1.1rem] px-1 rounded-full bg-rose-500 text-white text-[10px] font-bold leading-[1.1rem] text-center">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-11 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-amber-900/30 bg-ink-900 shadow-2xl shadow-black/30 overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-amber-900/30">
+            <p className="text-sm font-semibold text-amber-100">Notifications</p>
+            <button
+              type="button"
+              onClick={handleMarkAllRead}
+              disabled={unreadCount === 0}
+              className="text-xs text-market-400 hover:text-market-300 disabled:opacity-40"
+            >
+              Mark all read
+            </button>
+          </div>
+
+          <div className="max-h-96 overflow-y-auto">
+            {loading && notifications.length === 0 ? (
+              <p className="px-4 py-6 text-sm text-amber-700">Loading notifications...</p>
+            ) : notifications.length === 0 ? (
+              <p className="px-4 py-6 text-sm text-amber-700">No notifications yet.</p>
+            ) : (
+              notifications.map((notification) => (
+                <button
+                  key={notification.id}
+                  type="button"
+                  onClick={() => handleNotificationClick(notification)}
+                  className={clsx(
+                    "w-full px-4 py-3 text-left border-b border-amber-900/20 hover:bg-market-500/8 transition-colors",
+                    !notification.read && "bg-market-500/10",
+                  )}
+                >
+                  <span className="flex items-start gap-2">
+                    {!notification.read && (
+                      <span className="mt-1.5 h-2 w-2 rounded-full bg-market-400 flex-shrink-0" />
+                    )}
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium text-amber-100 truncate">
+                        {notification.title}
+                      </span>
+                      <span className="block text-xs text-amber-700 line-clamp-2 mt-0.5">
+                        {notification.body}
+                      </span>
+                      <span className="block text-[11px] text-amber-800 mt-1">
+                        {timeAgo(notification.createdAt)}
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              router.push("/notifications");
+            }}
+            className="w-full px-4 py-3 text-sm font-medium text-market-400 hover:text-market-300 hover:bg-market-500/8 border-t border-amber-900/30"
+          >
+            View all notifications
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   AssessmentQuestion,
   SkillBadge,
   BulkActionResponse,
+  NotificationItem,
 } from "@/utils/types";
 
 const api = axios.create({
@@ -1191,6 +1192,44 @@ export async function fetchUnreadCount(): Promise<number> {
     data: { unreadCount: number };
   }>("/api/messages/unread-count");
   return data.data.unreadCount;
+}
+
+export interface NotificationsResponse {
+  notifications: NotificationItem[];
+  unreadCount: number;
+  nextCursor: string | null;
+}
+
+export async function fetchNotifications(params?: {
+  limit?: number;
+  cursor?: string | null;
+}): Promise<NotificationsResponse> {
+  const { data } = await api.get<{
+    success: boolean;
+    data: NotificationsResponse;
+  }>("/api/notifications", {
+    params: {
+      limit: params?.limit,
+      cursor: params?.cursor || undefined,
+    },
+  });
+  return data.data;
+}
+
+export async function markNotificationRead(id: string): Promise<NotificationItem> {
+  const { data } = await api.patch<{
+    success: boolean;
+    data: NotificationItem;
+  }>(`/api/notifications/${id}/read`);
+  return data.data;
+}
+
+export async function markAllNotificationsRead(): Promise<{ updatedCount: number }> {
+  const { data } = await api.patch<{
+    success: boolean;
+    data: { updatedCount: number };
+  }>("/api/notifications/read-all");
+  return data.data;
 }
 
 /**

--- a/frontend/pages/notifications.tsx
+++ b/frontend/pages/notifications.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import clsx from "clsx";
+import {
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from "@/lib/api";
+import { timeAgo } from "@/utils/format";
+import type { NotificationItem } from "@/utils/types";
+
+interface NotificationsPageProps {
+  publicKey: string | null;
+  onConnect: () => void;
+}
+
+function notificationHref(notification: NotificationItem) {
+  return notification.linkPath || (notification.jobId ? `/jobs/${notification.jobId}` : "/notifications");
+}
+
+export default function NotificationsPage({ publicKey, onConnect }: NotificationsPageProps) {
+  const router = useRouter();
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  async function loadNotifications(cursor?: string | null) {
+    if (!publicKey) return;
+    if (cursor) setLoadingMore(true);
+    else setLoading(true);
+
+    try {
+      const result = await fetchNotifications({ limit: 20, cursor });
+      setNotifications((current) =>
+        cursor ? [...current, ...result.notifications] : result.notifications,
+      );
+      setUnreadCount(result.unreadCount);
+      setNextCursor(result.nextCursor);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }
+
+  useEffect(() => {
+    loadNotifications();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [publicKey]);
+
+  async function openNotification(notification: NotificationItem) {
+    if (!notification.read) {
+      setNotifications((items) =>
+        items.map((item) =>
+          item.id === notification.id ? { ...item, read: true } : item,
+        ),
+      );
+      setUnreadCount((count) => Math.max(count - 1, 0));
+      await markNotificationRead(notification.id).catch(() => undefined);
+    }
+    router.push(notificationHref(notification));
+  }
+
+  async function markEverythingRead() {
+    await markAllNotificationsRead();
+    setNotifications((items) => items.map((item) => ({ ...item, read: true })));
+    setUnreadCount(0);
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Notifications | Stellar MarketPay</title>
+      </Head>
+      <section className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+          <div>
+            <h1 className="font-display text-3xl font-bold text-amber-100">Notifications</h1>
+            <p className="text-sm text-amber-700 mt-1">
+              {publicKey ? `${unreadCount} unread notification${unreadCount === 1 ? "" : "s"}` : "Connect your wallet to view notifications."}
+            </p>
+          </div>
+          {publicKey && (
+            <button
+              type="button"
+              onClick={markEverythingRead}
+              disabled={unreadCount === 0}
+              className="btn-secondary text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Mark all read
+            </button>
+          )}
+        </div>
+
+        {!publicKey ? (
+          <div className="border border-amber-900/30 rounded-lg p-6 bg-ink-800/50">
+            <p className="text-amber-200 mb-4">Notifications are tied to your wallet account.</p>
+            <button type="button" onClick={onConnect} className="btn-primary">
+              Connect wallet
+            </button>
+          </div>
+        ) : loading ? (
+          <div className="border border-amber-900/30 rounded-lg p-6 bg-ink-800/50 text-amber-700">
+            Loading notifications...
+          </div>
+        ) : notifications.length === 0 ? (
+          <div className="border border-amber-900/30 rounded-lg p-6 bg-ink-800/50 text-amber-700">
+            No notifications yet.
+          </div>
+        ) : (
+          <div className="border border-amber-900/30 rounded-lg bg-ink-800/50 overflow-hidden">
+            {notifications.map((notification) => (
+              <button
+                key={notification.id}
+                type="button"
+                onClick={() => openNotification(notification)}
+                className={clsx(
+                  "w-full px-5 py-4 text-left border-b border-amber-900/20 last:border-b-0 hover:bg-market-500/8 transition-colors",
+                  !notification.read && "bg-market-500/10",
+                )}
+              >
+                <span className="flex gap-3">
+                  {!notification.read && (
+                    <span className="mt-2 h-2.5 w-2.5 rounded-full bg-market-400 flex-shrink-0" />
+                  )}
+                  <span className="min-w-0">
+                    <span className="block text-base font-semibold text-amber-100">
+                      {notification.title}
+                    </span>
+                    <span className="block text-sm text-amber-600 mt-1">
+                      {notification.body}
+                    </span>
+                    <span className="block text-xs text-amber-800 mt-2">
+                      {timeAgo(notification.createdAt)}
+                    </span>
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {publicKey && nextCursor && (
+          <div className="mt-6 flex justify-center">
+            <button
+              type="button"
+              onClick={() => loadNotifications(nextCursor)}
+              disabled={loadingMore}
+              className="btn-secondary text-sm"
+            >
+              {loadingMore ? "Loading..." : "Load more"}
+            </button>
+          </div>
+        )}
+      </section>
+    </>
+  );
+}

--- a/frontend/utils/types.ts
+++ b/frontend/utils/types.ts
@@ -40,6 +40,18 @@ export interface JobMilestone {
   disputedAt?: string | null;
 }
 
+export interface NotificationItem {
+  id: string;
+  userAddress: string;
+  type: string;
+  title: string;
+  body: string;
+  read: boolean;
+  jobId?: string | null;
+  linkPath?: string | null;
+  createdAt: string;
+}
+
 export interface Job {
   id: string;
   title: string;


### PR DESCRIPTION
Summary
- Adds an in-app notification center for Stellar MarketPay, including backend persistence, authenticated list/read endpoints, event-driven notification creation, a navbar unread badge/dropdown, and a full notifications page.

Issue
- Closes #281

Changes
- Added a notifications table migration with unread and created-at indexes.
- Added in-app notification service helpers for create, list, mark-read, and mark-all-read operations.
- Added GET /api/notifications, PATCH /api/notifications/:id/read, and PATCH /api/notifications/read-all.
- Creates notifications for application received, application accepted/rejected, new messages, escrow/payment events, and disputes.
- Added typed frontend notification API helpers and shared NotificationItem type.
- Added a navbar bell dropdown with unread count and last 10 notifications.
- Added /notifications page with read state, bulk mark-as-read, pagination, and notification links.

Validation
- Ran `node --check backend/src/services/notificationService.js backend/src/routes/notifications.js backend/src/services/applicationService.js backend/src/services/messageService.js backend/src/services/jobService.js`.
- Ran `git diff --check`.
- Ran `npm.cmd ci` in backend; failed because package.json and package-lock.json are not in sync, with missing lockfile entries such as fsevents@2.3.3 and @unrs resolver bindings. This appears pre-existing/environment-related.
- Ran `npm.cmd install --package-lock=false --no-audit --no-fund` in backend; timed out before creating backend/node_modules, so backend lint could not be run.
- Ran `npm.cmd ci` in frontend; command timed out, but frontend/node_modules was created.
- Ran `npm.cmd run lint` in frontend; passed with existing warnings in unrelated files.
- Ran `npm.cmd run type-check` in frontend; failed on unrelated existing errors in pages/dashboard.tsx and pages/jobs/[id].tsx.

Notes
- Fork verified: utahkanz-ops/Stellar-MarketPay- is a fork of Emmy123222/Stellar-MarketPay-.
- Git identity used: utahkanz-ops <272119084+utahkanz-ops@users.noreply.github.com>.
- No lockfiles were modified.