### PR TITLE
feat(wasm): add wasm-opt post-build step and document optimized build…

### DIFF
--- a/contracts/marketpay-contract/Makefile
+++ b/contracts/marketpay-contract/Makefile
@@ -1,0 +1,39 @@
+WASM_TARGET = wasm32-unknown-unknown
+WASM_OUT    = target/$(WASM_TARGET)/release/marketpay_contract.wasm
+WASM_OPT    = $(WASM_OUT:.wasm=.optimized.wasm)
+
+.PHONY: build build-optimized test clean check-wasm-opt
+
+# Standard release build (Cargo already applies opt-level=z, lto, codegen-units=1)
+build:
+	cargo build --target $(WASM_TARGET) --release
+
+# Optimized build: cargo release + wasm-opt -Oz post-processing
+# Requires wasm-opt (install via: cargo install wasm-opt  OR  brew install binaryen)
+build-optimized: build check-wasm-opt
+	wasm-opt -Oz --strip-debug --strip-producers \
+		-o $(WASM_OPT) \
+		$(WASM_OUT)
+	@echo ""
+	@echo "=== Binary size comparison ==="
+	@wc -c < $(WASM_OUT)  | xargs printf "  Before wasm-opt : %d bytes\n"
+	@wc -c < $(WASM_OPT)  | xargs printf "  After  wasm-opt : %d bytes\n"
+	@echo ""
+	@echo "Optimized binary: $(WASM_OPT)"
+
+# Run all tests
+test:
+	cargo test
+
+# Verify wasm-opt is available before attempting the optimized build
+check-wasm-opt:
+	@command -v wasm-opt >/dev/null 2>&1 || { \
+		echo "wasm-opt not found. Install it with:"; \
+		echo "  cargo install wasm-opt"; \
+		echo "  OR: brew install binaryen (macOS)"; \
+		echo "  OR: apt install binaryen (Debian/Ubuntu)"; \
+		exit 1; \
+	}
+
+clean:
+	cargo clean

--- a/contracts/marketpay-contract/README.md
+++ b/contracts/marketpay-contract/README.md
@@ -37,12 +37,39 @@ This Soroban smart contract manages trustless escrow between clients and freelan
 ## Build & Test
 
 ```bash
-# Build
+# Standard build
 cargo build --target wasm32-unknown-unknown --release
 
-# Test
+# Optimized build (cargo release + wasm-opt -Oz post-processing)
+# Requires wasm-opt — install with one of:
+#   cargo install wasm-opt
+#   brew install binaryen        (macOS)
+#   apt install binaryen         (Debian/Ubuntu)
+make build-optimized
+
+# Run tests
 cargo test
 ```
+
+### Release profile
+
+`Cargo.toml` already configures `[profile.release]` for minimum WASM size:
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `opt-level` | `"z"` | Optimise aggressively for binary size |
+| `lto` | `true` | Link-time optimisation — removes dead code across crates |
+| `codegen-units` | `1` | Single codegen unit for maximum inlining and dead-code elimination |
+| `strip` | `"symbols"` | Strip debug symbols from the binary |
+| `panic` | `"abort"` | Replace panic unwinding machinery with a single `unreachable` trap |
+
+After running `make build-optimized` the target binary is:
+
+```
+target/wasm32-unknown-unknown/release/marketpay_contract.optimized.wasm
+```
+
+Use this file (not the plain `.wasm`) when deploying or installing on-chain.
 
 ## Deploy
 
@@ -63,13 +90,14 @@ the active WASM and the on-chain record are in sync after an upgrade.
 
 1. **Build the new WASM**
    ```bash
-   cargo build --target wasm32-unknown-unknown --release
+   make build-optimized
+   # Produces: target/wasm32-unknown-unknown/release/marketpay_contract.optimized.wasm
    ```
 
 2. **Install the new WASM on-chain** (uploads bytes, returns a hash)
    ```bash
    stellar contract install \
-     --wasm target/wasm32-unknown-unknown/release/marketpay_contract.wasm \
+     --wasm target/wasm32-unknown-unknown/release/marketpay_contract.optimized.wasm \
      --source <admin-key> --network testnet
    # → prints NEW_WASM_HASH
    ```


### PR DESCRIPTION
Closes #548 

## Summary

The compiled WASM binary had no post-build optimization step beyond what Cargo's release profile provides. This change adds a `wasm-opt -Oz` post-build pass via a `Makefile` target and documents the full optimized build workflow in the contract README.

---

## What Changed

### `contracts/marketpay-contract/Cargo.toml` — already configured

The `[profile.release]` block was already set correctly and required no changes:

| Setting | Value | Effect |
|---------|-------|--------|
| `opt-level` | `"z"` | Optimise aggressively for binary size |
| `lto` | `true` | Link-time optimisation — removes dead code across crates |
| `codegen-units` | `1` | Single codegen unit for maximum inlining and dead-code elimination |
| `strip` | `"symbols"` | Strip debug symbols |
| `panic` | `"abort"` | Replaces panic unwinding with a single trap instruction |

### New — `contracts/marketpay-contract/Makefile`

Adds three targets:

- `make build` — standard `cargo build --target wasm32-unknown-unknown --release`
- `make build-optimized` — runs `cargo build --release` then `wasm-opt -Oz --strip-debug --strip-producers`, outputs `marketpay_contract.optimized.wasm`, and prints a before/after size comparison
- `make test` — runs `cargo test`
- `make check-wasm-opt` — guard that prints clear install instructions if `wasm-opt` is not found before the build fails

### Updated — `contracts/marketpay-contract/README.md`

- Replaced the basic `cargo build` snippet with the full `make build-optimized` workflow
- Added a release profile settings table explaining each flag
- Updated the contract upgrade step-by-step to reference `.optimized.wasm` instead of the plain `.wasm`

---

## Acceptance Criteria Coverage

| Criterion | Status |
|-----------|--------|
| `[profile.release]` has `opt-level = 'z'`, `lto = true`, `codegen-units = 1` | ✅ Already present |
| `wasm-opt -Oz` as post-build step | ✅ `make build-optimized` |
| Optimized build command documented in `contracts/README.md` | ✅ Updated `contracts/marketpay-contract/README.md` |
