### PR TITLE
Wire FaucetButton to Friendbot with toast feedback and testnet gate

### DIFF
--- a/frontend/components/FaucetButton.tsx
+++ b/frontend/components/FaucetButton.tsx
@@ -21,12 +21,22 @@ export default function FaucetButton({ publicKey, currentBalance, onBalanceUpdat
   const [faucetEnabled, setFaucetEnabled] = useState(false);
 
   useEffect(() => {
-    if (STELLAR_NETWORK !== "testnet") return;
+    if (STELLAR_NETWORK !== "testnet" || !publicKey) return;
     checkFaucetStatus();
+
     if (currentBalance !== undefined) {
       setNeedsFunding(parseFloat(currentBalance) === 0);
+      return;
     }
-  }, [currentBalance]);
+
+    // Caller didn't supply a balance (e.g. the global nav mount) — ask the
+    // backend directly so the button can still decide whether to show up.
+    checkAccountNeedsFunding(publicKey)
+      .then((status) => setNeedsFunding(status.needsFunding))
+      .catch((err) => {
+        console.error("Failed to check account funding status:", err);
+      });
+  }, [publicKey, currentBalance]);
 
   const checkFaucetStatus = async () => {
     try {

--- a/frontend/components/FaucetButton.tsx
+++ b/frontend/components/FaucetButton.tsx
@@ -3,7 +3,10 @@
  * Stellar testnet faucet button component
  */
 import { useState, useEffect } from "react";
-import { fundTestnetWallet, checkAccountNeedsFunding, getFaucetStatus } from "@/lib/api";
+import { fundTestnetWallet, checkAccountNeedsFunding, getFaucetStatus, getApiErrorMessage } from "@/lib/api";
+import { useToast } from "@/components/Toast";
+
+const STELLAR_NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet") as "testnet" | "mainnet";
 
 interface Props {
   publicKey: string;
@@ -12,13 +15,13 @@ interface Props {
 }
 
 export default function FaucetButton({ publicKey, currentBalance, onBalanceUpdate }: Props) {
+  const toast = useToast();
   const [needsFunding, setNeedsFunding] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [successMsg, setSuccessMsg] = useState("");
-  const [errorMsg, setErrorMsg] = useState("");
   const [faucetEnabled, setFaucetEnabled] = useState(false);
 
   useEffect(() => {
+    if (STELLAR_NETWORK !== "testnet") return;
     checkFaucetStatus();
     if (currentBalance !== undefined) {
       setNeedsFunding(parseFloat(currentBalance) === 0);
@@ -39,35 +42,30 @@ export default function FaucetButton({ publicKey, currentBalance, onBalanceUpdat
     if (!publicKey) return;
 
     setLoading(true);
-    setErrorMsg("");
-    setSuccessMsg("");
 
     try {
       const result = await fundTestnetWallet(publicKey);
-      
+
       if (result.success) {
-        setSuccessMsg(`Successfully funded with ${result.fundedAmount} XLM!`);
+        toast.success("10,000 XLM added to your testnet wallet");
         setNeedsFunding(false);
-        
+
         // Update parent component with new balance
         if (onBalanceUpdate && result.newBalance) {
           onBalanceUpdate(result.newBalance);
         }
-
-        // Clear success message after 5 seconds
-        setTimeout(() => setSuccessMsg(""), 5000);
       } else {
-        setErrorMsg(result.message);
+        toast.error(result.message);
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Faucet funding error:", err);
-      setErrorMsg(err.response?.data?.error || "Failed to fund wallet");
+      toast.error(getApiErrorMessage(err, "Failed to fund wallet"));
     } finally {
       setLoading(false);
     }
   };
 
-  if (!faucetEnabled || !needsFunding) {
+  if (STELLAR_NETWORK !== "testnet" || !faucetEnabled || !needsFunding) {
     return null;
   }
 
@@ -84,21 +82,10 @@ export default function FaucetButton({ publicKey, currentBalance, onBalanceUpdat
           </div>
         </div>
 
-        {successMsg && (
-          <div className="mb-3 p-2 bg-emerald-500/20 border border-emerald-500/30 rounded-lg text-emerald-400 text-xs">
-            ✅ {successMsg}
-          </div>
-        )}
-
-        {errorMsg && (
-          <div className="mb-3 p-2 bg-red-500/20 border border-red-500/30 rounded-lg text-red-400 text-xs">
-            ❌ {errorMsg}
-          </div>
-        )}
-
         <button
           onClick={handleFundWallet}
           disabled={loading}
+          aria-label="Fund testnet wallet with XLM"
           className="w-full btn-primary text-sm bg-blue-500 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {loading ? (


### PR DESCRIPTION
## Summary
`FaucetButton.tsx` already called a backend proxy that funds testnet wallets via Friendbot, but it was missing the pieces the issue asked for: toast feedback, an explicit network gate, an accessible label, and — critically — a way to ever render at all. `_app.tsx` mounts the button with only a `publicKey` prop, never `currentBalance`, so `needsFunding` never flipped `true` and the button could never appear in the running app regardless of wallet balance.

## Changes
- Route success/failure through the app's existing toast system (`useToast`) instead of local inline banners
- Success toast reads exactly "10,000 XLM added to your testnet wallet"; failure toast surfaces the specific backend error (e.g. rate-limit message) via `getApiErrorMessage`
- Gate rendering on `NEXT_PUBLIC_STELLAR_NETWORK === "testnet"` in addition to the existing backend-driven check
- Add `aria-label="Fund testnet wallet with XLM"` to the button
- Fix `needsFunding` never being determined when no `currentBalance` prop is passed, by falling back to `checkAccountNeedsFunding(publicKey)` — this is what makes the button actually appear in the app as currently wired in `_app.tsx`

## Closes
Closes #847

## Testing
- [x] Tested locally on Testnet (mocked backend via Playwright + Chromium, wallet seeded via localStorage — see screenshots)
- [x] No TypeScript / Rust errors (`FaucetButton.tsx` compiles clean; pre-existing unrelated type errors on `main` in other files are untouched)
- [ ] Docs updated if needed (n/a)

## Screenshots (if UI change)
Full walkthrough with all 5 states (button visible → loading → success toast → button hidden → rate-limit error toast) is here:

<img width="1280" height="800" alt="1" src="https://github.com/user-attachments/assets/aa315c08-8d8a-4a35-a07d-9032f66a70f1" />

<img width="1063" height="703" alt="Captura de pantalla 2026-07-28 143035" src="https://github.com/user-attachments/assets/5c93479d-ba42-40c1-bbd3-88b488985770" />
<img width="1059" height="708" alt="Captura de pantalla 2026-07-28 143040" src="https://github.com/user-attachments/assets/b8fe3c79-f5df-4d01-a419-63736440538c" />
<img width="1063" height="708" alt="Captura de pantalla 2026-07-28 143044" src="https://github.com/user-attachments/assets/0a978cb6-0da5-42d0-9159-674af832394b" />
<img width="1067" height="707" alt="Captura de pantalla 2026-07-28 143050" src="https://github.com/user-attachments/assets/ac5d57a1-54be-4b4b-b146-89ad5f16469c" />


## Notes
- The button still funds through the existing backend proxy (`POST /api/faucet/fund` → `faucetService.js`), which calls Friendbot server-side, rather than calling `friendbot.stellar.org` directly from the browser as the issue's literal wording suggests. That service already handles balance caching and rate limiting, so it was reused rather than duplicated client-side. Happy to switch to a direct client-side call if maintainers prefer literal compliance.
- While testing, hit two unrelated pre-existing defects on `main` (not fixed here, flagging for visibility): a broken re-export in `frontend/lib/stellar.ts` (`getUsdcContractId` referenced but never imported, crashes every page server-side) and a stray missing paren in `usePushNotifications.ts`.