### PR TITLE
Fix WebSocket double-connect, stale pagination cursor, earnings chart; mobile dashboard responsiveness

### DIFF
--- a/frontend/__tests__/EarningsChart.transform.test.ts
+++ b/frontend/__tests__/EarningsChart.transform.test.ts
@@ -1,0 +1,89 @@
+/**
+ * __tests__/EarningsChart.transform.test.ts
+ * Issue #858 — Unit tests for EarningsChart's chart data transformation.
+ * Guards against the reported regression (every month showing the grand
+ * total instead of that month's own earnings) and covers the new
+ * cumulative-view transform.
+ */
+import { buildMonthlyData, buildCumulativeMonthlyData } from "@/components/EarningsChart";
+import type { EarningPayment } from "@/lib/api";
+
+function payment(amountXlm: string, monthsAgo: number): EarningPayment {
+  const now = new Date();
+  const d = new Date(now.getFullYear(), now.getMonth() - monthsAgo, 15);
+  return {
+    id: `p-${monthsAgo}-${amountXlm}`,
+    jobId: `job-${monthsAgo}`,
+    jobTitle: "Job",
+    amountXlm,
+    releasedAt: d.toISOString(),
+    clientAddress: "GCLIENT",
+  };
+}
+
+describe("EarningsChart data transformation (#858)", () => {
+  it("attributes each payment to its own month, not the grand total, across all months", () => {
+    // Reproduces the issue's exact repro: 3 jobs completed in 3 different
+    // months. Every month must show only its own amount.
+    const payments = [payment("100", 2), payment("200", 1), payment("150", 0)];
+    const result = buildMonthlyData(payments);
+
+    const nonZero = result.filter((m) => m.total !== 0);
+    expect(nonZero).toHaveLength(3);
+    expect(nonZero.map((m) => m.total)).toEqual([100, 200, 150]);
+
+    // The specific regression this issue reported: no month should show the
+    // combined total of all payments.
+    const grandTotal = 100 + 200 + 150;
+    for (const m of result) {
+      expect(m.total).not.toBe(grandTotal);
+    }
+  });
+
+  it("sums multiple payments released within the same month", () => {
+    const payments = [payment("100", 0), payment("50", 0)];
+    const result = buildMonthlyData(payments);
+    const thisMonth = result[result.length - 1];
+    expect(thisMonth.total).toBe(150);
+  });
+
+  it("returns 12 zeroed months when there are no payments", () => {
+    const result = buildMonthlyData([]);
+    expect(result).toHaveLength(12);
+    expect(result.every((m) => m.total === 0)).toBe(true);
+  });
+
+  it("ignores payments released more than 12 months ago", () => {
+    const payments = [payment("999", 20)];
+    const result = buildMonthlyData(payments);
+    expect(result.every((m) => m.total === 0)).toBe(true);
+  });
+
+  describe("buildCumulativeMonthlyData", () => {
+    it("produces a running total that accumulates across months", () => {
+      const payments = [payment("100", 2), payment("200", 1), payment("150", 0)];
+      const result = buildCumulativeMonthlyData(payments);
+
+      const last3 = result.slice(-3).map((m) => m.total);
+      expect(last3).toEqual([100, 300, 450]);
+    });
+
+    it("is monotonically non-decreasing", () => {
+      const payments = [payment("100", 3), payment("50", 1)];
+      const result = buildCumulativeMonthlyData(payments);
+
+      for (let i = 1; i < result.length; i++) {
+        expect(result[i].total).toBeGreaterThanOrEqual(result[i - 1].total);
+      }
+    });
+
+    it("matches the sum of all per-period payments in the final month", () => {
+      const payments = [payment("100", 2), payment("200", 1), payment("150", 0)];
+      const cumulative = buildCumulativeMonthlyData(payments);
+      const perPeriod = buildMonthlyData(payments);
+
+      const expectedTotal = perPeriod.reduce((sum, m) => sum + m.total, 0);
+      expect(cumulative[cumulative.length - 1].total).toBe(expectedTotal);
+    });
+  });
+});

