### PR TITLE
fix: realtime bid comparison reconnect churn, bulk job actions UI + batch API, wallet low-balance monitor

### DIFF
--- a/backend/src/db/pool.js
+++ b/backend/src/db/pool.js
@@ -31,3 +31,9 @@ function getPoolStats() {
 
 module.exports = pool;
 module.exports.getPoolStats = getPoolStats;
+// Single physical pool used for both reads and writes. Exposed under both
+// names so services that destructure `{ readPool, writePool }` (to keep the
+// door open for a future read-replica split) resolve to a real pool instead
+// of `undefined`.
+module.exports.readPool = pool;
+module.exports.writePool = pool;

--- a/backend/src/routes/jobs.js
+++ b/backend/src/routes/jobs.js
@@ -951,4 +951,23 @@ router.post(
   },
 );
 
+// POST /api/jobs/batch — bulk close or delete jobs in a single DB transaction
+// Body: { action: 'close'|'delete', ids: string[] } (max 50 ids)
+// Authorization is all-or-nothing: the caller must own every specified job.
+router.post(
+  "/batch",
+  verifyJWT,
+  jobCreationRateLimiter,
+  async (req, res, next) => {
+    try {
+      const { action, ids } = req.body;
+      const { batchJobAction } = require("../services/jobService");
+      const result = await batchJobAction(action, ids, req.user.publicKey);
+      res.json({ success: true, ...result });
+    } catch (e) {
+      next(e);
+    }
+  },
+);
+
 module.exports = router;

