### PR TITLE
[Bug] Fix PostJobForm not resetting after successful submission

### DIFF
--- a/frontend/components/PostJobForm.tsx
+++ b/frontend/components/PostJobForm.tsx
@@ -432,6 +432,10 @@ export default function PostJobForm({
     setJobId(null);
     setCurrentStep(1);
     setCompletedSteps(new Set());
+    setDraftId(null);
+    setSaveStatus("idle");
+    setSuggestions([]);
+    setShowSuggestions(false);
     setForm({
       title: "",
       description: "",


### PR DESCRIPTION
## Summary

After successfully posting a job, the `PostJobForm` retained previously entered data via stale state variables (`draftId`, `saveStatus`) that were not reset in `handleReset()`.

## Changes

- Added `setDraftId(null)` to `handleReset()` — prevents stale draft ID from persisting across submissions
- Added `setSaveStatus('idle')` to `handleReset()` — resets the save indicator after reset
- Added `setSuggestions([])` and `setShowSuggestions(false)` to `handleReset()` — clears autocomplete suggestions

Closes #855