### PR TITLE
[Bug] Fix NotificationBell badge count not resetting after reading all notifications

### DIFF
--- a/frontend/components/NotificationBell.tsx
+++ b/frontend/components/NotificationBell.tsx
@@ -78,9 +78,15 @@ export default function NotificationBell({ publicKey }: NotificationBellProps) {
   }
 
   async function handleMarkAllRead() {
-    await markAllNotificationsRead();
-    setNotifications((items) => items.map((item) => ({ ...item, read: true })));
+    const previousCount = unreadCount;
     setUnreadCount(0);
+    setNotifications((items) => items.map((item) => ({ ...item, read: true })));
+    try {
+      await markAllNotificationsRead();
+    } catch {
+      setUnreadCount(previousCount);
+      setNotifications((items) => items.map((item) => ({ ...item, read: false })));
+    }
   }
 
   return (

--- a/frontend/components/NotificationBell.tsx
+++ b/frontend/components/NotificationBell.tsx
@@ -83,6 +83,12 @@ export default function NotificationBell({ publicKey }: NotificationBellProps) {
     setNotifications((items) => items.map((item) => ({ ...item, read: true })));
     try {
       await markAllNotificationsRead();
+      // revalidate server data
+      const result = await fetchNotifications({ limit: 10 }).catch(() => null);
+      if (result) {
+        setNotifications(result.notifications);
+        setUnreadCount(result.unreadCount);
+      }
     } catch {
       setUnreadCount(previousCount);
       setNotifications((items) => items.map((item) => ({ ...item, read: false })));

--- a/frontend/components/__tests__/NotificationBell.test.tsx
+++ b/frontend/components/__tests__/NotificationBell.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NotificationBell from "@/components/NotificationBell";
+
+const mockMarkAllRead = jest.fn().mockResolvedValue({ updatedCount: 5 });
+const mockFetchNotifications = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  markAllNotificationsRead: () => mockMarkAllRead(),
+  fetchNotifications: () => mockFetchNotifications(),
+  markNotificationRead: jest.fn().mockResolvedValue(undefined),
+  setJwtToken: jest.fn(),
+  getJwtToken: jest.fn().mockReturnValue(null),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: mockPush, pathname: "/" }),
+}));
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+function makeNotifications(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `n${i}`,
+    title: `Notification ${i}`,
+    body: `Body ${i}`,
+    read: false,
+    createdAt: new Date().toISOString(),
+    jobId: null,
+    linkPath: null,
+  }));
+}
+
+describe("NotificationBell", () => {
+  it("shows badge with unread count", async () => {
+    mockFetchNotifications.mockResolvedValue({
+      notifications: makeNotifications(3),
+      unreadCount: 3,
+      nextCursor: null,
+    });
+
+    render(<NotificationBell publicKey="GPUBKEY" />);
+
+    const badge = await screen.findByText("3");
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("optimistically resets count to 0 on 'Mark all read' click", async () => {
+    const notifications = makeNotifications(3);
+    mockFetchNotifications.mockResolvedValue({
+      notifications,
+      unreadCount: 3,
+      nextCursor: null,
+    });
+
+    render(<NotificationBell publicKey="GPUBKEY" />);
+
+    const bell = await screen.findByLabelText("Notifications");
+    await userEvent.click(bell);
+
+    const markAllBtn = await screen.findByText("Mark all read");
+    await userEvent.click(markAllBtn);
+
+    expect(screen.queryByText("3")).not.toBeInTheDocument();
+    expect(mockMarkAllRead).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores count if API call fails", async () => {
+    const notifications = makeNotifications(3);
+    mockFetchNotifications.mockResolvedValue({
+      notifications,
+      unreadCount: 3,
+      nextCursor: null,
+    });
+    mockMarkAllRead.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<NotificationBell publicKey="GPUBKEY" />);
+
+    const bell = await screen.findByLabelText("Notifications");
+    await userEvent.click(bell);
+
+    const markAllBtn = await screen.findByText("Mark all read");
+    await userEvent.click(markAllBtn);
+
+    const badge = await screen.findByText("3");
+    expect(badge).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/notifications.tsx
+++ b/frontend/pages/notifications.tsx
@@ -64,9 +64,16 @@ export default function NotificationsPage({ publicKey, onConnect }: Notification
   }
 
   async function markEverythingRead() {
-    await markAllNotificationsRead();
-    setNotifications((items) => items.map((item) => ({ ...item, read: true })));
+    const previousCount = unreadCount;
     setUnreadCount(0);
+    setNotifications((items) => items.map((item) => ({ ...item, read: true })));
+    try {
+      await markAllNotificationsRead();
+      await loadNotifications();
+    } catch {
+      setUnreadCount(previousCount);
+      setNotifications((items) => items.map((item) => ({ ...item, read: false })));
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary

After clicking "Mark all as read", the notification bell badge still showed the old count if the API call failed. The optimistic update happened *after* the async API call, so a failure prevented the count from ever resetting.

## Changes

- Moved `setUnreadCount(0)` and `setNotifications` update **before** the API call (optimistic UI pattern)
- Added try/catch with rollback: if `markAllNotificationsRead()` throws, the count and read state are restored to their previous values

Closes #851