--- a/backend/src/services/jobService.batch.test.js
+++ b/backend/src/services/jobService.batch.test.js
@@ -1,0 +1,117 @@
+/**
+ * src/services/jobService.batch.test.js
+ * Unit tests for batchJobAction — the service backing POST /api/jobs/batch (#869).
+ */
+"use strict";
+
+jest.mock("../db/pool", () => {
+  const { createPgMock } = require("../testUtils/pgMock");
+  return createPgMock();
+});
+
+const pool = require("../db/pool");
+const { defaultJobRow } = require("../testUtils/pgMock");
+const { batchJobAction } = require("./jobService");
+
+describe("batchJobAction", () => {
+  const CLIENT = "GABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABC";
+  const OTHER_CLIENT = "GZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ";
+
+  beforeEach(() => {
+    pool.reset();
+  });
+
+  function seedJob(overrides = {}) {
+    const row = defaultJobRow({ client_address: CLIENT, ...overrides });
+    pool.jobs.set(row.id, row);
+    return row;
+  }
+
+  it("rejects an invalid action", async () => {
+    await expect(batchJobAction("nuke", ["job-1"], CLIENT)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("rejects an empty ids array", async () => {
+    await expect(batchJobAction("close", [], CLIENT)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("rejects more than 50 ids in a single request", async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => `job-${i}`);
+    await expect(batchJobAction("close", ids, CLIENT)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("rejects the whole batch if the client does not own every job", async () => {
+    const mine = seedJob({ id: "job-mine", status: "open" });
+    const theirs = seedJob({
+      id: "job-theirs",
+      status: "open",
+      client_address: OTHER_CLIENT,
+    });
+
+    await expect(
+      batchJobAction("close", [mine.id, theirs.id], CLIENT),
+    ).rejects.toMatchObject({ status: 403 });
+
+    // Nothing should have been mutated — authorization is checked up front.
+    expect(pool.jobs.get(mine.id).status).toBe("open");
+  });
+
+  it("rejects the whole batch if any id does not exist", async () => {
+    const mine = seedJob({ id: "job-real", status: "open" });
+
+    await expect(
+      batchJobAction("close", [mine.id, "job-does-not-exist"], CLIENT),
+    ).rejects.toMatchObject({ status: 403 });
+
+    expect(pool.jobs.get(mine.id).status).toBe("open");
+  });
+
+  it("closes open jobs and reports non-open jobs as failed", async () => {
+    const openJob = seedJob({ id: "job-open", status: "open" });
+    const inProgressJob = seedJob({ id: "job-in-progress", status: "in_progress" });
+
+    const result = await batchJobAction(
+      "close",
+      [openJob.id, inProgressJob.id],
+      CLIENT,
+    );
+
+    expect(result.succeeded).toEqual([openJob.id]);
+    expect(result.failed).toEqual([
+      { id: inProgressJob.id, error: expect.stringContaining("not open") },
+    ]);
+    expect(pool.jobs.get(openJob.id).status).toBe("cancelled");
+    expect(pool.jobs.get(inProgressJob.id).status).toBe("in_progress");
+  });
+
+  it("soft-deletes jobs and reports in-progress jobs as failed", async () => {
+    const openJob = seedJob({ id: "job-open-2", status: "open" });
+    const inProgressJob = seedJob({ id: "job-in-progress-2", status: "in_progress" });
+
+    const result = await batchJobAction(
+      "delete",
+      [openJob.id, inProgressJob.id],
+      CLIENT,
+    );
+
+    expect(result.succeeded).toEqual([openJob.id]);
+    expect(result.failed).toEqual([
+      { id: inProgressJob.id, error: expect.stringContaining("in progress") },
+    ]);
+    expect(pool.jobs.get(openJob.id).deleted_at).toBeTruthy();
+    expect(pool.jobs.get(inProgressJob.id).deleted_at).toBeFalsy();
+  });
+
+  it("deduplicates repeated ids in the same request", async () => {
+    const openJob = seedJob({ id: "job-dup", status: "open" });
+    const result = await batchJobAction("close", [openJob.id, openJob.id], CLIENT);
+    expect(result.succeeded).toEqual([openJob.id]);
+    expect(result.failed).toEqual([]);
+  });
+});

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -1253,6 +1253,120 @@ async function bulkBoostJobs(jobIds, clientAddress, txHash) {
   return results;
 }
 
+const BATCH_ACTIONS = ["close", "delete"];
+const MAX_BATCH_SIZE = 50;
+
+/**
+ * Run a bulk "close" (cancel) or "delete" (soft-delete) operation for a set
+ * of jobs owned by a single client, inside one DB transaction.
+ *
+ * Authorization is all-or-nothing: if any requested id does not belong to
+ * `clientAddress` (or does not exist), the whole request is rejected before
+ * anything is written. Once authorized, each job is updated independently —
+ * a job whose current state doesn't allow the action (e.g. closing a job
+ * that isn't `open`) is reported in `failed` rather than aborting the batch.
+ *
+ * @param {"close"|"delete"} action
+ * @param {string[]} ids - Up to {@link MAX_BATCH_SIZE} job ids.
+ * @param {string} clientAddress - Stellar address of the authenticated client.
+ * @returns {Promise<{succeeded: string[], failed: {id: string, error: string}[]}>}
+ * @throws {Error} status 400 for invalid input, 403 if the client doesn't own every id.
+ */
+async function batchJobAction(action, ids, clientAddress) {
+  if (!BATCH_ACTIONS.includes(action)) {
+    const e = new Error("action must be 'close' or 'delete'");
+    e.status = 400;
+    throw e;
+  }
+  if (!Array.isArray(ids) || ids.length === 0) {
+    const e = new Error("ids must be a non-empty array");
+    e.status = 400;
+    throw e;
+  }
+  if (ids.length > MAX_BATCH_SIZE) {
+    const e = new Error(`Maximum ${MAX_BATCH_SIZE} ids per batch request`);
+    e.status = 400;
+    throw e;
+  }
+
+  const uniqueIds = [...new Set(ids)];
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const { rows: foundJobs } = await client.query(
+      `SELECT id, status, client_address, deleted_at FROM jobs WHERE id = ANY($1::text[])`,
+      [uniqueIds],
+    );
+    const foundById = new Map(foundJobs.map((j) => [String(j.id), j]));
+
+    const unauthorizedIds = uniqueIds.filter((id) => {
+      const job = foundById.get(String(id));
+      return !job || job.deleted_at || job.client_address !== clientAddress;
+    });
+    if (unauthorizedIds.length > 0) {
+      const e = new Error("You do not own all specified jobs");
+      e.status = 403;
+      throw e;
+    }
+
+    const succeeded = [];
+    const failed = [];
+
+    for (const id of uniqueIds) {
+      const job = foundById.get(String(id));
+      try {
+        if (action === "close") {
+          if (job.status !== "open") {
+            failed.push({ id, error: `Job is not open (status: ${job.status})` });
+            continue;
+          }
+          const { rows } = await client.query(
+            `UPDATE jobs SET status = 'cancelled', updated_at = NOW()
+             WHERE id = $1 AND client_address = $2 AND status = 'open' AND deleted_at IS NULL
+             RETURNING id`,
+            [id, clientAddress],
+          );
+          if (rows.length === 0) {
+            failed.push({ id, error: "Job could not be closed" });
+            continue;
+          }
+        } else {
+          if (job.status === "in_progress") {
+            failed.push({ id, error: "Cannot delete a job that is in progress" });
+            continue;
+          }
+          const { rows } = await client.query(
+            `UPDATE jobs SET deleted_at = NOW(), updated_at = NOW()
+             WHERE id = $1 AND client_address = $2 AND deleted_at IS NULL
+             RETURNING id`,
+            [id, clientAddress],
+          );
+          if (rows.length === 0) {
+            failed.push({ id, error: "Job could not be deleted" });
+            continue;
+          }
+        }
+        succeeded.push(id);
+      } catch (err) {
+        failed.push({ id, error: err.message || "Unknown error" });
+      }
+    }
+
+    await client.query("COMMIT");
+    return { succeeded, failed };
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // ignore rollback errors — connection may already be closed
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 /**
  * Get recommended jobs for a freelancer based on their skills.
  * Excludes jobs the freelancer has already applied to, been accepted for, or rejected from.
@@ -1362,6 +1476,7 @@ module.exports = {
   bulkCancelJobs,
   bulkExtendJobs,
   bulkBoostJobs,
+  batchJobAction,
   getRecommendedJobs,
   getSuggestions,
   rowToJob,

--- a/backend/src/testUtils/pgMock.js
+++ b/backend/src/testUtils/pgMock.js
@@ -182,6 +182,44 @@ function createPgMock() {
     }
 
 
+    if (text.startsWith("SELECT id, status, client_address, deleted_at FROM jobs WHERE id = ANY")) {
+      const ids = params[0] || [];
+      const rows = ids
+        .map((id) => jobs.get(id))
+        .filter(Boolean)
+        .map((job) => ({
+          id: job.id,
+          status: job.status,
+          client_address: job.client_address,
+          deleted_at: job.deleted_at || null,
+        }));
+      return { rows };
+    }
+
+    if (text.startsWith("UPDATE jobs SET status = 'cancelled', updated_at = NOW()")) {
+      const [id, clientAddress] = params;
+      const row = jobs.get(id);
+      if (!row || row.client_address !== clientAddress || row.status !== "open" || row.deleted_at) {
+        return { rows: [] };
+      }
+      row.status = "cancelled";
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [{ id: row.id }] };
+    }
+
+    if (text.startsWith("UPDATE jobs SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1 AND client_address = $2")) {
+      const [id, clientAddress] = params;
+      const row = jobs.get(id);
+      if (!row || row.client_address !== clientAddress || row.deleted_at) {
+        return { rows: [] };
+      }
+      row.deleted_at = new Date().toISOString();
+      row.updated_at = row.deleted_at;
+      jobs.set(row.id, row);
+      return { rows: [{ id: row.id }] };
+    }
+
     if (text.startsWith("UPDATE jobs SET escrow_contract_id")) {
       const row = jobs.get(params[1]);
       if (!row) return { rows: [] };
@@ -349,7 +387,12 @@ function createPgMock() {
     connect.mockClear();
   }
 
-  return { query, connect, jobs, applications, invitations, reset, end: jest.fn() };
+  const api = { query, connect, jobs, applications, invitations, reset, end: jest.fn() };
+  // Mirror the real pool.js module, which exposes the same pool under both
+  // `readPool` and `writePool` — services destructure those names.
+  api.readPool = api;
+  api.writePool = api;
+  return api;
 }
 
 module.exports = { createPgMock, defaultJobRow, defaultApplicationRow };

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,5 +4,9 @@ NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 NEXT_PUBLIC_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 NEXT_PUBLIC_USE_CONTRACT_MOCK=false
+# Platform treasury address that receives job-boost payments (BoostJobModal
+# and the dashboard's bulk "Boost Selected" action). Falls back to the
+# client's own address in dev if left unset.
+NEXT_PUBLIC_TREASURY_ADDRESS=
 NEXT_PUBLIC_CDN_URL=
 IMAGE_CDN_URL=

--- a/frontend/__tests__/bulk-job-action-bar.test.tsx
+++ b/frontend/__tests__/bulk-job-action-bar.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * __tests__/bulk-job-action-bar.test.tsx
+ * Issue #868 — integration tests for BulkJobActionBar: it should only
+ * appear once 2+ jobs are selected, confirm before destructive actions,
+ * and surface the succeeded/failed results of each action.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import BulkJobActionBar from "@/components/BulkJobActionBar";
+import type { BulkActionResponse } from "@/utils/types";
+
+function okResponse(succeeded: number, failed = 0): BulkActionResponse {
+  return {
+    success: failed === 0,
+    succeeded,
+    failed,
+    processedCount: succeeded + failed,
+    failedCount: failed,
+    results: [
+      ...Array.from({ length: succeeded }, (_, i) => ({ id: `ok-${i}`, success: true as const })),
+      ...Array.from({ length: failed }, (_, i) => ({
+        id: `bad-${i}`,
+        success: false as const,
+        error: "not open",
+      })),
+    ],
+  };
+}
+
+describe("BulkJobActionBar (#868)", () => {
+  it("renders nothing when fewer than 2 jobs are selected", () => {
+    const { container } = render(
+      <BulkJobActionBar
+        selectedCount={1}
+        onClose={jest.fn()}
+        onDelete={jest.fn()}
+        onBoost={jest.fn()}
+        onClearSelection={jest.fn()}
+        loading={false}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("appears once 2+ jobs are selected, with all three actions", () => {
+    render(
+      <BulkJobActionBar
+        selectedCount={3}
+        onClose={jest.fn()}
+        onDelete={jest.fn()}
+        onBoost={jest.fn()}
+        onClearSelection={jest.fn()}
+        loading={false}
+      />,
+    );
+    expect(screen.getByRole("toolbar", { name: /bulk job actions/i })).toBeInTheDocument();
+    expect(screen.getByText("Close Selected")).toBeInTheDocument();
+    expect(screen.getByText("Delete Selected")).toBeInTheDocument();
+    expect(screen.getByText("Boost Selected")).toBeInTheDocument();
+  });
+
+  it("requires confirmation before closing jobs, and only calls onClose after confirming", async () => {
+    const onClose = jest.fn().mockResolvedValue(okResponse(2));
+    render(
+      <BulkJobActionBar
+        selectedCount={2}
+        onClose={onClose}
+        onDelete={jest.fn()}
+        onBoost={jest.fn()}
+        onClearSelection={jest.fn()}
+        loading={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Close Selected"));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/Close 2 jobs\?/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Yes, Close"));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("requires confirmation before deleting jobs, and 'Keep Jobs' cancels without calling onDelete", () => {
+    const onDelete = jest.fn();
+    render(
+      <BulkJobActionBar
+        selectedCount={2}
+        onClose={jest.fn()}
+        onDelete={onDelete}
+        onBoost={jest.fn()}
+        onClearSelection={jest.fn()}
+        loading={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Delete Selected"));
+    expect(screen.getByText(/Delete 2 jobs\?/)).toBeInTheDocument();
+    expect(screen.getByText(/This cannot be undone/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Keep Jobs"));
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("boosting does not require a confirmation dialog", async () => {
+    const onBoost = jest.fn().mockResolvedValue(okResponse(2));
+    render(
+      <BulkJobActionBar
+        selectedCount={2}
+        onClose={jest.fn()}
+        onDelete={jest.fn()}
+        onBoost={onBoost}
+        onClearSelection={jest.fn()}
+        loading={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Boost Selected"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await waitFor(() => expect(onBoost).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows a summary of succeeded/failed jobs after a batch action completes", async () => {
+    const onDelete = jest.fn().mockResolvedValue(okResponse(1, 1));
+    render(
+      <BulkJobActionBar
+        selectedCount={2}
+        onClose={jest.fn()}
+        onDelete={onDelete}
+        onBoost={jest.fn()}
+        onClearSelection={jest.fn()}
+        loading={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Delete Selected"));
+    fireEvent.click(screen.getByText("Yes, Delete"));
+
+    await waitFor(() => expect(screen.getByText(/1 succeeded, 1 failed/)).toBeInTheDocument());
+    expect(screen.getByText(/not open/)).toBeInTheDocument();
+  });
+
+  it("clears the selection via the toolbar's clear button", () => {
+    const onClearSelection = jest.fn();
+    render(
+      <BulkJobActionBar
+        selectedCount={2}
+        onClose={jest.fn()}
+        onDelete={jest.fn()}
+        onBoost={jest.fn()}
+        onClearSelection={onClearSelection}
+        loading={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Clear selection"));
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables action buttons while loading", () => {
+    render(
+      <BulkJobActionBar
+        selectedCount={2}
+        onClose={jest.fn()}
+        onDelete={jest.fn()}
+        onBoost={jest.fn()}
+        onClearSelection={jest.fn()}
+        loading
+      />,
+    );
+
+    expect(screen.getByText("Close Selected").closest("button")).toBeDisabled();
+    expect(screen.getByText("Delete Selected").closest("button")).toBeDisabled();
+    expect(screen.getByText("Boost Selected").closest("button")).toBeDisabled();
+  });
+});

--- a/frontend/__tests__/realtime-bid-comparison.test.tsx
+++ b/frontend/__tests__/realtime-bid-comparison.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * __tests__/realtime-bid-comparison.test.tsx
+ * Issue #867 — RealtimeBidComparison must update live as new bids arrive
+ * over the `job:{id}:bids` WebSocket event, rather than only showing the
+ * applications it was initially rendered with.
+ *
+ * Uses a mocked WebSocket (jsdom does not implement a real one) to drive
+ * the component through useRealtimeBids.
+ */
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { ToastProvider } from "@/components/Toast";
+import RealtimeBidComparison from "@/components/RealtimeBidComparison";
+import type { Application } from "@/utils/types";
+
+// ── Mock WebSocket ────────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  url: string;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  /** Test helper — simulate the server accepting the connection. */
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  /** Test helper — simulate an inbound `{event, payload}` frame. */
+  simulateMessage(event: string, payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify({ event, payload }) });
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+const originalWebSocket = global.WebSocket;
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  // @ts-expect-error — test double, not a full WebSocket implementation
+  global.WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+  cleanup();
+  global.WebSocket = originalWebSocket;
+  jest.restoreAllMocks();
+});
+
+function renderComparison(props: Partial<React.ComponentProps<typeof RealtimeBidComparison>> = {}) {
+  return render(
+    <ToastProvider>
+      <RealtimeBidComparison
+        jobId="job-1"
+        initialApplications={[]}
+        isClient
+        {...props}
+      />
+    </ToastProvider>,
+  );
+}
+
+const newApplication: Application = {
+  id: "app-new",
+  jobId: "job-1",
+  freelancerAddress: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+  proposal: "I can deliver this within a week using Soroban.",
+  bidAmount: "300.0000000",
+  currency: "XLM",
+  status: "pending",
+  createdAt: "2026-01-15T00:00:00.000Z",
+};
+
+describe("RealtimeBidComparison — live updates over WebSocket (#867)", () => {
+  it("connects to /ws/realtime scoped by job id", () => {
+    renderComparison();
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].url).toContain("/ws/realtime");
+  });
+
+  it("appends a new bid the moment a job:{id}:bids new_bid event arrives", () => {
+    renderComparison();
+    const ws = MockWebSocket.instances[0];
+
+    expect(screen.queryByText(/I can deliver this within a week/)).not.toBeInTheDocument();
+
+    act(() => {
+      ws.simulateOpen();
+      ws.simulateMessage("job:job-1:bids", {
+        type: "new_bid",
+        application: newApplication,
+      });
+    });
+
+    expect(screen.getByText(/I can deliver this within a week/)).toBeInTheDocument();
+    expect(screen.getByText(/Applications \(1\)/)).toBeInTheDocument();
+  });
+
+  it("ignores bid events for a different job id", () => {
+    renderComparison();
+    const ws = MockWebSocket.instances[0];
+
+    act(() => {
+      ws.simulateOpen();
+      ws.simulateMessage("job:some-other-job:bids", {
+        type: "new_bid",
+        application: newApplication,
+      });
+    });
+
+    expect(screen.queryByText(/I can deliver this within a week/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Applications \(0\)/)).toBeInTheDocument();
+  });
+
+  it("does not duplicate a bid that is already in the list", () => {
+    renderComparison({ initialApplications: [newApplication] });
+    const ws = MockWebSocket.instances[0];
+
+    act(() => {
+      ws.simulateOpen();
+      ws.simulateMessage("job:job-1:bids", {
+        type: "new_bid",
+        application: newApplication,
+      });
+    });
+
+    expect(screen.getByText(/Applications \(1\)/)).toBeInTheDocument();
+  });
+
+  it("removes a bid when application:withdrawn arrives", () => {
+    jest.useFakeTimers();
+    renderComparison({ initialApplications: [newApplication] });
+    const ws = MockWebSocket.instances[0];
+
+    act(() => {
+      ws.simulateOpen();
+      ws.simulateMessage("job:job-1:bids", {
+        type: "application:withdrawn",
+        applicationId: newApplication.id,
+      });
+      jest.advanceTimersByTime(500); // past the fade-out timeout
+    });
+
+    expect(screen.getByText(/Applications \(0\)/)).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it("does not reconnect the WebSocket across re-renders (regression for #867)", () => {
+    // RealtimeBidComparison doesn't pass a `fetchApplications` prop, so it
+    // falls back to an inline `() => Promise.resolve(initialApplications)`
+    // — a new function identity on every render. If useRealtimeBids ever
+    // depends on that identity again, this test will start failing because
+    // a second WebSocket gets opened.
+    renderComparison();
+    const ws = MockWebSocket.instances[0];
+
+    act(() => {
+      ws.simulateOpen();
+      ws.simulateMessage("job:job-1:bids", {
+        type: "new_bid",
+        application: newApplication,
+      });
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(ws.readyState).toBe(MockWebSocket.OPEN);
+  });
+
+  it("shows a live indicator once the socket reports open", () => {
+    renderComparison();
+    const ws = MockWebSocket.instances[0];
+
+    expect(screen.queryByText("Live")).not.toBeInTheDocument();
+
+    act(() => {
+      ws.simulateOpen();
+    });
+
+    expect(screen.getByText("Live")).toBeInTheDocument();
+    // The connection must not have been torn down and reopened as a
+    // side effect of the resulting re-render (that reconnect churn was
+    // the root cause of #867).
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/frontend/__tests__/snapshots/__snapshots__/staticComponents.snap.test.tsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/staticComponents.snap.test.tsx.snap
@@ -399,13 +399,13 @@ exports[`static component snapshots BulkJobActionBar default: BulkJobActionBar 1
       viewBox="0 0 24 24"
     >
       <path
-        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+        d="M6 18L18 6M6 6l12 12"
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="2"
       />
     </svg>
-    Extend
+    Close Selected
   </button>
   <button
     class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium bg-ink-700 border border-amber-500/20 text-amber-300 hover:border-amber-400 hover:text-amber-200 transition-all disabled:opacity-50"
@@ -423,7 +423,7 @@ exports[`static component snapshots BulkJobActionBar default: BulkJobActionBar 1
         stroke-width="2"
       />
     </svg>
-    Boost
+    Boost Selected
   </button>
   <button
     class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium bg-red-500/10 border border-red-500/20 text-red-400 hover:border-red-400 hover:bg-red-500/15 transition-all disabled:opacity-50"
@@ -435,13 +435,13 @@ exports[`static component snapshots BulkJobActionBar default: BulkJobActionBar 1
       viewBox="0 0 24 24"
     >
       <path
-        d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3M4 7h16"
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="2"
       />
     </svg>
-    Cancel Jobs
+    Delete Selected
   </button>
 </div>
 `;
@@ -498,13 +498,13 @@ exports[`static component snapshots BulkJobActionBar loading: BulkJobActionBar l
       viewBox="0 0 24 24"
     >
       <path
-        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+        d="M6 18L18 6M6 6l12 12"
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="2"
       />
     </svg>
-    Extend
+    Close Selected
   </button>
   <button
     class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium bg-ink-700 border border-amber-500/20 text-amber-300 hover:border-amber-400 hover:text-amber-200 transition-all disabled:opacity-50"
@@ -523,7 +523,7 @@ exports[`static component snapshots BulkJobActionBar loading: BulkJobActionBar l
         stroke-width="2"
       />
     </svg>
-    Boost
+    Boost Selected
   </button>
   <button
     class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium bg-red-500/10 border border-red-500/20 text-red-400 hover:border-red-400 hover:bg-red-500/15 transition-all disabled:opacity-50"
@@ -536,13 +536,13 @@ exports[`static component snapshots BulkJobActionBar loading: BulkJobActionBar l
       viewBox="0 0 24 24"
     >
       <path
-        d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3M4 7h16"
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="2"
       />
     </svg>
-    Cancel Jobs
+    Delete Selected
   </button>
 </div>
 `;

--- a/frontend/__tests__/snapshots/staticComponents.snap.test.tsx
+++ b/frontend/__tests__/snapshots/staticComponents.snap.test.tsx
@@ -194,8 +194,8 @@ describe("static component snapshots", () => {
         <BulkJobActionBar
           selectedCount={2}
           loading={false}
-          onCancel={noop}
-          onExtend={noop}
+          onClose={noop}
+          onDelete={noop}
           onBoost={noop}
           onClearSelection={noop}
         />,
@@ -206,8 +206,8 @@ describe("static component snapshots", () => {
         <BulkJobActionBar
           selectedCount={2}
           loading
-          onCancel={noop}
-          onExtend={noop}
+          onClose={noop}
+          onDelete={noop}
           onBoost={noop}
           onClearSelection={noop}
         />,

--- a/frontend/__tests__/wallet-account-monitor.test.tsx
+++ b/frontend/__tests__/wallet-account-monitor.test.tsx
@@ -21,8 +21,18 @@ jest.mock("@/lib/api", () => ({
   getJwtToken: jest.fn().mockReturnValue(null),
 }));
 
+jest.mock("@/lib/stellar", () => ({
+  getXLMBalance: jest.fn().mockResolvedValue("100"),
+}));
+
+jest.mock("@/components/BuyXLMModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockInfo = jest.fn();
 jest.mock("@/components/Toast", () => ({
-  useToast: () => ({ success: jest.fn(), error: jest.fn(), info: jest.fn() }),
+  useToast: () => ({ success: jest.fn(), error: jest.fn(), info: mockInfo }),
   ToastProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
@@ -31,6 +41,7 @@ jest.mock("@/components/Toast", () => ({
 import WalletAccountMonitor from "@/components/WalletAccountMonitor";
 import * as walletLib from "@/lib/wallet";
 import * as apiLib from "@/lib/api";
+import * as stellarLib from "@/lib/stellar";
 
 const MOCK_PK = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 const MOCK_PK_B = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
@@ -49,14 +60,17 @@ describe("WalletAccountMonitor (#499)", () => {
     jest.restoreAllMocks();
   });
 
-  it("renders nothing (null output)", () => {
+  it("renders nothing (null output)", async () => {
     const { container } = render(
       <WalletAccountMonitor currentPublicKey={MOCK_PK} onDisconnect={onDisconnect} />,
     );
+    // Flush the initial balance poll (#871) so its state update doesn't leak
+    // into the next test as an unwrapped act() warning.
+    await act(async () => {});
     expect(container.firstChild).toBeNull();
   });
 
-  it("subscribes via subscribeToAccountChanges on mount and unsubscribes on unmount", () => {
+  it("subscribes via subscribeToAccountChanges on mount and unsubscribes on unmount", async () => {
     const unsubscribe = jest.fn();
     jest.spyOn(walletLib, "subscribeToAccountChanges").mockReturnValue(unsubscribe);
 
@@ -65,6 +79,7 @@ describe("WalletAccountMonitor (#499)", () => {
     );
     expect(walletLib.subscribeToAccountChanges).toHaveBeenCalledWith(expect.any(Function));
 
+    await act(async () => {});
     unmount();
     expect(unsubscribe).toHaveBeenCalled();
   });
@@ -158,5 +173,91 @@ describe("WalletAccountMonitor (#499)", () => {
 
     expect(onDisconnect).not.toHaveBeenCalled();
     jest.useRealTimers();
+  });
+});
+
+describe("WalletAccountMonitor — low-balance monitoring (#871)", () => {
+  let onDisconnect: jest.Mock;
+  let onBalanceChange: jest.Mock;
+
+  beforeEach(() => {
+    onDisconnect = jest.fn();
+    onBalanceChange = jest.fn();
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem("smp_wallet_public_key", MOCK_PK);
+    jest.spyOn(walletLib, "subscribeToAccountChanges").mockReturnValue(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("polls Horizon via getXLMBalance on mount and reports the balance upward", async () => {
+    jest.spyOn(stellarLib, "getXLMBalance").mockResolvedValue("42.5");
+
+    render(
+      <WalletAccountMonitor
+        currentPublicKey={MOCK_PK}
+        onDisconnect={onDisconnect}
+        onBalanceChange={onBalanceChange}
+      />,
+    );
+
+    await waitFor(() => expect(stellarLib.getXLMBalance).toHaveBeenCalledWith(MOCK_PK));
+    await waitFor(() => expect(onBalanceChange).toHaveBeenCalledWith("42.5"));
+  });
+
+  it("shows a low-balance banner once the balance drops below 5 XLM", async () => {
+    jest.spyOn(stellarLib, "getXLMBalance").mockResolvedValue("2.5");
+
+    const { findByRole } = render(
+      <WalletAccountMonitor currentPublicKey={MOCK_PK} onDisconnect={onDisconnect} />,
+    );
+
+    const banner = await findByRole("alert");
+    expect(banner.textContent).toContain("2.50 XLM");
+  });
+
+  it("does not show a banner when the balance is at or above the 5 XLM reserve", async () => {
+    jest.spyOn(stellarLib, "getXLMBalance").mockResolvedValue("50");
+
+    render(
+      <WalletAccountMonitor currentPublicKey={MOCK_PK} onDisconnect={onDisconnect} />,
+    );
+
+    await waitFor(() => expect(stellarLib.getXLMBalance).toHaveBeenCalled());
+    expect(mockInfo).not.toHaveBeenCalled();
+  });
+
+  it("fires a one-time warning toast once the balance drops below 10 XLM", async () => {
+    jest.spyOn(stellarLib, "getXLMBalance").mockResolvedValue("8");
+
+    render(
+      <WalletAccountMonitor currentPublicKey={MOCK_PK} onDisconnect={onDisconnect} />,
+    );
+
+    await waitFor(() =>
+      expect(mockInfo).toHaveBeenCalledWith(expect.stringContaining("Low balance warning")),
+    );
+    expect(mockInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the user dismiss the banner for the session", async () => {
+    jest.spyOn(stellarLib, "getXLMBalance").mockResolvedValue("1");
+
+    const { findByRole, queryByRole } = render(
+      <WalletAccountMonitor currentPublicKey={MOCK_PK} onDisconnect={onDisconnect} />,
+    );
+
+    const banner = await findByRole("alert");
+    const dismissButton = banner.querySelector('[aria-label="Dismiss low balance banner"]');
+    expect(dismissButton).not.toBeNull();
+
+    await act(async () => {
+      dismissButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(queryByRole("alert")).toBeNull();
   });
 });

--- a/frontend/components/BulkJobActionBar.tsx
+++ b/frontend/components/BulkJobActionBar.tsx
@@ -1,9 +1,11 @@
 /**
  * components/BulkJobActionBar.tsx
  *
- * Floating action bar that appears when one or more job cards are selected.
- * Shows the selection count and action buttons: Extend, Boost, Cancel.
- * Cancel triggers a confirmation modal before proceeding.
+ * Floating action bar that appears once 2+ job cards are selected via
+ * checkboxes (see PostedJobsTab). Shows the selection count and action
+ * buttons: Close Selected, Delete Selected, Boost Selected.
+ * Close and Delete are destructive and require confirmation before
+ * proceeding; Delete is irreversible.
  */
 import { useState } from "react";
 import clsx from "clsx";
@@ -11,45 +13,73 @@ import type { BulkActionResponse } from "@/utils/types";
 
 interface BulkJobActionBarProps {
   selectedCount: number;
-  onCancel: () => Promise<BulkActionResponse>;
-  onExtend: () => Promise<BulkActionResponse>;
+  onClose: () => Promise<BulkActionResponse>;
+  onDelete: () => Promise<BulkActionResponse>;
   onBoost: () => Promise<BulkActionResponse>;
   onClearSelection: () => void;
   loading: boolean;
 }
 
-type ActiveAction = "cancel" | "extend" | "boost" | null;
+type ActiveAction = "close" | "delete" | "boost" | null;
+type ConfirmAction = "close" | "delete" | null;
 
 export default function BulkJobActionBar({
   selectedCount,
-  onCancel,
-  onExtend,
+  onClose,
+  onDelete,
   onBoost,
   onClearSelection,
   loading,
 }: BulkJobActionBarProps) {
-  const [confirmAction, setConfirmAction] = useState<ActiveAction>(null);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null);
   const [result, setResult] = useState<BulkActionResponse | null>(null);
 
-  if (selectedCount === 0) return null;
+  // Only shown once 2+ jobs are selected — a single job already has
+  // per-row actions (Extend, Repost, etc.) in PostedJobsTab.
+  if (selectedCount < 2) return null;
 
   const handleAction = async (action: ActiveAction) => {
     if (!action) return;
     setResult(null);
 
     let res: BulkActionResponse;
-    if (action === "cancel") res = await onCancel();
-    else if (action === "extend") res = await onExtend();
+    if (action === "close") res = await onClose();
+    else if (action === "delete") res = await onDelete();
     else res = await onBoost();
 
     setResult(res);
     setConfirmAction(null);
   };
 
-  const actionLabel = (a: ActiveAction) => {
-    if (a === "cancel") return "Cancel Jobs";
-    if (a === "extend") return "Extend Jobs";
-    return "Boost Jobs";
+  const confirmCopy = (a: ConfirmAction) => {
+    if (a === "delete") {
+      return {
+        title: `Delete ${selectedCount} job${selectedCount !== 1 ? "s" : ""}?`,
+        warning: "This cannot be undone.",
+        body: (
+          <>
+            Deleted jobs are removed from your dashboard permanently. Jobs
+            that are <span className="text-amber-300 font-medium">in progress</span>{" "}
+            will be skipped.
+          </>
+        ),
+        confirmLabel: "Yes, Delete",
+        confirmingLabel: "Deleting…",
+      };
+    }
+    return {
+      title: `Close ${selectedCount} job${selectedCount !== 1 ? "s" : ""}?`,
+      warning: "This cannot be undone.",
+      body: (
+        <>
+          Only <span className="text-amber-300 font-medium">open</span> jobs
+          will be closed. Jobs that are in progress, completed, or already
+          closed will be skipped.
+        </>
+      ),
+      confirmLabel: "Yes, Close",
+      confirmingLabel: "Closing…",
+    };
   };
 
   return (
@@ -98,9 +128,9 @@ export default function BulkJobActionBar({
           </button>
         </div>
 
-        {/* Extend */}
+        {/* Close — destructive, requires confirmation */}
         <button
-          onClick={() => handleAction("extend")}
+          onClick={() => setConfirmAction("close")}
           disabled={loading}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium bg-ink-700 border border-market-500/20 text-amber-200 hover:border-market-400 hover:text-market-300 transition-all disabled:opacity-50"
         >
@@ -114,10 +144,10 @@ export default function BulkJobActionBar({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth={2}
-              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              d="M6 18L18 6M6 6l12 12"
             />
           </svg>
-          Extend
+          Close Selected
         </button>
 
         {/* Boost */}
@@ -139,12 +169,12 @@ export default function BulkJobActionBar({
               d="M13 10V3L4 14h7v7l9-11h-7z"
             />
           </svg>
-          Boost
+          Boost Selected
         </button>
 
-        {/* Cancel — destructive, requires confirmation */}
+        {/* Delete — destructive & irreversible, requires confirmation */}
         <button
-          onClick={() => setConfirmAction("cancel")}
+          onClick={() => setConfirmAction("delete")}
           disabled={loading}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium bg-red-500/10 border border-red-500/20 text-red-400 hover:border-red-400 hover:bg-red-500/15 transition-all disabled:opacity-50"
         >
@@ -158,15 +188,15 @@ export default function BulkJobActionBar({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth={2}
-              d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3M4 7h16"
             />
           </svg>
-          Cancel Jobs
+          Delete Selected
         </button>
       </div>
 
       {/* ── Confirmation modal ──────────────────────────────────────────── */}
-      {confirmAction === "cancel" && (
+      {confirmAction && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-ink-950/80 backdrop-blur-sm"
           role="dialog"
@@ -195,17 +225,15 @@ export default function BulkJobActionBar({
                   id="bulk-confirm-title"
                   className="font-display font-semibold text-amber-100"
                 >
-                  Cancel {selectedCount} job{selectedCount !== 1 ? "s" : ""}?
+                  {confirmCopy(confirmAction).title}
                 </h3>
                 <p className="text-xs text-amber-700 mt-0.5">
-                  This cannot be undone.
+                  {confirmCopy(confirmAction).warning}
                 </p>
               </div>
             </div>
             <p className="text-sm text-amber-700 mb-6">
-              Only <span className="text-amber-300 font-medium">open</span> jobs
-              will be cancelled. Jobs that are in progress, completed, or
-              already cancelled will be skipped.
+              {confirmCopy(confirmAction).body}
             </p>
             <div className="flex gap-3">
               <button
@@ -216,11 +244,13 @@ export default function BulkJobActionBar({
                 Keep Jobs
               </button>
               <button
-                onClick={() => handleAction("cancel")}
+                onClick={() => handleAction(confirmAction)}
                 disabled={loading}
                 className="flex-1 px-4 py-2.5 rounded-xl text-sm font-medium bg-red-500/15 border border-red-500/30 text-red-400 hover:bg-red-500/25 transition-all disabled:opacity-50"
               >
-                {loading ? "Cancelling…" : "Yes, Cancel"}
+                {loading
+                  ? confirmCopy(confirmAction).confirmingLabel
+                  : confirmCopy(confirmAction).confirmLabel}
               </button>
             </div>
           </div>

--- a/frontend/components/WalletAccountMonitor.tsx
+++ b/frontend/components/WalletAccountMonitor.tsx
@@ -1,26 +1,52 @@
 /**
  * components/WalletAccountMonitor.tsx
- * Monitors Freighter wallet account changes and disconnections.
- * Listens for accountChanged event and prompts re-authentication on change.
+ * Monitors Freighter wallet account changes/disconnections, and (#871) polls
+ * the connected account's XLM balance so we can warn the user before they
+ * run out of the minimum reserve.
+ *
+ * Balance monitoring:
+ *   - Polls Horizon `accounts/:address` every 60 s while a wallet is connected.
+ *   - Balance < 10 XLM  → one-time warning toast (per low-balance episode).
+ *   - Balance < 5 XLM   → persistent banner (Stellar's minimum account
+ *     reserve is currently 1 XLM + 0.5 XLM/subentry — 5 XLM is a safety
+ *     margin above that). Dismissible for the rest of the session.
+ *   - Banner links to the FaucetButton on testnet (already rendered
+ *     globally once `onBalanceChange` reports a real balance) or opens the
+ *     Buy XLM flow on mainnet.
  */
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { subscribeToAccountChanges } from "@/lib/wallet";
 import { setJwtToken } from "@/lib/api";
+import { getXLMBalance } from "@/lib/stellar";
 import { useToast } from "@/components/Toast";
+import BuyXLMModal from "@/components/BuyXLMModal";
 
 const WALLET_PUBLIC_KEY_STORAGE_KEY = "smp_wallet_public_key";
+const BALANCE_POLL_INTERVAL_MS = 60_000;
+const MINIMUM_RESERVE_XLM = 5;
+const LOW_BALANCE_WARNING_XLM = 10;
+const IS_TESTNET = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet") !== "mainnet";
 
 interface Props {
   currentPublicKey: string | null;
   onDisconnect: () => void;
+  /** Called on every successful balance poll — lets the parent keep other
+   * balance-dependent UI (e.g. FaucetButton) in sync without double-polling. */
+  onBalanceChange?: (xlmBalance: string) => void;
 }
 
 export default function WalletAccountMonitor({
   currentPublicKey,
   onDisconnect,
+  onBalanceChange,
 }: Props) {
   const { info } = useToast();
+  const [xlmBalance, setXlmBalance] = useState<number | null>(null);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  const [showBuyModal, setShowBuyModal] = useState(false);
+  const hasWarnedRef = useRef(false);
 
+  // ── Account change / disconnection monitoring (#499) ────────────────────
   useEffect(() => {
     if (!currentPublicKey) return;
 
@@ -60,5 +86,94 @@ export default function WalletAccountMonitor({
     };
   }, [currentPublicKey, onDisconnect, info]);
 
-  return null;
+  // ── Low-balance monitoring (#871) ────────────────────────────────────────
+  useEffect(() => {
+    // Reset per-account state whenever the connected wallet changes.
+    setXlmBalance(null);
+    setBannerDismissed(false);
+    hasWarnedRef.current = false;
+
+    if (!currentPublicKey) return;
+
+    let cancelled = false;
+
+    const pollBalance = async () => {
+      const balanceStr = await getXLMBalance(currentPublicKey);
+      if (cancelled) return;
+      const balance = parseFloat(balanceStr);
+      if (Number.isNaN(balance)) return;
+
+      setXlmBalance(balance);
+      onBalanceChange?.(balanceStr);
+
+      if (balance < LOW_BALANCE_WARNING_XLM) {
+        if (!hasWarnedRef.current) {
+          hasWarnedRef.current = true;
+          info(
+            `Low balance warning: ${balance.toFixed(2)} XLM remaining. Keep at least ${MINIMUM_RESERVE_XLM} XLM for the network reserve.`,
+          );
+        }
+      } else {
+        // Balance recovered above the warning threshold — allow the toast
+        // to fire again if it drops a second time this session.
+        hasWarnedRef.current = false;
+      }
+    };
+
+    pollBalance();
+    const interval = setInterval(pollBalance, BALANCE_POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [currentPublicKey, info, onBalanceChange]);
+
+  const showBanner =
+    currentPublicKey !== null &&
+    xlmBalance !== null &&
+    xlmBalance < MINIMUM_RESERVE_XLM &&
+    !bannerDismissed;
+
+  return (
+    <>
+      {showBanner && (
+        <div
+          role="alert"
+          className="fixed top-0 inset-x-0 z-50 flex flex-wrap items-center justify-center gap-3 bg-red-500/15 border-b border-red-500/30 px-4 py-2.5 text-sm text-red-200 backdrop-blur-sm"
+        >
+          <span>
+            ⚠ Your balance is <span className="font-mono font-semibold">{xlmBalance!.toFixed(2)} XLM</span> — below the {MINIMUM_RESERVE_XLM} XLM minimum reserve.
+          </span>
+          {IS_TESTNET ? (
+            <span className="text-red-300/90 text-xs">
+              A testnet funding widget is available in the bottom-right corner.
+            </span>
+          ) : (
+            <button
+              onClick={() => setShowBuyModal(true)}
+              className="text-xs font-medium px-2.5 py-1 rounded-lg bg-red-500/20 border border-red-500/40 hover:bg-red-500/30 transition-colors"
+            >
+              Buy XLM
+            </button>
+          )}
+          <button
+            onClick={() => setBannerDismissed(true)}
+            className="text-xs text-red-300/80 hover:text-red-100 transition-colors"
+            aria-label="Dismiss low balance banner"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {showBuyModal && currentPublicKey && (
+        <BuyXLMModal
+          publicKey={currentPublicKey}
+          onClose={() => setShowBuyModal(false)}
+          onComplete={() => setShowBuyModal(false)}
+        />
+      )}
+    </>
+  );
 }

--- a/frontend/components/dashboard-tabs/PostedJobsTab.tsx
+++ b/frontend/components/dashboard-tabs/PostedJobsTab.tsx
@@ -17,6 +17,9 @@ interface Props {
   extendModalJob: Job | null;
   onJobExtended: (updated: Job) => void;
   onCloseExtendModal: () => void;
+  /** Ids of jobs currently checked for bulk actions (see BulkJobActionBar). */
+  selectedJobIds?: Set<string>;
+  onToggleSelect?: (jobId: string) => void;
 }
 
 export default function PostedJobsTab({
@@ -25,7 +28,9 @@ export default function PostedJobsTab({
   onRepost,
   extendModalJob,
   onJobExtended,
-  onCloseExtendModal
+  onCloseExtendModal,
+  selectedJobIds,
+  onToggleSelect,
 }: Props) {
   const router = useRouter();
 
@@ -58,6 +63,16 @@ export default function PostedJobsTab({
           key={job.id}
           className="card-hover flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
         >
+          {onToggleSelect && (
+            <input
+              type="checkbox"
+              checked={selectedJobIds?.has(job.id) ?? false}
+              onChange={() => onToggleSelect(job.id)}
+              onClick={(e) => e.stopPropagation()}
+              className="mt-1 h-4 w-4 shrink-0 rounded border-market-500/30 bg-ink-900 text-market-400 focus:ring-market-400 focus:ring-offset-0"
+              aria-label={`Select ${job.title}`}
+            />
+          )}
           <Link
             href={`/jobs/${job.id}`}
             className="flex-1 min-w-0 block"

--- a/frontend/hooks/useRealtimeBids.ts
+++ b/frontend/hooks/useRealtimeBids.ts
@@ -58,6 +58,17 @@ export function useRealtimeBids({
   const tabVisibleRef = useRef(!document.hidden);
   const newestCardRef = useRef<HTMLDivElement | null>(null);
 
+  // Keep the latest `fetchApplications` in a ref rather than a `connect`/
+  // `startPoll` dependency. Callers (e.g. RealtimeBidComparison) often pass
+  // an inline fallback function that gets a new identity on every render —
+  // depending on it directly would tear down and reopen the WebSocket on
+  // every re-render, which is what caused new bids to stop showing up
+  // reliably (#867).
+  const fetchApplicationsRef = useRef(fetchApplications);
+  useEffect(() => {
+    fetchApplicationsRef.current = fetchApplications;
+  }, [fetchApplications]);
+
   // ── helpers ────────────────────────────────────────────────────────────────
 
   const clearPoll = useCallback(() => {
@@ -71,13 +82,13 @@ export function useRealtimeBids({
     clearPoll();
     pollTimerRef.current = setInterval(async () => {
       try {
-        const fresh = await fetchApplications();
+        const fresh = await fetchApplicationsRef.current();
         setApplications(fresh);
       } catch {
         // ignore — will retry next interval
       }
     }, POLL_INTERVAL);
-  }, [clearPoll, fetchApplications]);
+  }, [clearPoll]);
 
   const highlight = useCallback((id: string) => {
     setHighlightedIds((prev) => new Set([...prev, id]));

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1368,6 +1368,36 @@ export async function bulkBoostJobs(jobIds: string[], txHash: string): Promise<B
   return data.data;
 }
 
+/**
+ * Bulk close ("cancel") or permanently delete jobs via POST /api/jobs/batch
+ * (#869). The endpoint runs both operations in a single DB transaction and
+ * authorizes the whole request atomically — see backend/src/services/jobService.js.
+ */
+export async function batchJobAction(
+  action: "close" | "delete",
+  jobIds: string[],
+): Promise<BulkActionResponse> {
+  const { data } = await api.post<{
+    success: boolean;
+    succeeded: string[];
+    failed: { id: string; error: string }[];
+  }>("/api/jobs/batch", { action, ids: jobIds });
+
+  const results = [
+    ...data.succeeded.map((id) => ({ id, success: true as const })),
+    ...data.failed.map((f) => ({ id: f.id, success: false as const, error: f.error })),
+  ];
+
+  return {
+    success: data.failed.length === 0,
+    succeeded: data.succeeded.length,
+    failed: data.failed.length,
+    processedCount: results.length,
+    failedCount: data.failed.length,
+    results,
+  };
+}
+
 
 // ─── IPFS File Upload (Issue #202) ──────────────────────────────────────────
 

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -4,6 +4,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import { fetchGasEstimateSafe, tierToTransactionFee } from "./sorobanFees";
+import { getUsdcContractId } from "./config/tokens";
 
 const NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet") as "testnet" | "mainnet";
 const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -273,6 +274,8 @@ export async function createEscrowOnChain(
   return signAndSubmitEscrowTx(preparedXdr);
 }
 
+// Re-exported for external consumers. Note: `export ... from` does not bind a
+// local name usable elsewhere in *this* file, hence the separate import above.
 export { getUsdcContractId, USDC_CONTRACT_BY_NETWORK } from "./config/tokens";
 
 

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -71,6 +71,9 @@ function ThemeToggle() {
 
 function App({ Component, pageProps }: AppProps) {
   const [publicKey, setPublicKey] = useState<string | null>(null);
+  // Kept in sync by WalletAccountMonitor's balance poll (#871) and passed
+  // down to FaucetButton so its "needs funding" state reflects the real balance.
+  const [xlmBalance, setXlmBalance] = useState<string | undefined>(undefined);
   const [shortcutsModalOpen, setShortcutsModalOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [deferredInstallPrompt, setDeferredInstallPrompt] = useState<{
@@ -254,6 +257,7 @@ function App({ Component, pageProps }: AppProps) {
             <WalletAccountMonitor
               currentPublicKey={publicKey}
               onDisconnect={handleWalletDisconnect}
+              onBalanceChange={setXlmBalance}
             />
             <Head>
               <title>Stellar MarketPay — Decentralised Freelance Marketplace</title>
@@ -275,7 +279,13 @@ function App({ Component, pageProps }: AppProps) {
               <main>
                 <Component {...pageProps} publicKey={publicKey} onConnect={handleConnect} />
               </main>
-              {publicKey && <FaucetButton publicKey={publicKey} />}
+              {publicKey && (
+                <FaucetButton
+                  publicKey={publicKey}
+                  currentBalance={xlmBalance}
+                  onBalanceUpdate={setXlmBalance}
+                />
+              )}
               <ThemeToggle />
               <OnboardingWizard publicKey={publicKey} onConnect={handleConnect} />
               <CommandPalette isOpen={commandPaletteOpen} onClose={() => setCommandPaletteOpen(false)} />

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -6,8 +6,8 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import WalletConnect from "@/components/WalletConnect";
-import { fetchMyJobs, fetchMyApplications, fetchApplications } from "@/lib/api";
-import { getXLMBalance, getUSDCBalance, streamAccountTransactions } from "@/lib/stellar";
+import { fetchMyJobs, fetchMyApplications, fetchApplications, batchJobAction, boostJob } from "@/lib/api";
+import { getXLMBalance, getUSDCBalance, streamAccountTransactions, buildBoostJobTx, signAndSubmitSorobanTx } from "@/lib/stellar";
 import { formatXLM, shortenAddress, timeAgo, statusLabel, statusClass, copyToClipboard, exportJobsToCSV, exportApplicationsToCSV } from "@/utils/format";
 import type { Job, Application, ClientSpendingAnalytics, JobInvitation } from "@/utils/types";
 import EditProfileForm from "@/components/EditProfileForm";
@@ -131,47 +131,122 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
     setExtendModalJob(null);
   }, []);
 
-  const handleBulkCancel = useCallback(async () => {
+  const handleToggleJobSelect = useCallback((jobId: string) => {
+    setSelectedJobIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(jobId)) next.delete(jobId);
+      else next.add(jobId);
+      return next;
+    });
+  }, []);
+
+  // "Close Selected" / "Delete Selected" — both run server-side in a single
+  // DB transaction via POST /api/jobs/batch (#869).
+  const handleBulkClose = useCallback(async () => {
     setBulkLoading(true);
     try {
       const ids = Array.from(selectedJobIds);
-      await Promise.all(ids.map((id) => fetch(`/api/jobs/${id}/cancel`, { method: "POST" })));
+      const result = await batchJobAction("close", ids);
       setSelectedJobIds(new Set());
-      return { success: ids.length, failed: 0 };
-    } catch {
-      return { success: 0, failed: selectedJobIds.size };
+      return result;
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to close selected jobs");
+      return {
+        success: false,
+        succeeded: 0,
+        failed: selectedJobIds.size,
+        processedCount: selectedJobIds.size,
+        failedCount: selectedJobIds.size,
+        results: Array.from(selectedJobIds).map((id) => ({ id, success: false as const })),
+      };
     } finally {
       setBulkLoading(false);
     }
-  }, [selectedJobIds]);
+  }, [selectedJobIds, toast]);
 
-  const handleBulkExtend = useCallback(async () => {
+  const handleBulkDelete = useCallback(async () => {
     setBulkLoading(true);
     try {
       const ids = Array.from(selectedJobIds);
-      await Promise.all(ids.map((id) => fetch(`/api/jobs/${id}/extend`, { method: "POST" })));
+      const result = await batchJobAction("delete", ids);
       setSelectedJobIds(new Set());
-      return { success: ids.length, failed: 0 };
-    } catch {
-      return { success: 0, failed: selectedJobIds.size };
+      return result;
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete selected jobs");
+      return {
+        success: false,
+        succeeded: 0,
+        failed: selectedJobIds.size,
+        processedCount: selectedJobIds.size,
+        failedCount: selectedJobIds.size,
+        results: Array.from(selectedJobIds).map((id) => ({ id, success: false as const })),
+      };
     } finally {
       setBulkLoading(false);
     }
-  }, [selectedJobIds]);
+  }, [selectedJobIds, toast]);
 
+  // "Boost Selected" — there is no batch boost endpoint: boosting is an
+  // on-chain `boost_job` Soroban call per job (see BoostJobModal), so each
+  // selected job gets its own signed transaction, submitted one at a time.
+  // Defaults to the cheaper 7-day/5 XLM tier; use the per-job Boost action
+  // for the 30-day tier.
   const handleBulkBoost = useCallback(async () => {
+    if (!publicKey) {
+      return {
+        success: false,
+        succeeded: 0,
+        failed: selectedJobIds.size,
+        processedCount: selectedJobIds.size,
+        failedCount: selectedJobIds.size,
+        results: Array.from(selectedJobIds).map((id) => ({ id, success: false as const, error: "Wallet not connected" })),
+      };
+    }
+
     setBulkLoading(true);
+    const BOOST_AMOUNT_XLM = 5;
+    const isMockMode = process.env.NEXT_PUBLIC_USE_CONTRACT_MOCK === "true";
+    const treasuryAddress = process.env.NEXT_PUBLIC_TREASURY_ADDRESS || publicKey;
+    const ids = Array.from(selectedJobIds);
+    const results: { id: string; success: boolean; error?: string }[] = [];
+
     try {
-      const ids = Array.from(selectedJobIds);
-      await Promise.all(ids.map((id) => fetch(`/api/jobs/${id}/boost`, { method: "POST" })));
+      for (const id of ids) {
+        try {
+          let txHash: string;
+          if (isMockMode) {
+            txHash = `mock-boost-${Date.now()}-${id}`;
+          } else {
+            const xdr = await buildBoostJobTx({
+              jobId: id,
+              clientPublicKey: publicKey,
+              amountXlm: BOOST_AMOUNT_XLM,
+              treasuryAddress,
+            });
+            txHash = await signAndSubmitSorobanTx(xdr);
+          }
+          const updated = await boostJob(id, txHash, BOOST_AMOUNT_XLM);
+          setMyJobs((prev) => prev.map((j) => (j.id === id ? updated : j)));
+          results.push({ id, success: true });
+        } catch (e) {
+          results.push({ id, success: false, error: e instanceof Error ? e.message : "Boost failed" });
+        }
+      }
       setSelectedJobIds(new Set());
-      return { success: ids.length, failed: 0 };
-    } catch {
-      return { success: 0, failed: selectedJobIds.size };
     } finally {
       setBulkLoading(false);
     }
-  }, [selectedJobIds]);
+
+    const failedCount = results.filter((r) => !r.success).length;
+    return {
+      success: failedCount === 0,
+      succeeded: results.length - failedCount,
+      failed: failedCount,
+      processedCount: results.length,
+      failedCount,
+      results,
+    };
+  }, [selectedJobIds, publicKey]);
 
   const handleCopy = async () => {
     if (!publicKey) return;
@@ -634,6 +709,8 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
             extendModalJob={extendModalJob}
             onJobExtended={handleJobExtended}
             onCloseExtendModal={() => setExtendModalJob(null)}
+            selectedJobIds={selectedJobIds}
+            onToggleSelect={handleToggleJobSelect}
           />
         ) : tab === "applied" ? (
           <AppliedJobsTab myApplications={myApplications} />
@@ -958,8 +1035,8 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
 
       <BulkJobActionBar
         selectedCount={selectedJobIds.size}
-        onCancel={handleBulkCancel}
-        onExtend={handleBulkExtend}
+        onClose={handleBulkClose}
+        onDelete={handleBulkDelete}
         onBoost={handleBulkBoost}
         onClearSelection={() => setSelectedJobIds(new Set())}
         loading={bulkLoading}


### PR DESCRIPTION
## Summary

- **#867 — RealtimeBidComparison not updating on new bids**: the WebSocket subscription/message-handling logic (`job:{id}:bids` → append bid) was already implemented in `useRealtimeBids`, but the hook's `startPoll`/`connect` callbacks depended on the caller's `fetchApplications` prop directly. `RealtimeBidComparison` passes an inline fallback (`() => Promise.resolve(initialApplications)`) when no `fetchApplications` prop is given, which gets a new identity every render — this made `connect` unstable and reconnected the WebSocket on every re-render, which is what caused bids to stop reflecting reliably. Fixed by keeping the latest `fetchApplications` in a ref instead of a hook dependency, so the socket now only (re)connects when the job id actually changes. Added `frontend/__tests__/realtime-bid-comparison.test.tsx` with a mocked `WebSocket` covering new-bid append, withdrawal fade-out, cross-job event filtering, dedup, and a regression test asserting no reconnect happens across re-renders.
- **#868 — BulkJobActionBar wiring**: the component existed with Extend/Boost/Cancel actions, but nothing ever populated the dashboard's `selectedJobIds` state (no checkboxes existed anywhere), so the bar could never actually appear. Added checkboxes to job rows in `PostedJobsTab`, wired selection state through `dashboard.tsx`, and relabeled/rebuilt the actions to match the issue spec: **Close Selected** and **Delete Selected** (both destructive, both require a confirmation dialog, both call the new batch endpoint) and **Boost Selected** (no confirmation — the wallet signature step is itself the confirmation). The bar now only renders once 2+ jobs are selected. Added `frontend/__tests__/bulk-job-action-bar.test.tsx` (integration tests: visibility threshold, confirm/cancel flows per action, success/failure summary, disabled-while-loading).
- **#869 — POST /api/jobs/batch**: implemented `batchJobAction` in `jobService.js` and wired it up in `routes/jobs.js`. Runs in a single DB transaction (via `pool.connect()` + BEGIN/COMMIT/ROLLBACK), rejects the whole request (403) if the caller doesn't own every specified job, caps requests at 50 ids, and returns `{ succeeded: string[], failed: {id, error}[] }`. Added `backend/src/services/jobService.batch.test.js` (8 tests: invalid action, empty/oversized id lists, whole-batch auth rejection for a job the caller doesn't own or that doesn't exist, per-job close/delete success + failure reporting, id de-duplication).
- **#871 — WalletAccountMonitor low-balance alerts**: this component already exists but implements a *different* feature (#499 — Freighter account-change/disconnection handling), already tested and wired into `_app.tsx`. Rather than replace it, extended it to also poll Horizon `accounts/:address` (via the existing `getXLMBalance` helper) every 60s: a dismissible banner appears once balance < 5 XLM (minimum reserve), and a one-time info toast fires once balance < 10 XLM. The banner links to the testnet `FaucetButton` (now correctly wired with a live balance via `_app.tsx`, which previously never received a `currentBalance` so it could never show) or opens `BuyXLMModal` on mainnet. Added balance-monitoring test cases to `frontend/__tests__/wallet-account-monitor.test.tsx`.

### Incidental fixes required to make the above work/testable
- `backend/src/db/pool.js` / `backend/src/testUtils/pgMock.js`: `jobService.js` and `applicationService.js` destructure `{ readPool, writePool }` from `db/pool`, but the module only ever exported the raw pool object — both names resolved to `undefined`, so **every** DB call in those two services threw `TypeError: Cannot read properties of undefined (reading 'query')` (confirmed pre-existing on `main`, 8/10 `jobService.test.js` tests and all 5 `applicationService.test.js` tests were already failing for this reason). Fixed by exporting the same pool under both names. This was necessary for the new batch endpoint (and its tests) to work at all; it also fixes 3/5 previously-broken `applicationService.test.js` tests as a side effect (2 remaining failures there are unrelated pre-existing logic bugs, left alone).
- `frontend/lib/stellar.ts`: `export { getUsdcContractId } from "./config/tokens"` followed by using `getUsdcContractId()` locally in the same file — a re-export doesn't create a local binding, so this threw `ReferenceError: getUsdcContractId is not defined` at module-load time for any test importing `lib/stellar` without a manual mock. Fixed with a proper local import alongside the existing re-export. Needed because `WalletAccountMonitor` now imports `getXLMBalance` from this module directly.

### Test plan
- [x] Backend: `npx jest src/services/jobService.batch.test.js` — 8/8 passing
- [x] Backend: `npx eslint src/services/jobService.js src/routes/jobs.js src/testUtils/pgMock.js src/db/pool.js` — clean
- [x] Frontend: `npx jest realtime-bid-comparison bulk-job-action-bar wallet-account-monitor` — 28/28 passing
- [x] Frontend: `npx tsc --noEmit` — no new errors (one pre-existing, unrelated syntax error in `hooks/usePushNotifications.ts`)
- [x] Frontend: `npx eslint` on all changed files — clean (one pre-existing warning in `dashboard.tsx` unrelated to this change)
- [x] Frontend: full `npx jest` run — same 4 pre-existing failing suites as `main` (stale snapshots for JobCard/ShareJobModal/BoostJobModal/PostJobForm/RealtimeBidComparison, a pre-existing duplicate `fetchDisputeOnchainCids` declaration breaking `fetchXlmPriceHistory` tests, and a pre-existing pdf-library load failure in `asyncComponents.snap.test.tsx`) — none of these are touched or worsened by this PR; `BulkJobActionBar`'s two snapshots were updated to match its new labels/icons.

Closes #867
Closes #868
Closes #869
Closes #871