### PR TITLE
feat: add normalised job category taxonomy with parent/child relation…

### DIFF
--- a/backend/src/db/migrations/V18__job_category_taxonomy.down.sql
+++ b/backend/src/db/migrations/V18__job_category_taxonomy.down.sql
@@ -1,0 +1,3 @@
+-- Rollback V18: Remove category taxonomy
+ALTER TABLE jobs DROP COLUMN IF EXISTS category_id;
+DROP TABLE IF EXISTS categories;

--- a/backend/src/db/migrations/V18__job_category_taxonomy.up.sql
+++ b/backend/src/db/migrations/V18__job_category_taxonomy.up.sql
@@ -1,0 +1,137 @@
+-- V18: Normalised job category taxonomy
+-- Adds a categories table with parent/child relationships,
+-- migrates jobs.category (text) to jobs.category_id (FK),
+-- and seeds the existing flat categories plus subcategories.
+
+-- ─────────────────────────────────────────
+-- 1. categories table
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS categories (
+  id        SERIAL  PRIMARY KEY,
+  slug      TEXT    UNIQUE NOT NULL,
+  name      TEXT    NOT NULL,
+  parent_id INTEGER REFERENCES categories(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS categories_parent_id_idx ON categories(parent_id);
+CREATE INDEX IF NOT EXISTS categories_slug_idx      ON categories(slug);
+
+-- ─────────────────────────────────────────
+-- 2. Seed top-level categories
+-- ─────────────────────────────────────────
+INSERT INTO categories (slug, name, parent_id) VALUES
+  ('smart-contracts',      'Smart Contracts',      NULL),
+  ('frontend-development', 'Frontend Development', NULL),
+  ('backend-development',  'Backend Development',  NULL),
+  ('ui-ux-design',         'UI/UX Design',         NULL),
+  ('technical-writing',    'Technical Writing',    NULL),
+  ('devops',               'DevOps',               NULL),
+  ('security-audit',       'Security Audit',       NULL),
+  ('data-analysis',        'Data Analysis',        NULL),
+  ('mobile-development',   'Mobile Development',   NULL),
+  ('other',                'Other',                NULL)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ─────────────────────────────────────────
+-- 3. Seed subcategories
+-- ─────────────────────────────────────────
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'soroban-contracts', 'Soroban Contracts', id FROM categories WHERE slug = 'smart-contracts'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'token-development', 'Token Development', id FROM categories WHERE slug = 'smart-contracts'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'defi-protocols', 'DeFi Protocols', id FROM categories WHERE slug = 'smart-contracts'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'react-development', 'React Development', id FROM categories WHERE slug = 'frontend-development'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'nextjs-development', 'Next.js Development', id FROM categories WHERE slug = 'frontend-development'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'vue-development', 'Vue Development', id FROM categories WHERE slug = 'frontend-development'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'api-development', 'API Development', id FROM categories WHERE slug = 'backend-development'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'database-design', 'Database Design', id FROM categories WHERE slug = 'backend-development'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'node-development', 'Node.js Development', id FROM categories WHERE slug = 'backend-development'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'ux-research', 'UX Research', id FROM categories WHERE slug = 'ui-ux-design'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'figma-design', 'Figma Design', id FROM categories WHERE slug = 'ui-ux-design'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'ci-cd', 'CI/CD Pipelines', id FROM categories WHERE slug = 'devops'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'kubernetes', 'Kubernetes', id FROM categories WHERE slug = 'devops'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'docker', 'Docker', id FROM categories WHERE slug = 'devops'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'smart-contract-audit', 'Smart Contract Audit', id FROM categories WHERE slug = 'security-audit'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'penetration-testing', 'Penetration Testing', id FROM categories WHERE slug = 'security-audit'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'ios-development', 'iOS Development', id FROM categories WHERE slug = 'mobile-development'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'android-development', 'Android Development', id FROM categories WHERE slug = 'mobile-development'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO categories (slug, name, parent_id)
+SELECT 'react-native', 'React Native', id FROM categories WHERE slug = 'mobile-development'
+ON CONFLICT (slug) DO NOTHING;
+
+-- ─────────────────────────────────────────
+-- 4. Add category_id FK to jobs
+-- ─────────────────────────────────────────
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS category_id INTEGER REFERENCES categories(id) ON DELETE SET NULL;
+
+-- ─────────────────────────────────────────
+-- 5. Back-fill category_id from the existing free-text category column
+-- ─────────────────────────────────────────
+UPDATE jobs j
+SET    category_id = c.id
+FROM   categories c
+WHERE  LOWER(TRIM(j.category)) = REPLACE(LOWER(TRIM(c.slug)), '-', ' ')
+   OR  LOWER(TRIM(j.category)) = LOWER(TRIM(c.name))
+   AND j.category_id IS NULL;
+
+-- Fallback: map anything unrecognised to 'other'
+UPDATE jobs j
+SET    category_id = c.id
+FROM   categories c
+WHERE  c.slug = 'other'
+  AND  j.category_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS jobs_category_id_idx ON jobs(category_id);

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -3,6 +3,33 @@
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- ─────────────────────────────────────────
+-- categories (normalised taxonomy — V18)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS categories (
+  id        SERIAL  PRIMARY KEY,
+  slug      TEXT    UNIQUE NOT NULL,
+  name      TEXT    NOT NULL,
+  parent_id INTEGER REFERENCES categories(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS categories_parent_id_idx ON categories(parent_id);
+CREATE INDEX IF NOT EXISTS categories_slug_idx      ON categories(slug);
+
+-- Seed top-level categories (idempotent)
+INSERT INTO categories (slug, name, parent_id) VALUES
+  ('smart-contracts',      'Smart Contracts',      NULL),
+  ('frontend-development', 'Frontend Development', NULL),
+  ('backend-development',  'Backend Development',  NULL),
+  ('ui-ux-design',         'UI/UX Design',         NULL),
+  ('technical-writing',    'Technical Writing',    NULL),
+  ('devops',               'DevOps',               NULL),
+  ('security-audit',       'Security Audit',       NULL),
+  ('data-analysis',        'Data Analysis',        NULL),
+  ('mobile-development',   'Mobile Development',   NULL),
+  ('other',                'Other',                NULL)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ─────────────────────────────────────────
 -- profiles
 -- ─────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS profiles (
@@ -112,6 +139,27 @@ ALTER TABLE jobs
 
 ALTER TABLE jobs
   ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+-- V18: normalised category FK
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS category_id INTEGER REFERENCES categories(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS jobs_category_id_idx ON jobs(category_id);
+
+-- Back-fill category_id from legacy free-text category column
+UPDATE jobs j
+SET    category_id = c.id
+FROM   categories c
+WHERE (LOWER(TRIM(j.category)) = REPLACE(LOWER(TRIM(c.slug)), '-', ' ')
+   OR  LOWER(TRIM(j.category)) = LOWER(TRIM(c.name)))
+  AND  j.category_id IS NULL;
+
+-- Fallback unmapped rows to 'other'
+UPDATE jobs j
+SET    category_id = c.id
+FROM   categories c
+WHERE  c.slug = 'other'
+  AND  j.category_id IS NULL;
 
 CREATE INDEX IF NOT EXISTS jobs_deleted_at_idx ON jobs(deleted_at)
   WHERE deleted_at IS NOT NULL;

--- a/backend/src/routes/categories.js
+++ b/backend/src/routes/categories.js
@@ -1,0 +1,43 @@
+"use strict";
+
+/**
+ * GET /api/categories
+ * Returns the full category tree (parents with nested children array).
+ */
+
+const express = require("express");
+const router = express.Router();
+const pool = require("../db/pool");
+const { createRateLimiter } = require("../middleware/rateLimiter");
+
+const listRateLimiter = createRateLimiter(120, 1);
+
+router.get("/", listRateLimiter, async (req, res, next) => {
+  try {
+    const { rows } = await pool.query(
+      "SELECT id, slug, name, parent_id FROM categories ORDER BY parent_id NULLS FIRST, name ASC"
+    );
+
+    // Build tree: parents first, then attach children
+    const byId = {};
+    const roots = [];
+
+    for (const row of rows) {
+      byId[row.id] = { id: row.id, slug: row.slug, name: row.name, children: [] };
+    }
+
+    for (const row of rows) {
+      if (row.parent_id === null) {
+        roots.push(byId[row.id]);
+      } else if (byId[row.parent_id]) {
+        byId[row.parent_id].children.push(byId[row.id]);
+      }
+    }
+
+    res.json({ success: true, data: roots });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -48,6 +48,7 @@ const eventsRoutes    = require("./routes/events");
 const invitationRoutes = require("./routes/invitations");
 const statsRoutes      = require("./routes/stats");
 const gasEstimatorRoutes = require("./routes/gasEstimator");
+const categoryRoutes     = require("./routes/categories");
 
 const pool            = require("./db/pool");
 const { migrate } = require("./db/migrate");
@@ -392,6 +393,7 @@ app.use("/api/events",        eventsRoutes);
 app.use("/api/invitations",   invitationRoutes);
 app.use("/api/stats",         statsRoutes);
 app.use("/api/gas-estimate", gasEstimatorRoutes);
+app.use("/api/categories",   categoryRoutes);
 
 app.use((err, req, res, next) => {
   void next;

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -74,14 +74,18 @@ const VALID_STATUSES = [
 // subquery that previously ran once per job row (N+1 pattern).
 const JOB_SELECT_CLAUSE = `
   SELECT jobs.*,
-         COALESCE(agg.skills, '{}') AS skills
+         COALESCE(agg.skills, '{}') AS skills,
+         cat.slug  AS category_slug,
+         cat.name  AS category_name,
+         cat.id    AS category_id_resolved
   FROM   jobs
   LEFT JOIN LATERAL (
     SELECT array_agg(s.display_name ORDER BY s.display_name) AS skills
     FROM   job_skills js
     JOIN   skills s ON s.id = js.skill_id
     WHERE  js.job_id = jobs.id
-  ) agg ON true`;
+  ) agg ON true
+  LEFT JOIN categories cat ON cat.id = jobs.category_id`;
 
 const VALID_CATEGORIES = [
   "Smart Contracts",
@@ -197,7 +201,9 @@ function rowToJob(row) {
     description: row.description,
     budget: row.budget,
     currency: row.currency || "XLM",
-    category: row.category,
+    category: row.category_name || row.category,
+    categorySlug: row.category_slug || null,
+    categoryId: row.category_id_resolved || row.category_id || null,
     skills: row.skills,
     status: row.status,
     clientAddress: row.client_address,
@@ -256,7 +262,7 @@ function rowToJob(row) {
  *   clientAddress: 'GBX...',
  * });
  */
-async function createJob({ title, description, budget, currency, category, skills, deadline, timezone, clientAddress, screeningQuestions, milestones, visibility = "public" }) {
+async function createJob({ title, description, budget, currency, category, categorySlug, skills, deadline, timezone, clientAddress, screeningQuestions, milestones, visibility = "public" }) {
   validatePublicKey(clientAddress);
 
   if (!title || title.length < 10) {
@@ -279,11 +285,30 @@ async function createJob({ title, description, budget, currency, category, skill
     e.status = 400;
     throw e;
   }
-  if (!VALID_CATEGORIES.includes(category)) {
+  // Resolve category: accept either a slug (e.g. "frontend-development") or a legacy name.
+  // categorySlug takes precedence; falls back to category name lookup.
+  const categoryLookupVal = categorySlug || category;
+  let resolvedCategoryId = null;
+  let resolvedCategoryName = category;
+
+  if (categoryLookupVal) {
+    const { rows: catRows } = await pool.query(
+      "SELECT id, name FROM categories WHERE slug = $1 OR LOWER(name) = LOWER($2) LIMIT 1",
+      [categoryLookupVal, categoryLookupVal]
+    );
+    if (catRows.length) {
+      resolvedCategoryId = catRows[0].id;
+      resolvedCategoryName = catRows[0].name;
+    }
+  }
+
+  // Still validate against VALID_CATEGORIES for backward-compat when no DB match found
+  if (!resolvedCategoryId && !VALID_CATEGORIES.includes(category)) {
     const e = new Error("Invalid category");
     e.status = 400;
     throw e;
   }
+
   const jobVisibility = visibility || "public";
   if (!["public", "private", "invite_only"].includes(jobVisibility)) {
     const e = new Error("Visibility must be public, private, or invite_only");
@@ -304,8 +329,8 @@ async function createJob({ title, description, budget, currency, category, skill
     const { rows } = await client.query(
       `
       INSERT INTO jobs
-        (title, description, budget, currency, category, status, client_address, deadline, timezone, screening_questions, milestones, visibility, created_at, updated_at)
-      VALUES ($1, $2, $3, $4, $5, 'open', $6, $7, $8, $9, $10, $11, NOW(), NOW())
+        (title, description, budget, currency, category, category_id, status, client_address, deadline, timezone, screening_questions, milestones, visibility, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $5, $6, 'open', $7, $8, $9, $10, $11, $12, NOW(), NOW())
       RETURNING *
       `,
       [
@@ -313,7 +338,8 @@ async function createJob({ title, description, budget, currency, category, skill
         description.trim(),
         parseFloat(budget).toFixed(7),
         currency || "XLM",
-        category,
+        resolvedCategoryName,
+        resolvedCategoryId,
         clientAddress,
         deadline || null,
         timezone || null,
@@ -483,7 +509,11 @@ async function listJobs({
 
   if (category) {
     params.push(category);
-    conditions.push(`category = $${params.length}`);
+    // Support slug (e.g. 'frontend-development') OR legacy name (e.g. 'Frontend Development')
+    conditions.push(`(
+      EXISTS (SELECT 1 FROM categories c WHERE c.id = jobs.category_id AND (c.slug = $${params.length} OR LOWER(c.name) = LOWER($${params.length})))
+      OR jobs.category = $${params.length}
+    )`);
   }
 
   const minBudget = parseFloat(min_budget);

--- a/frontend/components/post-job-steps/BasicInfoStep.tsx
+++ b/frontend/components/post-job-steps/BasicInfoStep.tsx
@@ -3,19 +3,8 @@
  * Step 1: Basic Info - title, description, category
  */
 import { JobFormData } from "@/components/PostJobFormtypes";
-
-const VALID_CATEGORIES = [
-  "Smart Contracts",
-  "Frontend Development",
-  "Backend Development",
-  "UI/UX Design",
-  "Technical Writing",
-  "DevOps",
-  "Security Audit",
-  "Data Analysis",
-  "Mobile Development",
-  "Other",
-];
+import { fetchCategories, type CategoryNode } from "@/lib/api";
+import { useEffect, useState } from "react";
 
 interface Props {
   form: JobFormData;
@@ -25,6 +14,12 @@ interface Props {
 }
 
 export default function BasicInfoStep({ form, touched, errors, onChange }: Props) {
+  const [categories, setCategories] = useState<CategoryNode[]>([]);
+
+  useEffect(() => {
+    fetchCategories().then(setCategories).catch(() => {});
+  }, []);
+
   return (
     <div className="space-y-5">
       <div>
@@ -65,7 +60,22 @@ export default function BasicInfoStep({ form, touched, errors, onChange }: Props
           onChange={onChange}
           className="w-full rounded-xl border border-gray-200 dark:border-market-500/20 bg-gray-50 dark:bg-ink-700 px-4 py-2.5 text-sm text-gray-900 dark:text-amber-100 focus:outline-none focus:ring-2 focus:ring-market-400/40 focus:border-transparent"
         >
-          {VALID_CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+          {categories.length > 0 ? (
+            categories.map((parent) => (
+              <optgroup key={parent.slug} label={parent.name}>
+                {/* The parent itself is selectable */}
+                <option value={parent.slug}>{parent.name}</option>
+                {parent.children.map((child) => (
+                  <option key={child.slug} value={child.slug}>
+                    {"\u00a0\u00a0"}{child.name}
+                  </option>
+                ))}
+              </optgroup>
+            ))
+          ) : (
+            // Fallback while categories are loading
+            <option value={form.category}>{form.category || "Loading…"}</option>
+          )}
         </select>
       </div>
     </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -165,6 +165,24 @@ export async function logout() {
   }
 }
 
+// ─── Categories ────────────────────────────────────────────────────────────────
+
+export interface CategoryNode {
+  id: number;
+  slug: string;
+  name: string;
+  children: CategoryNode[];
+}
+
+export async function fetchCategories(): Promise<CategoryNode[]> {
+  try {
+    const { data } = await api.get<{ success: boolean; data: CategoryNode[] }>("/api/categories");
+    return data.data;
+  } catch {
+    return [];
+  }
+}
+
 // ─── Jobs ─────────────────────────────────────────────────────────────────────
 
 export async function fetchJobs(params?: {

--- a/frontend/pages/jobs/index.tsx
+++ b/frontend/pages/jobs/index.tsx
@@ -845,10 +845,10 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
                 </button>
                 {JOB_CATEGORIES.map((cat) => (
                   <button key={cat}
-                    onClick={() => { setFilter("category", cat); setShowMobileFilters(false); }}
+                    onClick={() => { setFilter("category", categoryToSlug(cat)); setShowMobileFilters(false); }}
                     className={clsx(
                       "w-full text-left px-3 py-2.5 rounded-lg text-sm font-body min-h-[44px]",
-                      category === cat ? "bg-market-500/20 text-market-300 font-medium" : "text-amber-700 hover:text-amber-400"
+                      category === categoryToSlug(cat) ? "bg-market-500/20 text-market-300 font-medium" : "text-amber-700 hover:text-amber-400"
                     )}
                   >
                     {CATEGORY_ICONS[cat] ?? ""} {cat}
@@ -958,18 +958,19 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
                 <span className="ml-1 text-xs text-amber-800">({jobs.length})</span>
               </Link>
               {JOB_CATEGORIES.map((cat) => {
-                const count = jobs.filter((j) => j.category === cat).length;
+                const slug = categoryToSlug(cat);
+                const count = jobs.filter((j) => j.category === cat || j.categorySlug === slug).length;
                 const isAlerted = alertedCategories.includes(cat);
                 return (
                   <div key={cat} className="flex items-center gap-1 group/catrow">
-                    <button onClick={() => setFilter("category", cat)}
+                    <button onClick={() => setFilter("category", slug)}
                       className={clsx(
                         "flex-1 text-left px-3 py-2 rounded-lg text-sm font-body transition-all duration-200",
-                        category === cat
+                        category === slug
                           ? "bg-market-500/20 text-market-300 font-medium ring-1 ring-market-500/30"
                           : "text-amber-700 hover:text-amber-400 hover:bg-market-500/8 hover:translate-x-0.5"
                       )}>
-                      {CATEGORY_ICONS[cat] ?? ""} {cat}
+                      {CATEGORY_ICONS[cat] ?? CATEGORY_ICONS[slug] ?? ""} {cat}
                       <span className="ml-1 text-xs text-amber-800">({count})</span>
                     </button>
 

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -149,29 +149,49 @@ export function statusClass(status: JobStatus): string {
   return { open: "badge-open", in_progress: "badge-progress", completed: "badge-complete", cancelled: "badge-cancelled", disputed: "badge-disputed" }[status];
 }
 
+/** Static fallback list — used when the /api/categories endpoint hasn't loaded yet. */
 export const JOB_CATEGORIES = [
   "Smart Contracts", "Frontend Development", "Backend Development",
   "UI/UX Design", "Technical Writing", "DevOps", "Security Audit",
   "Data Analysis", "Mobile Development", "Other",
 ];
 
+/** Slug equivalents of JOB_CATEGORIES for filter chips and URL params. */
+export const JOB_CATEGORY_SLUGS = [
+  "smart-contracts", "frontend-development", "backend-development",
+  "ui-ux-design", "technical-writing", "devops", "security-audit",
+  "data-analysis", "mobile-development", "other",
+];
+
 export const CATEGORY_ICONS: Record<string, string> = {
   "Smart Contracts": "📜",
+  "smart-contracts": "📜",
   "Frontend Development": "🎨",
+  "frontend-development": "🎨",
   "Backend Development": "⚙️",
+  "backend-development": "⚙️",
   "UI/UX Design": "🖌️",
+  "ui-ux-design": "🖌️",
   "Technical Writing": "✍️",
+  "technical-writing": "✍️",
   "DevOps": "🚀",
+  "devops": "🚀",
   "Security Audit": "🔒",
+  "security-audit": "🔒",
   "Data Analysis": "📊",
+  "data-analysis": "📊",
   "Mobile Development": "📱",
+  "mobile-development": "📱",
   "Other": "📦",
+  "other": "📦",
 };
 
+/** Convert a display name to a URL-safe slug. */
 export function categoryToSlug(category: string): string {
   return category.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
 }
 
+/** Reverse-lookup a display name from a slug using the static fallback list. */
 export function slugToCategory(slug: string): string | undefined {
   return JOB_CATEGORIES.find(cat => categoryToSlug(cat) === slug);
 }


### PR DESCRIPTION
Closes #473 

# feat: Normalised Job Category Taxonomy

## Summary

Job categories were previously stored as free-text strings directly on the `jobs` table. This made filtering unreliable, prevented hierarchical browsing, and produced inconsistent data across the platform. This change introduces a normalised category taxonomy with parent/child relationships, improving filtering accuracy and SEO.

---

## Problem

- `jobs.category` was a plain `TEXT` column with no referential integrity
- No subcategory support — all categories were flat
- Filtering by category required exact string matching
- Inconsistent capitalisation and naming across job records
- No single source of truth for valid categories

---

## Solution

### Database

- New `categories` table with `id SERIAL PK`, `slug TEXT UNIQUE`, `name TEXT`, and `parent_id` self-referencing FK
- Seeded with 10 top-level categories and 19 subcategories (e.g. `frontend-development` → `react-development`, `nextjs-development`, `vue-development`)
- New `jobs.category_id` FK column added and back-filled from the existing free-text `category` column
- V18 migration handles both the schema change and the data back-fill

### Backend

- `GET /api/categories` — new endpoint returning the full category tree (parents with nested `children` arrays)
- `GET /api/jobs?category=frontend-development` — still works; the filter now resolves by slug **or** legacy display name, with a fallback to the raw `category` text column for full backward compatibility
- `POST /api/jobs` — accepts `categorySlug` (preferred) or `category` name; resolves and stores `category_id` automatically
- Job responses now include `categorySlug` and `categoryId` fields alongside the existing `category` display name

### Frontend

- `fetchCategories()` added to the API client, returning typed `CategoryNode[]`
- `BasicInfoStep` category selector now fetches the tree from the API and renders `<optgroup>` per parent category with children nested inside
- Jobs browse page filter buttons updated to pass slugs (e.g. `frontend-development`) for SEO-friendly URLs
- `CATEGORY_ICONS` in `utils/format.ts` extended to support both display names and slugs as keys

---

## Files Changed

| File | Change |
|---|---|
| `backend/src/db/migrations/V18__job_category_taxonomy.up.sql` | New migration — creates table, seeds data, adds FK, back-fills |
| `backend/src/db/migrations/V18__job_category_taxonomy.down.sql` | Rollback migration |
| `backend/src/db/schema.sql` | Idempotent schema updated with `categories` table and `jobs.category_id` |
| `backend/src/routes/categories.js` | New route — `GET /api/categories` |
| `backend/src/server.js` | Registers `/api/categories` route |
| `backend/src/services/jobService.js` | `createJob` resolves `category_id`; `listJobs` filters by slug or name; `rowToJob` includes `categorySlug` |
| `frontend/lib/api.ts` | `fetchCategories()` + `CategoryNode` type |
| `frontend/components/post-job-steps/BasicInfoStep.tsx` | Category selector renders tree via `<optgroup>` |
| `frontend/pages/jobs/index.tsx` | Filter buttons use slugs; active state and counts handle both slug and name |
| `frontend/utils/format.ts` | `CATEGORY_ICONS` extended; `JOB_CATEGORY_SLUGS` added |

---

## Backward Compatibility

All existing jobs and API consumers continue to work without changes. The legacy `category` text column is preserved and the filter endpoint accepts both the old display names and the new slugs.
