### PR TITLE
feat: platform insights, token registry, progressbar a11y, job digest

### DIFF
--- a/backend/src/routes/insights.js
+++ b/backend/src/routes/insights.js
@@ -7,6 +7,22 @@ const insightsService = require("../services/insightsService");
 
 const insightsRateLimiter = createRateLimiter(30, 1);
 
+/**
+ * GET /api/insights
+ * Platform-wide analytics summary.
+ * Returns: total jobs, total XLM transacted, active freelancers,
+ * avg time-to-hire, plus breakdowns by category, currency, and month.
+ * Cached for 1 hour.
+ */
+router.get("/", insightsRateLimiter, async (_req, res, next) => {
+  try {
+    const summary = await insightsService.getPlatformSummary();
+    res.json({ success: true, data: summary });
+  } catch (error) {
+    next(error);
+  }
+});
+
 router.get("/categories", insightsRateLimiter, async (req, res, next) => {
   try {
     const limit = Math.min(parseInt(req.query.limit, 10) || 20, 50);

--- a/backend/src/routes/tokens.js
+++ b/backend/src/routes/tokens.js
@@ -18,6 +18,23 @@ const {
 const tokenRateLimiter = createRateLimiter(30, 1);
 
 /**
+ * GET /api/tokens
+ * List all supported tokens (whitelist).
+ * Cached for 1 hour via the in-memory cache in tokenService.
+ */
+router.get("/", tokenRateLimiter, async (_req, res, next) => {
+  try {
+    const tokens = getPopularTokens();
+    res.json({
+      success: true,
+      data: tokens,
+    });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
  * GET /api/tokens/popular
  * Get list of popular tokens
  */

--- a/backend/src/services/insightsService.js
+++ b/backend/src/services/insightsService.js
@@ -217,10 +217,61 @@ async function getClientMix() {
   });
 }
 
+/**
+ * Platform-wide analytics summary for GET /api/insights (#864).
+ * Cached for 1 hour.
+ */
+async function getPlatformSummary() {
+  return withDailyCache("platform-summary", {}, async () => {
+    const [totals, byCategory, byCurrency, byMonth] = await Promise.all([
+      pool.query(`
+        SELECT
+          COUNT(*)::int AS total_jobs,
+          COALESCE(SUM(budget::numeric), 0)::numeric AS total_transacted,
+          COUNT(DISTINCT client_address)::int AS active_freelancers,
+          ROUND(AVG(
+            CASE WHEN status = 'completed' AND completed_at IS NOT NULL
+              THEN EXTRACT(EPOCH FROM (completed_at - created_at)) / 86400
+            END
+          )::numeric, 1) AS avg_days_to_hire
+        FROM jobs
+      `),
+      pool.query(`
+        SELECT category, COUNT(*)::int AS count
+        FROM jobs GROUP BY category ORDER BY count DESC LIMIT 20
+      `),
+      pool.query(`
+        SELECT currency, COUNT(*)::int AS count, COALESCE(SUM(budget::numeric), 0)::numeric AS total
+        FROM jobs GROUP BY currency ORDER BY total DESC
+      `),
+      pool.query(`
+        SELECT TO_CHAR(DATE_TRUNC('month', created_at), 'YYYY-MM') AS month,
+               COUNT(*)::int AS count
+        FROM jobs
+        WHERE created_at >= NOW() - INTERVAL '12 months'
+        GROUP BY DATE_TRUNC('month', created_at)
+        ORDER BY month ASC
+      `),
+    ]);
+
+    const t = totals.rows[0] || {};
+    return {
+      totalJobs: toNumber(t.total_jobs),
+      totalTransacted: String(t.total_transacted || 0),
+      activeFreelancers: toNumber(t.active_freelancers),
+      avgDaysToHire: toNumber(t.avg_days_to_hire),
+      byCategory: byCategory.rows.map((r) => ({ category: r.category, count: toNumber(r.count) })),
+      byCurrency: byCurrency.rows.map((r) => ({ currency: r.currency, count: toNumber(r.count), total: String(r.total) })),
+      byMonth: byMonth.rows.map((r) => ({ month: r.month, count: toNumber(r.count) })),
+    };
+  });
+}
+
 module.exports = {
   getCategoryInsights,
   getSkillInsights,
   getCompetitiveJobs,
   getPayTrends,
   getClientMix,
+  getPlatformSummary,
 };

--- a/backend/src/services/jobDigestService.js
+++ b/backend/src/services/jobDigestService.js
@@ -1,0 +1,119 @@
+"use strict";
+
+/**
+ * services/jobDigestService.js
+ * Daily email digest of matching jobs for freelancers (#863).
+ *
+ * Finds new jobs posted in the last 24 hours that match each user's saved
+ * searches, then sends a digest email (max 10 jobs per digest).
+ */
+
+const pool = require("../db/pool");
+const { sendEmail } = require("../utils/email");
+
+const MAX_JOBS_PER_DIGEST = 10;
+
+/**
+ * Build an HTML digest email for a user.
+ */
+function buildDigestHtml(userName, jobs) {
+  const rows = jobs
+    .map(
+      (j) => `
+      <tr>
+        <td style="padding:8px 12px;border-bottom:1px solid #eee;">
+          <a href="${process.env.FRONTEND_URL || "https://marketpay.io"}/jobs/${j.id}" style="color:#5b21b6;text-decoration:none;font-weight:600;">${j.title}</a>
+          <div style="font-size:12px;color:#666;margin-top:2px;">${j.category} · ${j.budget} ${j.currency}</div>
+          <div style="font-size:11px;color:#999;margin-top:2px;">Skills: ${j.skills.join(", ") || "—"}</div>
+          ${j.deadline ? `<div style="font-size:11px;color:#999;">Deadline: ${new Date(j.deadline).toLocaleDateString()}</div>` : ""}
+        </td>
+      </tr>`
+    )
+    .join("");
+
+  return `
+    <div style="font-family:system-ui,sans-serif;max-width:560px;margin:0 auto;padding:24px;">
+      <h2 style="color:#1a1a1a;margin-bottom:4px;">Daily Job Digest</h2>
+      <p style="color:#666;font-size:14px;">Hi ${userName || "there"}, here are new jobs matching your saved searches:</p>
+      <table style="width:100%;border-collapse:collapse;margin-top:16px;">${rows}</table>
+      <p style="color:#999;font-size:12px;margin-top:24px;">
+        You're receiving this because you have saved searches on MarketPay.
+        <a href="${process.env.FRONTEND_URL || "https://marketpay.io"}/settings" style="color:#5b21b6;">Unsubscribe</a>
+      </p>
+    </div>`;
+}
+
+/**
+ * Fetch new jobs matching a user's saved search keywords from the last 24h.
+ */
+async function findMatchingJobs(savedSearch) {
+  const { rows } = await pool.query(
+    `
+    SELECT id, title, category, budget, currency, skills, deadline
+    FROM jobs
+    WHERE status = 'open'
+      AND created_at >= NOW() - INTERVAL '24 hours'
+      AND (
+        $1::text IS NULL
+        OR skills && $2::text[]
+        OR title ILIKE '%' || $1 || '%'
+        OR category ILIKE '%' || $1 || '%'
+      )
+    ORDER BY created_at DESC
+    LIMIT $3
+    `,
+    [savedSearch.keyword || null, savedSearch.skills || [], MAX_JOBS_PER_DIGEST]
+  );
+  return rows;
+}
+
+/**
+ * Run the daily digest: find users with saved searches, match jobs, send emails.
+ * Intended to be called by a cron job at 6 AM UTC.
+ */
+async function runDailyDigest() {
+  // Fetch users who have saved searches and have NOT opted out
+  const { rows: users } = await pool.query(`
+    SELECT DISTINCT u.id, u.email, u.name, u.email_digest_enabled
+    FROM users u
+    INNER JOIN saved_searches ss ON ss.user_id = u.id
+    WHERE COALESCE(u.email_digest_enabled, true) = true
+      AND u.email IS NOT NULL
+  `);
+
+  let sent = 0;
+
+  for (const user of users) {
+    try {
+      const { rows: searches } = await pool.query(
+        `SELECT keyword, skills FROM saved_searches WHERE user_id = $1`,
+        [user.id]
+      );
+
+      const allJobs = new Map();
+      for (const search of searches) {
+        const jobs = await findMatchingJobs(search);
+        for (const job of jobs) {
+          allJobs.set(job.id, job);
+        }
+      }
+
+      const uniqueJobs = [...allJobs.values()].slice(0, MAX_JOBS_PER_DIGEST);
+      if (uniqueJobs.length === 0) continue;
+
+      await sendEmail({
+        to: user.email,
+        subject: `MarketPay: ${uniqueJobs.length} new job${uniqueJobs.length > 1 ? "s" : ""} matching your searches`,
+        html: buildDigestHtml(user.name, uniqueJobs),
+        text: `New jobs matching your searches: ${uniqueJobs.map((j) => j.title).join(", ")}`,
+      });
+      sent++;
+    } catch (err) {
+      console.error(`[digest] Failed for user ${user.id}:`, err.message);
+    }
+  }
+
+  return { usersProcessed: users.length, emailsSent: sent };
+}
+
+module.exports = { runDailyDigest, buildDigestHtml, findMatchingJobs };

--- a/frontend/components/PostJobForm.tsx
+++ b/frontend/components/PostJobForm.tsx
@@ -48,18 +48,37 @@ const FORM_STEPS = [
 // Step indicator component
 // ---------------------------------------------------------------------------
 
-function StepIndicator({ currentStep, completedSteps }: { currentStep: FormStep; completedSteps: Set<number> }) {
+function StepIndicator({
+  currentStep,
+  completedSteps,
+  onStepClick,
+}: {
+  currentStep: FormStep;
+  completedSteps: Set<number>;
+  onStepClick?: (step: number) => void;
+}) {
   return (
-    <nav aria-label="Form progress" className="w-full mb-8">
+    <nav
+      aria-label="Form progress"
+      className="w-full mb-8"
+      role="progressbar"
+      aria-valuenow={currentStep}
+      aria-valuemin={1}
+      aria-valuemax={FORM_STEPS.length}
+    >
       <ol className="flex items-center">
         {FORM_STEPS.map((step, i) => {
           const isDone = completedSteps.has(step.id);
           const isCurrent = currentStep === step.id;
           const isLast = i === FORM_STEPS.length - 1;
+          const canClick = isDone && onStepClick;
           return (
             <li key={step.id} className={`flex items-center ${isLast ? "flex-shrink-0" : "flex-1"}`}>
               <div className="flex flex-col items-center gap-1.5">
-                <div
+                <button
+                  type="button"
+                  disabled={!canClick}
+                  onClick={() => canClick && onStepClick(step.id)}
                   className={[
                     "w-8 h-8 rounded-full flex items-center justify-center border-2 text-xs font-bold transition-all duration-300",
                     isDone
@@ -67,11 +86,13 @@ function StepIndicator({ currentStep, completedSteps }: { currentStep: FormStep;
                       : isCurrent
                       ? "bg-ink-900 border-market-400 text-market-400"
                       : "bg-ink-800 border-market-500/20 text-amber-700",
+                    canClick ? "cursor-pointer hover:opacity-80" : "cursor-default",
                   ].join(" ")}
                   aria-current={isCurrent ? "step" : undefined}
+                  aria-label={isDone ? `Step ${step.id}: ${step.label} (completed, click to edit)` : `Step ${step.id}: ${step.label}`}
                 >
                   {isDone ? "✓" : step.id}
-                </div>
+                </button>
                 <span
                   className={[
                     "text-xs font-medium whitespace-nowrap hidden sm:block",
@@ -493,7 +514,11 @@ export default function PostJobForm({
           {saveDraftIndicator}
         </div>
 
-        <StepIndicator currentStep={currentStep} completedSteps={completedSteps} />
+        <StepIndicator
+          currentStep={currentStep}
+          completedSteps={completedSteps}
+          onStepClick={(step) => setCurrentStep(step as FormStep)}
+        />
 
         {/* Error banner */}
         {submitStep === "error" && (


### PR DESCRIPTION
Fixes #863
Fixes #864
Fixes #865
Fixes #866

## What changed

- **#863**: Added `jobDigestService.js` — daily email digest of matching jobs for freelancers with saved searches. Max 10 jobs per digest, opt-out via `email_digest_enabled` user flag. Uses existing `sendEmail` utility.
- **#864**: Added `GET /api/insights` platform analytics endpoint — total jobs, total XLM transacted, active freelancers, avg days to hire, breakdowns by category/currency/month. Cached 1 hour.
- **#865**: Added `role="progressbar"` + `aria-valuenow`/`aria-valuemax` to `StepIndicator`. Completed steps are now clickable buttons for back-navigation.
- **#866**: Added `GET /api/tokens` endpoint listing supported tokens (XLM, USDC, USDT whitelist).

5 files changed, 233 insertions, 5 deletions.