--- a/frontend/__tests__/jobs-pagination-reset.test.tsx
+++ b/frontend/__tests__/jobs-pagination-reset.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * __tests__/jobs-pagination-reset.test.tsx
+ * Issue #857 — Verifies that changing a filter resets pagination instead of
+ * combining a stale cursor (from before the filter change) with the new
+ * filter on the next "load more" fetch.
+ */
+import { render, waitFor, act } from "@testing-library/react";
+import React from "react";
+
+// ── Controllable router mock ──────────────────────────────────────────────────
+// Overrides the global static mock (jest.setup.tsx) with one whose `query`
+// can change between renders, and whose `push` actually updates it — close
+// enough to real Next.js router behavior for this test's purposes.
+let mockQuery: Record<string, string | undefined> = {};
+const mockPush = jest.fn((arg: { query: Record<string, string | undefined> }) => {
+  mockQuery = arg.query;
+});
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    pathname: "/jobs",
+    push: mockPush,
+    query: mockQuery,
+    isReady: true,
+  }),
+}));
+
+// ── Other dependencies ─────────────────────────────────────────────────────────
+
+jest.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", t: (key: string) => key },
+    ready: true,
+  }),
+}));
+
+jest.mock("@/hooks/useBookmarks", () => ({
+  useBookmarks: () => ({
+    isSaved: () => false,
+    toggleBookmark: jest.fn(),
+    savedCount: 0,
+    getSavedJobs: jest.fn(),
+    bookmarks: [],
+  }),
+}));
+
+jest.mock("@/lib/wallet", () => ({
+  getConnectedPublicKey: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/components/JobFiltersPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="job-filters-panel" />,
+  ActiveFilterChips: () => null,
+}));
+
+jest.mock("@/components/JobCard", () => ({
+  __esModule: true,
+  default: ({ job }: { job: { id: string } }) => <div data-testid={`job-card-${job.id}`} />,
+  JobCardSkeleton: () => <div data-testid="job-card-skeleton" />,
+}));
+
+// A single mock "virtual item" whose index always satisfies the "near the
+// end of the list, trigger load-more" condition for however many jobs are
+// rendered, so the page's real infinite-scroll effect (not a test shortcut)
+// is what fires `handleLoadMore`.
+jest.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: () => ({
+    getVirtualItems: () => [{ index: 0, start: 0, size: 200 }],
+    getTotalSize: () => 200,
+    scrollToIndex: jest.fn(),
+  }),
+}));
+
+interface FetchJobsParams {
+  category?: string;
+  cursor?: string;
+}
+interface FetchJobsResult {
+  jobs: unknown[];
+  nextCursor: string | null;
+}
+
+const fetchJobsCalls: FetchJobsParams[] = [];
+// Deferred response for the one call this test wants to hold "in flight"
+// (the auto-triggered load-more for cursor-design-page1) so a filter change
+// can happen while it's still pending.
+let deferredDesignPage2Resolve: ((v: FetchJobsResult) => void) | null = null;
+
+const fetchJobsMock = jest.fn(async (params: FetchJobsParams): Promise<FetchJobsResult> => {
+  fetchJobsCalls.push(params);
+
+  if (params.cursor === "cursor-design-page1") {
+    return new Promise<FetchJobsResult>((resolve) => {
+      deferredDesignPage2Resolve = resolve;
+    });
+  }
+
+  if (params.cursor === undefined) {
+    // Fresh page-1 load for whatever category is currently active.
+    return {
+      jobs: [{ id: `job-${params.category}-1`, category: params.category }],
+      nextCursor: `cursor-${params.category}-page1`,
+    };
+  }
+
+  // Any other cursor (e.g. a legitimate load-more for the *current* filter
+  // after the race window) — resolve with no further pages so the test
+  // doesn't need to drain an unbounded chain of auto-triggered loads.
+  return { jobs: [], nextCursor: null };
+});
+
+jest.mock("@/lib/api", () => ({
+  fetchJobs: (...args: [FetchJobsParams]) => fetchJobsMock(...args),
+  fetchRecommendedJobs: jest.fn().mockResolvedValue([]),
+  fetchJobSuggestions: jest.fn().mockResolvedValue([]),
+  fetchSavedSearches: jest.fn().mockResolvedValue([]),
+  createSavedSearch: jest.fn(),
+}));
+
+import JobsPage from "@/pages/jobs/index";
+
+describe("jobs pagination reset on filter change (#857)", () => {
+  beforeEach(() => {
+    mockQuery = { category: "design" };
+    mockPush.mockClear();
+    fetchJobsMock.mockClear();
+    fetchJobsCalls.length = 0;
+    deferredDesignPage2Resolve = null;
+  });
+
+  it("does not combine a stale cursor with a new filter after the filter changes mid-flight", async () => {
+    const { rerender } = render(<JobsPage />);
+
+    // Initial page-1 load, then the auto-triggered load-more for
+    // cursor-design-page1 — which this mock deliberately leaves pending.
+    await waitFor(() =>
+      expect(fetchJobsCalls.some((c) => c.cursor === "cursor-design-page1")).toBe(true),
+    );
+    await waitFor(() => expect(deferredDesignPage2Resolve).not.toBeNull());
+
+    // Simulate `setFilter("category", "engineering")`: a new category, and
+    // (matching the real handler) the page param reset in the URL query —
+    // while the design-category load-more above is still unresolved.
+    mockQuery = { category: "engineering" };
+    act(() => {
+      rerender(<JobsPage />);
+    });
+
+    // The reload effect (dependent on `category`) reruns and issues its own
+    // fresh, cursor-less fetch for the new filter.
+    await waitFor(() =>
+      expect(
+        fetchJobsCalls.some((c) => c.category === "engineering" && c.cursor === undefined),
+      ).toBe(true),
+    );
+
+    // Now let the *stale* (category=design) load-more resolve. Without the
+    // fix, `nextCursor` would still hold "cursor-design-page1" at the moment
+    // `category` changed, and the auto-load effect could fire another
+    // `fetchJobs` combining that stale cursor with the now-current
+    // `engineering` category once this resolves. With the fix, `nextCursor`
+    // was reset to null synchronously when `category` changed, so no such
+    // call is ever made.
+    await act(async () => {
+      deferredDesignPage2Resolve?.({ jobs: [], nextCursor: "cursor-design-page2" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const badCall = fetchJobsCalls.find(
+      (c) => c.category === "engineering" && c.cursor && c.cursor.startsWith("cursor-design"),
+    );
+    expect(badCall).toBeUndefined();
+
+    // The stale cursor from the design load-more's resolution must never be
+    // used for a subsequent fetch at all, regardless of category.
+    const usedStaleCursor = fetchJobsCalls.some((c) => c.cursor === "cursor-design-page2");
+    expect(usedStaleCursor).toBe(false);
+  });
+});

--- a/frontend/__tests__/useRealtimeBids.test.ts
+++ b/frontend/__tests__/useRealtimeBids.test.ts
@@ -1,0 +1,137 @@
+/**
+ * __tests__/useRealtimeBids.test.ts
+ * Issue #856 — Verifies useRealtimeBids only ever keeps one WebSocket
+ * connection active through a React Strict Mode mount/cleanup/remount
+ * cycle, and that unmounting closes the connection.
+ */
+import { renderHook, act } from "@testing-library/react";
+import React from "react";
+import { useRealtimeBids } from "@/hooks/useRealtimeBids";
+import type { Application } from "@/utils/types";
+
+// ── Mock WebSocket ────────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static OPEN = 1;
+  static CLOSED = 3;
+
+  url: string;
+  readyState = 0; // CONNECTING
+  closeCalls = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  /** Test helper — simulates the server accepting the connection. */
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  /** Test helper — simulates a server-pushed message. */
+  simulateMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  close() {
+    this.closeCalls++;
+    this.readyState = MockWebSocket.CLOSED;
+    // A real WebSocket's close handshake is asynchronous — onclose does not
+    // fire synchronously from calling close(). Deferring via a microtask
+    // reproduces the exact race this hook's fix is guarding against: a
+    // remount can run (and reassign wsRef.current) before this fires.
+    queueMicrotask(() => this.onclose?.());
+  }
+}
+
+describe("useRealtimeBids (#856)", () => {
+  const initialApplications: Application[] = [];
+  const fetchApplications = jest.fn().mockResolvedValue([]);
+
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    fetchApplications.mockClear();
+    (global as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = MockWebSocket;
+  });
+
+  it("closes the WebSocket connection on unmount", async () => {
+    const { unmount } = renderHook(() =>
+      useRealtimeBids({ jobId: "job-1", initialApplications, fetchApplications }),
+    );
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const ws = MockWebSocket.instances[0];
+
+    unmount();
+
+    expect(ws.closeCalls).toBe(1);
+  });
+
+  it("keeps only one connection active through a Strict Mode mount/cleanup/remount cycle", async () => {
+    const { result } = renderHook(
+      () => useRealtimeBids({ jobId: "job-1", initialApplications, fetchApplications }),
+      { wrapper: React.StrictMode },
+    );
+
+    // Strict Mode's dev-only mount → cleanup → mount simulation runs
+    // synchronously during the initial render, so by now two sockets may
+    // well have been constructed (React deliberately exercises this) — the
+    // guarantee under test is that only the *second* (current) one is live.
+    expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(1);
+    const staleWs = MockWebSocket.instances[0];
+    const currentWs = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+
+    // The stale socket's close handshake resolves late (after the remount
+    // already created/attached the current one). Without the isCurrent()
+    // guard this would null out the ref to the live socket and schedule a
+    // spurious duplicate reconnect.
+    await act(async () => {
+      staleWs.close();
+      await Promise.resolve();
+    });
+
+    act(() => currentWs.simulateOpen());
+    expect(result.current.wsStatus).toBe("open");
+
+    // A message on the CURRENT socket must be the one reflected in state.
+    const incoming: Application = {
+      id: "app-1",
+      jobId: "job-1",
+      freelancerAddress: "GFREELANCER",
+      proposal: "I can do this",
+      bidAmount: "100",
+      currency: "XLM",
+      status: "pending",
+      createdAt: new Date().toISOString(),
+    };
+    act(() => {
+      currentWs.simulateMessage({
+        event: "job:job-1:bids",
+        payload: { type: "new_bid", application: incoming },
+      });
+    });
+    expect(result.current.applications).toHaveLength(1);
+    expect(result.current.applications[0].id).toBe("app-1");
+
+    // A message arriving on the STALE socket must be ignored — it is no
+    // longer the connection this hook considers current.
+    const ignoredApplication: Application = { ...incoming, id: "app-should-be-ignored" };
+    act(() => {
+      staleWs.simulateMessage({
+        event: "job:job-1:bids",
+        payload: { type: "new_bid", application: ignoredApplication },
+      });
+    });
+    expect(result.current.applications).toHaveLength(1);
+    expect(result.current.wsStatus).toBe("open"); // unaffected by the stale close resolving
+
+    fetchApplications.mockClear();
+  });
+});

--- a/frontend/components/EarningsChart.tsx
+++ b/frontend/components/EarningsChart.tsx
@@ -32,7 +32,13 @@ interface Props {
   publicKey: string;
 }
 
-function buildMonthlyData(payments: EarningPayment[]): { month: string; total: number }[] {
+/**
+ * Builds the last 12 calendar months, each bucket holding only the earnings
+ * *released in that specific month* (per-period) — Issue #858. Exported so
+ * the transformation itself is independently unit-testable rather than only
+ * observable through a full component render.
+ */
+export function buildMonthlyData(payments: EarningPayment[]): { month: string; total: number }[] {
   const now = new Date();
   const months: { month: string; total: number }[] = [];
 
@@ -51,6 +57,23 @@ function buildMonthlyData(payments: EarningPayment[]): { month: string; total: n
   }
 
   return months;
+}
+
+/**
+ * Running-total view of the same 12 months — Issue #858's "cumulative"
+ * toggle option. Each month's `total` is the sum of every per-period amount
+ * up to and including that month, so the series is monotonically
+ * non-decreasing (unlike `buildMonthlyData`, which resets each month).
+ */
+export function buildCumulativeMonthlyData(
+  payments: EarningPayment[],
+): { month: string; total: number }[] {
+  const perPeriod = buildMonthlyData(payments);
+  let running = 0;
+  return perPeriod.map((m) => {
+    running += m.total;
+    return { month: m.month, total: running };
+  });
 }
 
 function buildCategoryData(payments: EarningPayment[]): { name: string; value: number }[] {
@@ -85,6 +108,7 @@ export default function EarningsChart({ publicKey }: Props) {
   const [data, setData] = useState<EarningsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<"per-period" | "cumulative">("per-period");
 
   useEffect(() => {
     setLoading(true);
@@ -110,7 +134,8 @@ export default function EarningsChart({ publicKey }: Props) {
     );
   }
 
-  const monthlyData = buildMonthlyData(data.payments);
+  const monthlyData =
+    viewMode === "cumulative" ? buildCumulativeMonthlyData(data.payments) : buildMonthlyData(data.payments);
   const categoryData = buildCategoryData(data.payments);
   const totalXlm = parseFloat(data.totalXlm) || 0;
   const avgPerJob = data.payments.length > 0 ? totalXlm / data.payments.length : 0;
@@ -135,15 +160,39 @@ export default function EarningsChart({ publicKey }: Props) {
 
       {/* Monthly bar chart */}
       <div className="card">
-        <div className="flex items-center justify-between mb-4">
-          <p className="font-display text-lg text-amber-100">Monthly Earnings (Last 12 Months)</p>
-          <button
-            onClick={() => exportCSV(data.payments)}
-            className="btn-secondary text-xs px-3 py-1.5"
-            aria-label="Export earnings data as CSV"
-          >
-            Export CSV
-          </button>
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+          <p className="font-display text-lg text-amber-100">
+            {viewMode === "cumulative" ? "Cumulative Earnings" : "Monthly Earnings"} (Last 12 Months)
+          </p>
+          <div className="flex items-center gap-2">
+            <div className="flex rounded-md border border-amber-900/30 overflow-hidden text-xs" role="group" aria-label="Chart view mode">
+              <button
+                onClick={() => setViewMode("per-period")}
+                aria-pressed={viewMode === "per-period"}
+                className={`px-3 py-1.5 transition-colors ${
+                  viewMode === "per-period" ? "bg-market-300 text-black" : "text-amber-700 hover:text-amber-100"
+                }`}
+              >
+                Per-period
+              </button>
+              <button
+                onClick={() => setViewMode("cumulative")}
+                aria-pressed={viewMode === "cumulative"}
+                className={`px-3 py-1.5 transition-colors ${
+                  viewMode === "cumulative" ? "bg-market-300 text-black" : "text-amber-700 hover:text-amber-100"
+                }`}
+              >
+                Cumulative
+              </button>
+            </div>
+            <button
+              onClick={() => exportCSV(data.payments)}
+              className="btn-secondary text-xs px-3 py-1.5"
+              aria-label="Export earnings data as CSV"
+            >
+              Export CSV
+            </button>
+          </div>
         </div>
         {monthlyData.every((m) => m.total === 0) ? (
           <p className="text-sm text-amber-800 text-center py-8">No payments in the last 12 months.</p>
@@ -154,7 +203,10 @@ export default function EarningsChart({ publicKey }: Props) {
               <YAxis tick={{ fill: "#a8956a", fontSize: 11 }} axisLine={false} tickLine={false} tickFormatter={(v) => `${v}`} />
               <Tooltip
                 contentStyle={{ background: "#1a1610", border: "1px solid rgba(245,158,11,0.15)", borderRadius: 8, color: "#fef3c7", fontSize: 12 }}
-                formatter={(value) => [`${Number(value).toFixed(2)} XLM`, "Earned"]}
+                formatter={(value) => [
+                  `${Number(value).toFixed(2)} XLM`,
+                  viewMode === "cumulative" ? "Cumulative" : "Earned",
+                ]}
                 cursor={{ fill: "rgba(245,158,11,0.06)" }}
               />
               <Bar dataKey="total" fill="#f59e0b" radius={[4, 4, 0, 0]} />
@@ -168,27 +220,34 @@ export default function EarningsChart({ publicKey }: Props) {
         <div className="card">
           <p className="font-display text-lg text-amber-100 mb-4">Earnings by Job</p>
           <div className="flex flex-col sm:flex-row items-center gap-6">
-            <ResponsiveContainer width={200} height={200}>
-              <PieChart>
-                <Pie
-                  data={categoryData}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={50}
-                  outerRadius={80}
-                  dataKey="value"
-                  paddingAngle={3}
-                >
-                  {categoryData.map((_, index) => (
-                    <Cell key={index} fill={PIE_COLORS[index % PIE_COLORS.length]} />
-                  ))}
-                </Pie>
-                <Tooltip
-                  contentStyle={{ background: "#1a1610", border: "1px solid rgba(245,158,11,0.15)", borderRadius: 8, color: "#fef3c7", fontSize: 12 }}
-                  formatter={(value) => [`${Number(value).toFixed(2)} XLM`]}
-                />
-              </PieChart>
-            </ResponsiveContainer>
+            {/* Issue #859: a fixed 200x200 ResponsiveContainer doesn't
+                actually resize — it's the same pixel size on every screen.
+                Sizing the wrapper instead (smaller on mobile) and letting
+                the container fill it (100%) makes the chart genuinely
+                responsive. */}
+            <div className="w-[160px] h-[160px] sm:w-[200px] sm:h-[200px] flex-shrink-0">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={categoryData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={50}
+                    outerRadius={80}
+                    dataKey="value"
+                    paddingAngle={3}
+                  >
+                    {categoryData.map((_, index) => (
+                      <Cell key={index} fill={PIE_COLORS[index % PIE_COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    contentStyle={{ background: "#1a1610", border: "1px solid rgba(245,158,11,0.15)", borderRadius: 8, color: "#fef3c7", fontSize: 12 }}
+                    formatter={(value) => [`${Number(value).toFixed(2)} XLM`]}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
             <div className="flex-1 space-y-2 min-w-0">
               {categoryData.map((item, i) => (
                 <div key={item.name} className="flex items-center justify-between gap-3">

--- a/frontend/components/ReferralDashboard.tsx
+++ b/frontend/components/ReferralDashboard.tsx
@@ -300,25 +300,37 @@ export default function ReferralDashboard({
                 </p>
               </div>
             ) : (
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="text-left text-xs text-amber-700 border-b border-market-500/10">
-                      <th className="pb-2 pr-4 font-medium">Referee</th>
-                      <th className="pb-2 pr-4 font-medium">Job</th>
-                      <th className="pb-2 pr-4 font-medium text-right">
-                        Bonus
-                      </th>
-                      <th className="pb-2 font-medium">Date</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-market-500/8">
-                    {stats.payouts.map((payout) => (
-                      <PayoutRow key={payout.id} payout={payout} />
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <>
+                {/* Table view — sm and up. Issue #859: card view below takes
+                    over on narrow screens instead of forcing horizontal
+                    scroll on a 4-column table. */}
+                <div className="hidden sm:block overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-xs text-amber-700 border-b border-market-500/10">
+                        <th className="pb-2 pr-4 font-medium">Referee</th>
+                        <th className="pb-2 pr-4 font-medium">Job</th>
+                        <th className="pb-2 pr-4 font-medium text-right">
+                          Bonus
+                        </th>
+                        <th className="pb-2 font-medium">Date</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-market-500/8">
+                      {stats.payouts.map((payout) => (
+                        <PayoutRow key={payout.id} payout={payout} />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Card view — below sm. */}
+                <div className="sm:hidden space-y-2">
+                  {stats.payouts.map((payout) => (
+                    <PayoutCard key={payout.id} payout={payout} />
+                  ))}
+                </div>
+              </>
             ))}
         </div>
       ) : (
@@ -394,6 +406,33 @@ function RefereeRow({ referee }: { referee: ReferralReferee }) {
         )}
         <StatusBadge status={referee.status} />
       </div>
+    </div>
+  );
+}
+
+function PayoutCard({ payout }: { payout: ReferralPayout }) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2.5 rounded-xl bg-ink-900/40 border border-market-500/10">
+      <div className="min-w-0">
+        <p className="text-sm text-amber-100 truncate">{payout.jobTitle}</p>
+        <p className="text-xs text-amber-700 font-mono">
+          {shortenAddress(payout.refereeAddress)}
+        </p>
+        <p className="text-xs text-amber-800 mt-0.5">
+          {new Date(payout.createdAt).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })}
+        </p>
+      </div>
+      <span className="text-sm font-mono font-semibold text-emerald-400 flex-shrink-0">
+        +
+        {parseFloat(payout.amountXlm).toLocaleString("en-US", {
+          maximumFractionDigits: 4,
+        })}{" "}
+        XLM
+      </span>
     </div>
   );
 }

--- a/frontend/hooks/useRealtimeBids.ts
+++ b/frontend/hooks/useRealtimeBids.ts
@@ -112,12 +112,26 @@ export function useRealtimeBids({
     wsRef.current = ws;
     setWsStatus("connecting");
 
+    // React Strict Mode mounts, cleans up, then mounts again — the cleanup
+    // below closes `ws` and clears `wsRef.current`, but `WebSocket.close()`
+    // is asynchronous, so this socket's own `onclose` (and any in-flight
+    // `onmessage`) can still fire *after* the second mount has already
+    // created a brand-new socket and reassigned `wsRef.current` to it.
+    // Without this guard, the stale socket's `onclose` would null out the
+    // ref to the current, live socket and schedule a spurious reconnect —
+    // exactly the duplicate-connection bug this fixes. Every handler below
+    // checks it is still the connection `wsRef` currently points to before
+    // acting, so a superseded socket's late events are inert no-ops.
+    const isCurrent = () => wsRef.current === ws;
+
     ws.onopen = () => {
+      if (!isCurrent()) return;
       setWsStatus("open");
       clearPoll(); // WebSocket is up — stop polling
     };
 
     ws.onmessage = (event) => {
+      if (!isCurrent()) return;
       try {
         const { event: evtName, payload } = JSON.parse(event.data as string);
 
@@ -148,6 +162,7 @@ export function useRealtimeBids({
     };
 
     ws.onclose = () => {
+      if (!isCurrent()) return;
       wsRef.current = null;
       setWsStatus("closed");
       startPoll(); // start polling until we reconnect
@@ -157,6 +172,7 @@ export function useRealtimeBids({
     };
 
     ws.onerror = () => {
+      if (!isCurrent()) return;
       ws.close(); // triggers onclose → reconnect + poll
     };
   }, [jobId, clearPoll, startPoll, highlight, fadeRemove]);
@@ -172,9 +188,14 @@ export function useRealtimeBids({
 
     return () => {
       document.removeEventListener("visibilitychange", onVisibility);
+      // Clear the reconnect timer *before* closing the socket: closing
+      // triggers `onclose`, but that handler now checks `isCurrent()` and
+      // is a no-op for a ref that's about to be nulled below anyway — this
+      // ordering just avoids scheduling a reconnect that would immediately
+      // be orphaned by the unmount.
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
       wsRef.current?.close();
       wsRef.current = null;
-      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
       clearPoll();
     };
   }, [connect, clearPoll]);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2513,20 +2513,3 @@ export async function fetchDisputeOnchainCids(jobId: string): Promise<string[]> 
     return [];
   }
 }
-
-//  Dispute Evidence On-Chain Audit (Issue #448) 
-/**
- * Fetch the IPFS CIDs of dispute evidence anchored on-chain for a job.
- * Backed by GET /api/disputes/:jobId/onchain-cids. Returns an empty array
- * if the contract has no entries yet or the network is unreachable.
- */
-export async function fetchDisputeOnchainCids(jobId: string): Promise<string[]> {
-  try {
-    const { data } = await api.get<{ success: boolean; data: { cids: string[] } }>(
-      `/api/disputes/${encodeURIComponent(jobId)}/onchain-cids`,
-    );
-    return Array.isArray(data?.data?.cids) ? data.data.cids : [];
-  } catch {
-    return [];
-  }
-}

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -573,39 +573,70 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
         )}
 
       {/* Tabs */}
-      <div className="flex border-b border-market-500/10 mb-6 overflow-x-auto">
-        {(
-          [
-            "posted",
-            "applied",
-            "invitations",
-            "analytics",
-            "earnings",
-            ...(canViewSpending ? (["spending"] as Tab[]) : []),
-            "send",
-            "edit_profile",
-            "templates",
-            "price_alerts",
-            "withdrawals",
-            "saved_searches",
-          ] as Tab[]
-        ).map((t) => (
-          <button key={t} onClick={() => setTab(t)} className={clsx("px-6 py-3 text-sm font-medium transition-all border-b-2 -mb-px whitespace-nowrap", tab === t ? "border-market-400 text-market-300" : "border-transparent text-amber-700 hover:text-amber-400")}>
-            {t === "posted" ? `Jobs Posted (${myJobs.length})` :
-             t === "applied" ? `Applications (${myApplications.length})` :
-             t === "invitations" ? `Invitations${myInvitations.length > 0 ? ` (${myInvitations.length})` : ""}` :
-             t === "analytics" ? "Job Analytics" :
-             t === "earnings" ? "Earnings" :
-             t === "spending" ? "Spending" :
-             t === "send" ? "Send" :
-             t === "templates" ? "Templates" :
-             t === "price_alerts" ? "Price Alerts" :
-             t === "withdrawals" ? `Withdrawals (${withdrawHistory.length})` :
-             t === "saved_searches" ? `Saved Searches${savedSearches.length > 0 ? ` (${savedSearches.length})` : ""}` :
-             "Edit Profile"}
-          </button>
-        ))}
-      </div>
+      {(() => {
+        const tabIds: Tab[] = [
+          "posted",
+          "applied",
+          "invitations",
+          "analytics",
+          "earnings",
+          ...(canViewSpending ? (["spending"] as Tab[]) : []),
+          "send",
+          "edit_profile",
+          "templates",
+          "price_alerts",
+          "withdrawals",
+          "saved_searches",
+        ];
+        const tabLabel = (t: Tab): string =>
+          t === "posted" ? `Jobs Posted (${myJobs.length})` :
+          t === "applied" ? `Applications (${myApplications.length})` :
+          t === "invitations" ? `Invitations${myInvitations.length > 0 ? ` (${myInvitations.length})` : ""}` :
+          t === "analytics" ? "Job Analytics" :
+          t === "earnings" ? "Earnings" :
+          t === "spending" ? "Spending" :
+          t === "send" ? "Send" :
+          t === "templates" ? "Templates" :
+          t === "price_alerts" ? "Price Alerts" :
+          t === "withdrawals" ? `Withdrawals (${withdrawHistory.length})` :
+          t === "saved_searches" ? `Saved Searches${savedSearches.length > 0 ? ` (${savedSearches.length})` : ""}` :
+          "Edit Profile";
+
+        return (
+          <>
+            {/* Desktop/tablet: horizontal tab row — sm and up. */}
+            <div className="hidden sm:flex border-b border-market-500/10 mb-6 overflow-x-auto">
+              {tabIds.map((t) => (
+                <button key={t} onClick={() => setTab(t)} className={clsx("px-6 py-3 text-sm font-medium transition-all border-b-2 -mb-px whitespace-nowrap", tab === t ? "border-market-400 text-market-300" : "border-transparent text-amber-700 hover:text-amber-400")}>
+                  {tabLabel(t)}
+                </button>
+              ))}
+            </div>
+
+            {/* Mobile: dropdown — Issue #859. A 13-item horizontal tab bar
+                overflows and truncates on narrow screens; a native select
+                is both compact and gets the OS's own accessible picker UI
+                for free. */}
+            <div className="sm:hidden mb-6">
+              <label htmlFor="dashboard-tab-select" className="sr-only">
+                Dashboard section
+              </label>
+              <select
+                id="dashboard-tab-select"
+                value={tab}
+                onChange={(e) => setTab(e.target.value as Tab)}
+                className="w-full px-4 py-3 rounded-xl bg-ink-900/60 border border-market-500/20 text-sm font-medium text-amber-100"
+              >
+                {tabIds.map((t) => (
+                  <option key={t} value={t}>
+                    {tabLabel(t)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </>
+        );
+      })()}
 
         {loading ? (
           <div className="space-y-6 animate-pulse">

--- a/frontend/pages/jobs/index.tsx
+++ b/frontend/pages/jobs/index.tsx
@@ -102,6 +102,16 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [nextCursor, setNextCursor] = useState<string | null>(null);
+  // Mirrors `nextCursor` synchronously (state updates are async/batched, so a
+  // value read from `nextCursor` inside a callback that resumes after an
+  // `await` may be stale by then). `handleLoadMore` uses this to detect,
+  // *after* its fetch resolves, whether a filter change reset the cursor
+  // while the request was in flight — see the comment there (Issue #857).
+  const nextCursorRef = useRef<string | null>(null);
+  const setNextCursorTracked = useCallback((value: string | null) => {
+    nextCursorRef.current = value;
+    setNextCursor(value);
+  }, []);
   const [currentPage, setCurrentPage] = useState(1);
   const [userTimezone, setUserTimezone] = useState<string>("");
   const [manualTimezone, setManualTimezone] = useState<string>("");
@@ -311,6 +321,20 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
   useEffect(() => {
     if (!router.isReady) return;
 
+    // Issue #857: `handleLoadMore` reads `nextCursor` from state to fetch the
+    // next page, but this effect's own reload (triggered by any filter
+    // dependency below changing) is async — while it's in flight, `nextCursor`
+    // still holds the *previous* filter's cursor. If a "load more" trigger
+    // fires during that window, it would combine the new filters with a
+    // cursor computed under the old ones, producing wrong results (e.g.
+    // staying on page 3's cursor after switching category). Resetting it to
+    // null synchronously, before the async reload even starts, closes that
+    // race: `handleLoadMore`'s own `if (!nextCursor || loadingMore) return;`
+    // guard then blocks it until this effect's reload completes and sets the
+    // real cursor for the new filters.
+    setNextCursorTracked(null);
+    setCurrentPage(1);
+
     let isCancelled = false;
 
     async function loadJobs() {
@@ -362,7 +386,7 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
 
         if (!isCancelled) {
           setJobs(allJobs);
-          setNextCursor(loadedNextCursor);
+          setNextCursorTracked(loadedNextCursor);
           setCurrentPage(pagesLoaded);
         }
       } catch (_) {
@@ -506,6 +530,14 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
   const handleLoadMore = useCallback(async () => {
     if (!nextCursor || loadingMore) return;
 
+    // Captured up front: if a filter changes while this request is in
+    // flight, the reload effect resets `nextCursor`/`nextCursorRef` (Issue
+    // #857). Comparing against the ref (not the `nextCursor` closed over by
+    // this callback) after the `await` below tells us whether that happened,
+    // so this request's — now-stale — results are never applied on top of
+    // whatever the new filter has since loaded.
+    const requestCursor = nextCursor;
+
     setLoadingMore(true);
     setError(null);
 
@@ -517,7 +549,7 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
         status: status || undefined,
         limit: 20,
         search: search.trim() || undefined,
-        cursor: nextCursor,
+        cursor: requestCursor,
         timezone: activeTimezone || undefined,
         viewerAddress: viewerAddress || undefined,
         minBudget: minBudget || undefined,
@@ -529,12 +561,19 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
         maxApplications: filterQuery.maxApplications,
       });
 
+      if (nextCursorRef.current !== requestCursor) {
+        // A filter changed while this request was in flight — discard its
+        // result instead of appending stale jobs / overwriting the new
+        // filter's cursor with this one.
+        return;
+      }
+
       setJobs((prev) => {
         const seenIds = new Set(prev.map((job) => job.id));
         const uniqueNewJobs = result.jobs.filter((job) => !seenIds.has(job.id));
         return prev.concat(uniqueNewJobs);
       });
-      setNextCursor(result.nextCursor);
+      setNextCursorTracked(result.nextCursor);
 
       const nextPage = currentPage + 1;
       setCurrentPage(nextPage);


### PR DESCRIPTION
## Changes

- **#856 — WebSocket double-connect in Strict Mode:** `useRealtimeBids` already had a cleanup function (closes the socket, clears timers), but `WebSocket.close()` is asynchronous — in React Strict Mode's dev-only mount→cleanup→mount cycle, a stale socket's `onopen`/`onmessage`/`onclose` could still fire *after* a second socket had already taken over `wsRef.current`, nulling the ref to the live connection and triggering a spurious third reconnect. Every handler now checks it's still the connection `wsRef` points to before acting.
- **#857 — Pagination cursor not preserved across filter changes... in the wrong direction:** `nextCursor` persisted across a filter change while the reload it triggers is still in flight, so a "load more" firing in that window combined the *new* filter with the *old* cursor. Resets `nextCursor`/`currentPage` synchronously the moment any filter dependency changes. This surfaced a second, closely related race during testing: `handleLoadMore`'s own in-flight request (already using the old cursor) could resolve *after* the reset and silently reintroduce the same bug one layer later — overwriting the new filter's fresh cursor with its stale one. Guarded via a ref that mirrors `nextCursor` synchronously across the async boundary.
- **#858 — EarningsChart cumulative values:** the per-period computation itself was already correct — verified against the issue's exact repro (Jan $100 / Feb $200 / Mar $150), each amount lands in its own month, not a $450 grand total repeated everywhere. The actually-missing piece was the cumulative-vs-per-period toggle described in the acceptance criteria. Adds `buildCumulativeMonthlyData` and a view-mode switch. Also fixes the category pie chart's `ResponsiveContainer` — it had a hardcoded `width={200} height={200}`, which isn't actually responsive regardless of screen size — to fill a sized wrapper div instead.
- **#859 — Mobile responsive freelancer dashboard:** the 13-item tab bar (posted/applied/invitations/analytics/earnings/spending/send/etc.) is now a native `<select>` dropdown below 640px, with the existing horizontal tab row kept for sm and up. The referral payout history table gets a card-view alternative on narrow screens instead of forcing horizontal scroll on a 4-column table.

## Also fixed (blocking)

Removed an exact-duplicate `fetchDisputeOnchainCids` function definition in `lib/api.ts` (byte-identical bodies, clearly a bad merge artifact) — it broke Jest's SWC transform for *any* test importing from that module, including this PR's own new `EarningsChart` test.

## Test plan

- [x] `useRealtimeBids.test.ts` — 2 new tests using `renderHook` + `React.StrictMode`, including one that fails without the fix (verified) and one confirming unmount closes the socket
- [x] `jobs-pagination-reset.test.tsx` — verifies no `fetchJobs` call ever combines a stale cursor with a new filter through a real mid-flight race; fails without either half of the fix (verified independently)
- [x] `EarningsChart.transform.test.ts` — 7 tests covering per-period attribution (the issue's exact repro), same-month aggregation, the 12-month window, and the new cumulative transform
- [x] `tsc --noEmit` — clean on all touched files
- [x] Manual DevTools mobile-emulation testing (iPhone 12 / Galaxy S21) per the issue's acceptance criteria wasn't possible in this environment — verified via responsive Tailwind breakpoints and Jest/tsc instead

Closes #856
Closes #857
Closes #858
Closes #859