### PR TITLE
Add skip navigation link for keyboard users

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -236,6 +236,12 @@ function App({ Component, pageProps }: AppProps) {
 
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-lg focus:bg-market-500 focus:px-4 focus:py-2 focus:font-semibold focus:text-ink-900 focus:shadow-lg"
+      >
+        Skip to main content
+      </a>
       {/*
        * Non-critical third-party scripts — loaded after the page is interactive
        * so they don't block TTI. Add any analytics, widgets, or tracking scripts
@@ -272,7 +278,7 @@ function App({ Component, pageProps }: AppProps) {
             <div className="min-h-screen bg-lines" style={{ backgroundColor: "var(--bg)" }}>
               <Navbar publicKey={publicKey} onConnect={handleConnect} onDisconnect={() => setPublicKey(null)} />
               <MobileTabBar publicKey={publicKey} />
-              <main>
+              <main id="main-content">
                 <Component {...pageProps} publicKey={publicKey} onConnect={handleConnect} />
               </main>
               {publicKey && <FaucetButton publicKey={publicKey} />}


### PR DESCRIPTION
## Summary
Keyboard users had to tab through the entire navbar on every page before reaching main content. This adds a visually-hidden "skip to main content" link that becomes visible on keyboard focus and jumps straight to the main content landmark.

## Type
- [x] New feature (accessibility)

## Related Issue
Closes #832

## Changes
- Added a `<a href="#main-content" className="sr-only focus:not-sr-only ...">Skip to main content</a>` link as the first element rendered in `pages/_app.tsx`, before the navbar.
- Added `id="main-content"` to the shared `<main>` element in `pages/_app.tsx`, which wraps every page's content — so the skip target applies site-wide without per-page edits.

## Testing
- [x] Tested locally: pressing Tab reveals the skip link as the first focusable element; activating it jumps focus to `#main-content`, bypassing the navbar.
- [x] `npm run lint` passes with no new warnings/errors.
- [x] `npm test` — same pre-existing 7 failing tests as on unmodified `main`; no new failures introduced.
- [x] No TypeScript errors introduced (one pre-existing unrelated `tsc` error on `main` in `hooks/usePushNotifications.ts`, untouched by this change).

## Screenshots
Manually verified in-browser: the link is invisible by default, and on the first Tab press it appears top-left as an amber pill reading "Skip to main content", positioned above the navbar. Activating it (Enter) navigates the URL to `#main-content` and moves focus past the nav.

<img width="1132" height="602" alt="Captura de pantalla 2026-07-28 112643" src="https://github.com/user-attachments/assets/5e275e5c-0aea-4c5b-8548-fe08ec0f9a64" />

## Notes for reviewers
- The project's `<main>` element lives once in `_app.tsx` and wraps every page's `<Component />`, so a single `id="main-content"` there covers all routes per the acceptance criteria ("on each page") without duplicating markup per-page.
- While verifying this change locally I found a few pre-existing, unrelated issues on `main` that block a fully clean local dev/build (missing import in `lib/stellar.ts`, a CSP header that blocks `next dev`'s eval-based devtool, and a `next build` failure from an undefined `EscrowCountdown` reference in `components/JobStatusTimeline.tsx`). None of those are touched here to keep this PR scoped to the accessibility issue — happy to file separate issues/PRs for them if useful.