### PR TITLE
feat: implement in-app messaging between client and freelancer (#810)

### DIFF
--- a/packages/backend/src/api/routes/messages.ts
+++ b/packages/backend/src/api/routes/messages.ts
@@ -1,0 +1,109 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../../middleware/authMiddleware';
+import { asyncHandler } from '../../utils/errorHandler';
+import { AppDataSource } from '../../db/dataSource';
+import { Message } from '../../db/entities/Message';
+import { Booking } from '../../db/entities/Booking';
+import { BadRequestError, ForbiddenError, NotFoundError } from '../../utils/errors';
+import { getWebSocketServer } from '../../websockets/server';
+import { logger } from '../../utils/logger';
+
+const router = Router();
+
+const sendMessageSchema = z.object({
+  content: z.string().min(1).max(5000),
+});
+
+router.get(
+  '/:jobId/messages',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const { jobId } = req.params;
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
+    const offset = parseInt(req.query.offset as string) || 0;
+    const walletAddress = req.user?.walletAddress;
+
+    const messageRepo = AppDataSource.getRepository(Message);
+    const bookingRepo = AppDataSource.getRepository(Booking);
+
+    const booking = await bookingRepo.findOne({ where: { id: jobId } });
+    if (!booking) {
+      throw new NotFoundError('Job not found');
+    }
+
+    if (booking.walletAddress !== walletAddress) {
+      throw new ForbiddenError('You are not a participant in this job');
+    }
+
+    const [messages, total] = await messageRepo.findAndCount({
+      where: { jobId },
+      order: { createdAt: 'DESC' },
+      skip: offset,
+      take: limit,
+    });
+
+    res.json({
+      success: true,
+      data: messages.reverse(),
+      pagination: {
+        total,
+        limit,
+        offset,
+        hasMore: offset + limit < total,
+      },
+    });
+  }),
+);
+
+router.post(
+  '/:jobId/messages',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = sendMessageSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new BadRequestError('Validation error', parsed.error.flatten());
+    }
+
+    const { jobId } = req.params;
+    const walletAddress = req.user?.walletAddress;
+
+    const bookingRepo = AppDataSource.getRepository(Booking);
+    const booking = await bookingRepo.findOne({ where: { id: jobId } });
+    if (!booking) {
+      throw new NotFoundError('Job not found');
+    }
+
+    if (booking.walletAddress !== walletAddress) {
+      throw new ForbiddenError('Only job participants can send messages');
+    }
+
+    const messageRepo = AppDataSource.getRepository(Message);
+    const message = messageRepo.create({
+      jobId,
+      senderAddress: walletAddress,
+      content: parsed.data.content,
+    });
+    await messageRepo.save(message);
+
+    try {
+      const ws = getWebSocketServer();
+      (ws as any).io?.to(`job:${jobId}`)?.emit('message:new', {
+        id: message.id,
+        jobId: message.jobId,
+        senderAddress: message.senderAddress,
+        content: message.content,
+        createdAt: message.createdAt,
+      });
+    } catch (e) {
+      logger.warn('WebSocket not available — skipping message broadcast');
+    }
+
+    res.status(201).json({
+      success: true,
+      data: message,
+    });
+  }),
+);
+
+export const messageRoutes = router;

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,0 +1,245 @@
+// @ts-ignore
+import cors from 'cors';
+// @ts-ignore
+import express from 'express';
+// @ts-ignore
+import morgan from 'morgan';
+import { securityMiddleware } from './middleware/securityMiddleware';
+import { createFlightRoutes } from './api/routes/flights';
+import { bookingRoutes } from './api/routes/bookings';
+import { refundRoutes } from './api/routes/refunds';
+import { insuranceRoutes } from './api/routes/insurance';
+import { groupBookingRoutes } from './api/routes/group-bookings';
+import { securityRoutes } from './api/routes/security';
+import { adminAuthRoutes } from './api/routes/admin/auth';
+import { adminFlightRoutes } from './api/routes/admin/flights';
+import { adminUserRoutes } from './api/routes/admin/users';
+import { adminBookingRoutes } from './api/routes/admin/bookings';
+import { adminAnalyticsRoutes } from './api/routes/admin/analytics';
+import { adminRefundRoutes } from './api/routes/admin/refunds';
+import { tenantAnalyticsRoutes } from './api/routes/admin/tenantAnalytics';
+import { analyticsAuditRoutes } from './api/routes/admin/analyticsAudit';
+import { collaborationRoutes } from './api/routes/collaboration';
+import { authRoutes } from './api/routes/auth';
+import disputeRoutes from './api/routes/disputes';
+import serviceRoutes from './api/routes/services';
+import contractEventRoutes from './api/routes/contract-events';
+import transactionRoutes from './api/routes/transactions';
+import checkinRoutes from './api/routes/checkin';
+import journeyRoutes from './api/routes/journeys';
+import { documentRoutes } from './api/routes/documents';
+import { alertRoutes } from './api/routes/alerts';
+import { reviewRoutes } from './api/routes/reviews';
+import { userRoutes } from './api/routes/users';
+import { carbonRoutes } from './api/routes/carbon';
+import { trackingRoutes } from './api/routes/tracking';
+import { feedbackRoutes } from './api/routes/feedback';
+import { createCurrencyRoutes } from './api/routes/currencies';
+import { referralRoutes } from './api/routes/referrals';
+import { recommendationRoutes } from './api/routes/recommendations';
+import { flightStatusRoutes } from './api/routes/flightStatus';
+import { analyticsRoutes } from './api/routes/analytics';
+import { messageRoutes } from './api/routes/messages';
+// @ts-ignore
+import swaggerUi from 'swagger-ui-express';
+import { openApiDocument } from './api/openapi/generator';
+import { validateRequest } from './middleware/validationMiddleware';
+
+// @ts-ignore
+import type { Application } from 'express';
+
+import {
+  createDefaultFlightSearchService,
+  FlightSearchService,
+} from './services/flightSearchService';
+import { errorHandler, asyncHandler } from './utils/errorHandler';
+import { logger } from './utils/logger';
+import { cspMiddleware } from './middleware/csp';
+import { rateLimitMiddleware } from './middleware/rate-limit';
+import healthRouter from './routes/health';
+import { metricsMiddleware } from './middleware/metricsMiddleware';
+import { register } from './services/metrics';
+import { AppDataSource } from './db/dataSource';
+import { dbInitMiddleware } from './middleware/dbMiddleware';
+import {
+  createIpRateLimiter,
+  createTieredRateLimiter,
+  IpRateLimitOptions,
+  TieredRateLimitOptions,
+} from './utils/rateLimiter';
+import { requireAuth } from './middleware/authMiddleware';
+import { NotFoundError } from './utils/errors';
+import { AppError } from './services/ErrorHandlingService';
+import { requestLogger } from './middleware/requestLogger';
+import { analyticsAuditLogger } from './middleware/audit-logger';
+
+export interface AppOptions {
+  flightSearchService?: FlightSearchService;
+  globalRateLimit?: false | Partial<IpRateLimitOptions>;
+  tieredRateLimit?: false | Partial<TieredRateLimitOptions>;
+  searchRateLimit?: false | Partial<IpRateLimitOptions>;
+}
+
+export const createApp = async (options: AppOptions = {}) => {
+  const app = express();
+  const { config } = await import('./config');
+
+  if (config.trustProxy) {
+    app.set('trust proxy', 1);
+  }
+
+  const flightSearchService = options.flightSearchService || createDefaultFlightSearchService();
+
+  const globalRateLimitMiddleware =
+    options.globalRateLimit === false
+      ? null
+      : createIpRateLimiter({
+        points: config.rateLimitMax,
+        durationSeconds: config.rateLimitWindowSec,
+        keyPrefix: 'traqora-global-rate-limit',
+        ...options.globalRateLimit,
+      });
+
+  const tieredRateLimitMiddleware =
+    options.tieredRateLimit === false
+      ? null
+      : createTieredRateLimiter({
+        keyPrefix: 'traqora-tiered-rate-limit',
+        redisUrl: config.redisUrl || undefined,
+        trustProxy: config.trustProxy,
+        useCloudflareHeaders: config.useCloudflareHeaders,
+        public: {
+          points: config.rateLimitPublicMax,
+          durationSeconds: config.rateLimitWindowSec,
+        },
+        user: {
+          points: config.rateLimitUserMax,
+          durationSeconds: config.rateLimitWindowSec,
+        },
+        premium: {
+          points: config.rateLimitPremiumMax,
+          durationSeconds: config.rateLimitWindowSec,
+        },
+        ddos: {
+          points: config.ddosBurstMax,
+          durationSeconds: config.ddosBurstWindowSec,
+        },
+        blockDurationSeconds: config.rateLimitBlockDurationSec,
+        blockAfterViolations: config.rateLimitBlockAfterViolations,
+        captchaAfterViolations: config.captchaAfterViolations,
+        ...options.tieredRateLimit,
+      });
+
+  const searchRateLimitMiddleware = createIpRateLimiter({
+    points: 100,
+    durationSeconds: 60,
+    keyPrefix: 'traqora-flight-search-rate-limit',
+    ...options.searchRateLimit,
+  });
+
+  app.use(cspMiddleware);
+  app.use(rateLimitMiddleware);
+  app.use('/health', healthRouter);
+
+  app.use(securityMiddleware);
+  app.use(
+    cors({
+      origin: config.corsOrigin,
+      credentials: true,
+    })
+  );
+
+  if (globalRateLimitMiddleware) {
+    app.use(globalRateLimitMiddleware);
+  }
+
+  if (tieredRateLimitMiddleware) {
+    app.use(tieredRateLimitMiddleware);
+  }
+
+  app.use(requestLogger);
+  app.use(metricsMiddleware);
+  app.use(morgan('combined', { stream: { write: (message: string) => logger.info(message.trim()) } }));
+
+  app.use(dbInitMiddleware);
+
+  // Stripe webhook requires raw body — must be registered BEFORE express.json()
+  app.use('/api/v1/bookings/webhook/stripe', express.raw({ type: '*/*' }));
+
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: true }));
+
+  app.get('/metrics', asyncHandler(async (_req: express.Request, res: express.Response) => {
+    res.set('Content-Type', register.contentType);
+    res.end(await register.metrics());
+  }));
+
+  app.get('/readiness', asyncHandler(async (_req: express.Request, res: express.Response) => {
+    if (!AppDataSource.isInitialized && config.databaseUrl) {
+      throw new AppError('Database not initialized', { statusCode: 503, code: 'SERVICE_UNAVAILABLE' });
+    }
+    if (AppDataSource.isInitialized) {
+      await AppDataSource.query('SELECT 1');
+    }
+    return res.json({ status: 'ready' });
+  }));
+
+  // OpenAPI documentation routes
+  app.get('/api/openapi.json', (_req: express.Request, res: express.Response) => {
+    res.json(openApiDocument);
+  });
+
+  app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(openApiDocument));
+
+  app.use('/api/v1/alerts', requireAuth, alertRoutes);
+  app.use('/api/v1/reviews', reviewRoutes);
+  app.use('/api/v1/flight-status', flightStatusRoutes);
+  app.use('/api/v1/analytics', analyticsRoutes);
+
+
+  app.use('/api/v1/auth', validateRequest('/api/v1/auth/challenge'), validateRequest('/api/v1/auth/verify'), validateRequest('/api/v1/auth/refresh'), authRoutes);
+  app.use('/api/v1/flights', createFlightRoutes(flightSearchService, searchRateLimitMiddleware));
+  app.use('/api/flights', createFlightRoutes(flightSearchService, searchRateLimitMiddleware));
+  app.use('/api/v1/bookings', requireAuth, bookingRoutes);
+  app.use('/api/v1/refunds', requireAuth, refundRoutes);
+  app.use('/api/v1/insurance', insuranceRoutes);
+  app.use('/api/v1/group-bookings', requireAuth, groupBookingRoutes); // <-- Added group booking routes
+  app.use('/api/v1/security', securityRoutes);
+  app.use('/api/v1/documents', requireAuth, documentRoutes);
+  app.use('/api/v1/referrals', referralRoutes);
+  app.use('/api/v1/recommendations', recommendationRoutes);
+  app.use('/api/v1/users', userRoutes);
+
+  // Admin routes
+  app.use('/api/v1/admin/auth', adminAuthRoutes);
+  app.use('/api/v1/admin/flights', adminFlightRoutes);
+  app.use('/api/v1/admin/users', adminUserRoutes);
+  app.use('/api/v1/admin/bookings', adminBookingRoutes);
+  app.use('/api/v1/admin/analytics', analyticsAuditRoutes);
+  app.use('/api/v1/admin/analytics', analyticsAuditLogger);
+  app.use('/api/v1/admin/analytics', adminAnalyticsRoutes);
+  app.use('/api/v1/admin/analytics', tenantAnalyticsRoutes);
+  app.use('/api/v1/admin/refunds', adminRefundRoutes);
+  app.use('/api/v1/collaboration', collaborationRoutes);
+  app.use('/api/v1/disputes', disputeRoutes);
+  app.use('/api/v1/services', serviceRoutes);
+  app.use('/api/v1/contract-events', contractEventRoutes);
+  app.use('/api/v1/transactions', transactionRoutes);
+  app.use('/api/v1/checkin', requireAuth, checkinRoutes);
+  app.use('/api/v1/journeys', journeyRoutes);
+  app.use('/api/v1/carbon', carbonRoutes);
+  app.use('/api/v1/tracking', requireAuth, trackingRoutes);
+  app.use('/api/v1/feedback', feedbackRoutes);
+  app.use('/api/v1/currencies', createCurrencyRoutes());
+
+  // Messaging routes (Issue #810)
+  app.use('/api/v1/jobs', requireAuth, messageRoutes);
+
+  app.use((_req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    next(new NotFoundError('Endpoint not found'));
+  });
+
+  app.use(errorHandler);
+
+  return app;
+};

--- a/packages/backend/src/db/dataSource.ts
+++ b/packages/backend/src/db/dataSource.ts
@@ -1,0 +1,172 @@
+import "reflect-metadata";
+import { UserPreference } from "./entities/UserPreference";
+import { NotificationLog } from "./entities/NotificationLog";
+import { DataSource } from "typeorm";
+import { config } from "../config";
+import { logger } from "../utils/logger";
+import { Booking } from "./entities/Booking";
+import { Flight } from "./entities/Flight";
+import { Passenger } from "./entities/Passenger";
+import { IdempotencyKey } from "./entities/IdempotencyKey";
+import { AdminUser } from "./entities/AdminUser";
+import { AdminAuditLog } from "./entities/AdminAuditLog";
+import { Refund } from "./entities/Refund";
+import { User } from "./entities/User";
+import { TravelDocument } from "./entities/TravelDocument";
+import { Tenant } from "./entities/Tenant";
+import { DashboardShare } from "./entities/DashboardShare";
+import { DashboardComment } from "./entities/DashboardComment";
+import { AnalyticsAuditLog } from "./entities/AnalyticsAuditLog";
+import { ContractEventLog } from "./entities/ContractEventLog";
+import { InsurancePolicy } from "./entities/InsurancePolicy";
+import { InsuranceClaim } from "./entities/InsuranceClaim";
+import { CheckIn } from "./entities/CheckIn";
+import { BiometricCredential } from "./entities/BiometricCredential";
+import { SearchHistoryEntry } from "./entities/SearchHistoryEntry";
+import { SavedSearch } from "./entities/SavedSearch";
+import { UserProfile } from "./entities/UserProfile";
+import { AccountDeletionRequest } from "./entities/AccountDeletionRequest";
+import { Dispute } from "./entities/Dispute";
+import { DisputeEvidence } from "./entities/DisputeEvidence";
+import { RecommendationEvent } from "./entities/RecommendationEvent";
+import { Review } from "./entities/Review";
+import { Feedback } from "./entities/Feedback";
+import { FeedbackVote } from "./entities/FeedbackVote";
+import { CarbonOffset } from "./entities/CarbonOffset";
+import { OffsetProject } from "./entities/OffsetProject";
+import { TrackedFlight } from "./entities/TrackedFlight";
+import { PriceObservation } from "./entities/PriceObservation";
+import { Message } from "./entities/Message";
+
+const isTest = process.env.NODE_ENV === "test";
+
+export const AppDataSource = new DataSource(
+  isTest
+    ? {
+      type: "better-sqlite3",
+      database: ":memory:",
+      dropSchema: true,
+      synchronize: true,
+      entities: [
+        Booking,
+        Flight,
+        Passenger,
+        IdempotencyKey,
+        UserPreference,
+        NotificationLog,
+        AdminUser,
+        AdminAuditLog,
+        Refund,
+        User,
+        TravelDocument,
+        Tenant,
+        DashboardShare,
+        DashboardComment,
+        AnalyticsAuditLog,
+        ContractEventLog,
+        InsurancePolicy,
+        InsuranceClaim,
+        CheckIn,
+        BiometricCredential,
+        SearchHistoryEntry,
+        SavedSearch,
+        UserProfile,
+        AccountDeletionRequest,
+        Dispute,
+        DisputeEvidence,
+        RecommendationEvent,
+        Review,
+        Feedback,
+        FeedbackVote,
+        CarbonOffset,
+        OffsetProject,
+        TrackedFlight,
+        PriceObservation,
+        Message,
+      ],
+      logging: false,
+    }
+    : {
+      type: "postgres",
+      url: config.databaseUrl,
+      synchronize: false,
+      logging: false,
+      entities: [
+        Booking,
+        Flight,
+        Passenger,
+        IdempotencyKey,
+        UserPreference,
+        NotificationLog,
+        AdminUser,
+        AdminAuditLog,
+        Refund,
+        User,
+        TravelDocument,
+        Tenant,
+        DashboardShare,
+        DashboardComment,
+        AnalyticsAuditLog,
+        ContractEventLog,
+        InsurancePolicy,
+        InsuranceClaim,
+        CheckIn,
+        BiometricCredential,
+        SearchHistoryEntry,
+        SavedSearch,
+        UserProfile,
+        AccountDeletionRequest,
+        Dispute,
+        DisputeEvidence,
+        RecommendationEvent,
+        Review,
+        Feedback,
+        FeedbackVote,
+        CarbonOffset,
+        OffsetProject,
+        TrackedFlight,
+        PriceObservation,
+        Message,
+      ],
+      migrations: [__dirname + "/migrations/*.{js,ts}"],
+      ssl:
+        config.environment === "production"
+          ? { rejectUnauthorized: false }
+          : false,
+    },
+);
+
+export const initDataSource = async () => {
+  if (AppDataSource.isInitialized) return;
+
+  // In test mode use the in-memory SQLite datasource — no DATABASE_URL needed
+  if (isTest) {
+    await AppDataSource.initialize();
+    return;
+  }
+
+  // If no database URL is configured (dev without Postgres), skip initialization
+  if (!config.databaseUrl) {
+    logger.warn(
+      "No Postgres DATABASE_URL provided, skipping TypeORM datasource initialization",
+    );
+    return;
+  }
+
+  await AppDataSource.initialize();
+
+  try {
+    logger.info("Checking database migrations...");
+    const hasPending = await AppDataSource.showMigrations();
+    if (hasPending) {
+      logger.info("Pending migrations found. Running migrations...");
+      const runMigrations = await AppDataSource.runMigrations();
+      logger.info(`Successfully executed ${runMigrations.length} migrations.`);
+    } else {
+      logger.info("Database schema is up to date.");
+    }
+  } catch (error) {
+    logger.error("Failed to run database migrations on startup:", error as Error);
+    throw error;
+  }
+};

--- a/packages/backend/src/db/entities/Message.ts
+++ b/packages/backend/src/db/entities/Message.ts
@@ -1,0 +1,26 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity({ name: 'messages' })
+export class Message {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: 'varchar', length: 64 })
+  jobId: string;
+
+  @Column({ type: 'varchar', length: 128 })
+  senderAddress: string;
+
+  @Column({ type: 'text' })
+  content: string;
+
+  @CreateDateColumn({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz' })
+  createdAt: Date;
+}

--- a/packages/backend/src/websockets/server.ts
+++ b/packages/backend/src/websockets/server.ts
@@ -1,0 +1,355 @@
+import { Server, Socket } from 'socket.io';
+import { createAdapter } from '@socket.io/redis-adapter';
+import { createClient } from 'redis';
+import http from 'http';
+import { logger } from '../utils/logger';
+import { config } from '../config';
+import jwt from 'jsonwebtoken';
+import { chatBotService, ChatMessage } from '../services/chatBotService';
+
+// Interface for typed events
+interface ServerToClientEvents {
+  priceUpdate: (data: { flightId: string; price: number; timestamp: Date }) => void;
+  alert: (data: FlightAlertPayload) => void;
+  booking_status: (data: { bookingId: string; status: string; timestamp: Date }) => void;
+  flight_status: (data: FlightStatusPayload) => void;
+  contract_event: (data: ContractEventPayload) => void;
+  'chat:reply': (data: { message: ChatMessage; escalated: boolean }) => void;
+}
+
+export type FlightStatus = 'SCHEDULED' | 'DELAYED' | 'GATE_CHANGED' | 'BOARDING' | 'CANCELLED' | 'LANDED';
+
+export interface FlightStatusPayload {
+  flightId: string;
+  status: FlightStatus;
+  /** Present for DELAYED (new departure time) and GATE_CHANGED (new gate) updates. */
+  detail?: string;
+  timestamp: Date;
+}
+
+export interface FlightAlertPayload {
+  message: string;
+  flightId: string;
+  status?: string;
+  gate?: string;
+  delayMinutes?: number;
+  timestamp?: Date;
+}
+
+interface ClientToServerEvents {
+  subscribe: (flightId: string) => void;
+  unsubscribe: (flightId: string) => void;
+  subscribe_address: (walletAddress: string) => void;
+  unsubscribe_address: (walletAddress: string) => void;
+  subscribe_job: (jobId: string) => void;
+  unsubscribe_job: (jobId: string) => void;
+  'chat:message': (text: string) => void;
+}
+
+export interface ContractEventPayload {
+  contractId: string;
+  eventType: string;
+  ledger: number;
+  walletAddress?: string;
+  data: unknown;
+  timestamp: Date;
+}
+
+export class WebSocketServer {
+  private io: Server<ClientToServerEvents, ServerToClientEvents>;
+  private pubClient: any;
+  private subClient: any;
+  private redisEnabled: boolean = false; // Track Redis status
+  /** Chat message history per socket connection (issue #379). Cleared on disconnect. */
+  private chatHistory = new Map<string, ChatMessage[]>();
+
+  constructor(httpServer: http.Server) {
+    this.io = new Server(httpServer, {
+      cors: {
+        origin: config.corsOrigin || '*',
+        methods: ['GET', 'POST']
+      }
+    });
+
+    // Setup connection handlers immediately
+    this.setupConnectionHandlers();
+    
+    // Setup Redis adapter asynchronously but don't block
+    this.setupRedisAdapter().catch(error => {
+      logger.error('Redis adapter setup failed, continuing with in-memory adapter:', error);
+    });
+  }
+
+  private async setupRedisAdapter() {
+    try {
+      const redisUrl = config.redisUrl || process.env.REDIS_URL || 'redis://172.20.145.159:6379';
+      logger.info(`Attempting to connect to Redis at: ${redisUrl}`);
+      
+      this.pubClient = createClient({ url: redisUrl });
+      this.subClient = this.pubClient.duplicate();
+
+      // Add error handlers before connecting
+      this.pubClient.on('error', (err: any) => {
+        logger.error(`Redis Publisher error: ${err.message}`);
+        this.redisEnabled = false;
+      });
+
+      this.subClient.on('error', (err: any) => {
+        logger.error(`Redis Subscriber error: ${err.message}`);
+        this.redisEnabled = false;
+      });
+
+      // Connect with timeout
+      await Promise.race([
+        Promise.all([this.pubClient.connect(), this.subClient.connect()]),
+        new Promise((_, reject) => 
+          setTimeout(() => reject(new Error('Redis connection timeout')), 5000)
+        )
+      ]);
+
+      // Apply Redis adapter
+      this.io.adapter(createAdapter(this.pubClient, this.subClient));
+      this.redisEnabled = true;
+      logger.info('✅ WebSocket Redis Adapter initialized successfully');
+      
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.warn(`⚠️ Redis adapter not initialized (using in-memory adapter): ${errorMessage}`);
+      this.redisEnabled = false;
+      
+      // Clean up any partial connections
+      if (this.pubClient) {
+        try { this.pubClient.quit(); } catch (e) {}
+      }
+      if (this.subClient) {
+        try { this.subClient.quit(); } catch (e) {}
+      }
+    }
+  }
+
+  private setupConnectionHandlers() {
+    // Add connection logging middleware
+    this.io.use((socket, next) => {
+      logger.info(`Socket connection attempt: ${socket.id}`);
+      next();
+    });
+
+    // Authentication middleware: verify JWT if provided, attach to socket.data.user
+    this.io.use((socket, next) => {
+      const token = socket.handshake.auth?.token;
+      if (!token) return next();
+
+      try {
+        const payload = jwt.verify(token, config.jwtSecret) as any;
+        (socket as any).data = (socket as any).data || {};
+        (socket as any).data.user = payload;
+        logger.info(`Socket ${socket.id} authenticated (user=${payload?.sub || payload?.id || 'unknown'})`);
+      } catch (err) {
+        logger.warn(`Socket ${socket.id} failed auth: ${(err as any)?.message || err}`);
+        // allow connection to proceed but unauthenticated
+      }
+      return next();
+    });
+
+    this.io.on('connection', (socket: Socket) => {
+      logger.info(`✅ Client connected: ${socket.id} (Redis: ${this.redisEnabled ? 'enabled' : 'disabled'})`);
+
+      socket.on('subscribe', (flightId: string) => {
+        logger.info(`Client ${socket.id} subscribed to flight ${flightId}`);
+        socket.join(`flight:${flightId}`);
+      });
+
+      socket.on('unsubscribe', (flightId: string) => {
+        logger.info(`Client ${socket.id} unsubscribed from flight ${flightId}`);
+        socket.leave(`flight:${flightId}`);
+      });
+
+      socket.on('subscribe_booking', (bookingId: string) => {
+        logger.info(`Client ${socket.id} subscribed to booking ${bookingId}`);
+        socket.join(`booking:${bookingId}`);
+      });
+
+      socket.on('unsubscribe_booking', (bookingId: string) => {
+        logger.info(`Client ${socket.id} unsubscribed from booking ${bookingId}`);
+        socket.leave(`booking:${bookingId}`);
+      });
+
+      socket.on('subscribe_address', (walletAddress: string) => {
+        logger.info(`Client ${socket.id} subscribed to address room ${walletAddress}`);
+        socket.join(`address:${walletAddress}`);
+      });
+
+      socket.on('unsubscribe_address', (walletAddress: string) => {
+        logger.info(`Client ${socket.id} unsubscribed from address room ${walletAddress}`);
+        socket.leave(`address:${walletAddress}`);
+      });
+
+      socket.on('subscribe_job', (jobId: string) => {
+        logger.info(`Client ${socket.id} subscribed to job ${jobId}`);
+        socket.join(`job:${jobId}`);
+      });
+
+      socket.on('unsubscribe_job', (jobId: string) => {
+        logger.info(`Client ${socket.id} unsubscribed from job ${jobId}`);
+        socket.leave(`job:${jobId}`);
+      });
+
+      socket.on('chat:message', (text: string) => {
+        this.handleChatMessage(socket, text);
+      });
+
+      socket.on('disconnect', () => {
+        logger.info(`🔴 Client disconnected: ${socket.id}`);
+        this.chatHistory.delete(socket.id);
+      });
+
+      // Handle errors
+      socket.on('error', (error) => {
+        logger.error(`Socket ${socket.id} error:`, error);
+      });
+    });
+
+    // Handle server-level errors
+    this.io.engine.on('connection_error', (err: any) => {
+      logger.error('Engine connection error:', err);
+    });
+  }
+
+  public broadcastPriceUpdate(flightId: string, price: number) {
+    const room = `flight:${flightId}`;
+    logger.info(`Broadcasting price update to ${room}: $${price}`);
+    
+    this.io.to(room).emit('priceUpdate', {
+      flightId,
+      price,
+      timestamp: new Date()
+    });
+  }
+
+  public broadcastBookingStatus(bookingId: string, status: string) {
+    const room = `booking:${bookingId}`;
+    logger.info(`Broadcasting booking status to ${room}: ${status}`);
+    this.io.to(room).emit('booking_status', {
+      bookingId,
+      status,
+      timestamp: new Date(),
+    });
+  }
+
+  /**
+   * Broadcasts a flight status change (issue #381) — delays, gate changes,
+   * cancellations, boarding calls — to clients subscribed to that flight's
+   * room via the existing `subscribe`/`unsubscribe` events. Distinct from
+   * `priceUpdate`, which only covers pricing.
+   */
+  public broadcastFlightStatus(flightId: string, status: FlightStatus, detail?: string) {
+    const room = `flight:${flightId}`;
+    logger.info(`Broadcasting flight status to ${room}: ${status}`);
+    this.io.to(room).emit('flight_status', {
+      flightId,
+      status,
+      detail,
+      timestamp: new Date(),
+    });
+  }
+
+  /**
+   * Broadcast a flight status change (delay, cancellation, gate change) to
+   * everyone subscribed to that flight's room. Uses the `alert` event that
+   * was already declared on ServerToClientEvents but had no emitter (#380).
+   * Distinct from `broadcastFlightStatus` above (issue #381, merged in
+   * parallel): different event name (`alert` vs `flight_status`) and a
+   * richer payload (a pre-built message string) — flightStatus.ts and the
+   * FlightStatusBanner/useFlightStatusAlerts client code this PR adds
+   * depend on this one specifically.
+   */
+  public broadcastFlightAlert(payload: FlightAlertPayload) {
+    const room = `flight:${payload.flightId}`;
+    logger.info(`Broadcasting flight alert to ${room}: ${payload.message}`);
+    this.io.to(room).emit('alert', {
+      ...payload,
+      timestamp: payload.timestamp ?? new Date(),
+    });
+  }
+
+  /**
+   * Broadcast a Soroban contract event to all subscribers of the contract room
+   * and, when a wallet address is present, to that address-specific room too.
+   */
+  public broadcastContractEvent(payload: ContractEventPayload) {
+    const contractRoom = `contract:${payload.contractId}`;
+    this.io.to(contractRoom).emit('contract_event', payload);
+
+    if (payload.walletAddress) {
+      const addressRoom = `address:${payload.walletAddress}`;
+      this.io.to(addressRoom).emit('contract_event', payload);
+    }
+
+    logger.debug('Contract event broadcast', {
+      contractId: payload.contractId,
+      eventType: payload.eventType,
+      ledger: payload.ledger,
+    });
+  }
+
+  // Method to check Redis status
+  public isRedisEnabled(): boolean {
+    return this.redisEnabled;
+  }
+
+  /**
+   * Handles an inbound chat message (issue #379): appends it to the
+   * socket's history, gets a bot response (or an escalation signal), and
+   * replies over the same socket. Escalation just flags the message —
+   * routing to a human queue is a follow-on integration, not built here.
+   */
+  private handleChatMessage(socket: Socket<ClientToServerEvents, ServerToClientEvents>, text: string): void {
+    const trimmed = typeof text === 'string' ? text : '';
+    const history = this.chatHistory.get(socket.id) ?? [];
+
+    const userMessage: ChatMessage = {
+      id: `${socket.id}-${history.length}`,
+      from: 'user',
+      text: trimmed,
+      createdAt: new Date(),
+    };
+    history.push(userMessage);
+
+    const { reply, escalate } = chatBotService.respond(trimmed);
+    const botMessage: ChatMessage = {
+      id: `${socket.id}-${history.length}`,
+      from: escalate ? 'agent' : 'bot',
+      text: reply,
+      createdAt: new Date(),
+    };
+    history.push(botMessage);
+
+    this.chatHistory.set(socket.id, history);
+
+    if (escalate) {
+      logger.info(`Chat escalated to human agent for socket ${socket.id}`);
+    }
+
+    socket.emit('chat:reply', { message: botMessage, escalated: escalate });
+  }
+
+  /** Test/introspection hook: read a socket's chat history. */
+  public getChatHistory(socketId: string): ChatMessage[] {
+    return this.chatHistory.get(socketId) ?? [];
+  }
+}
+
+let wsServer: WebSocketServer | null = null;
+
+export const initWebSocket = (httpServer: http.Server) => {
+  logger.info('Initializing WebSocket server...');
+  wsServer = new WebSocketServer(httpServer);
+  return wsServer;
+};
+
+export const getWebSocketServer = () => {
+  if (!wsServer) {
+    throw new Error('WebSocket Server not initialized');
+  }
+  return wsServer;
+};

--- a/packages/backend/tests/messages.test.ts
+++ b/packages/backend/tests/messages.test.ts
@@ -1,0 +1,168 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { AppDataSource, initDataSource } from '../src/db/dataSource';
+import { Booking } from '../src/db/entities/Booking';
+import { Flight } from '../src/db/entities/Flight';
+import { Passenger } from '../src/db/entities/Passenger';
+import { config } from '../src/config';
+
+const validToken = jwt.sign(
+  { walletAddress: 'GAUSER', walletType: 'freighter' },
+  config.jwtSecret,
+  { expiresIn: '1h' }
+);
+
+const otherToken = jwt.sign(
+  { walletAddress: 'GAOTHER', walletType: 'freighter' },
+  config.jwtSecret,
+  { expiresIn: '1h' }
+);
+
+jest.mock('../src/services/stripe', () => ({
+  stripe: {
+    paymentIntents: { create: jest.fn() },
+    webhooks: { constructEvent: jest.fn() },
+  },
+  stripeWebhookSecret: 'whsec_test',
+}));
+
+jest.mock('../src/services/soroban', () => ({
+  buildCreateBookingUnsignedXdr: jest.fn(),
+  submitSignedSorobanXdr: jest.fn(),
+  getTransactionStatus: jest.fn(),
+}));
+
+describe('Messages API (Issue #810)', () => {
+  let app: any;
+  let bookingId: string;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    await initDataSource();
+
+    const { createApp } = await import('../src/app');
+    app = await createApp({ globalRateLimit: false, tieredRateLimit: false, searchRateLimit: false });
+
+    const flightRepo = AppDataSource.getRepository(Flight);
+    const flight = await flightRepo.save(
+      flightRepo.create({
+        flightNumber: 'MSG001',
+        fromAirport: 'JFK',
+        toAirport: 'LAX',
+        departureTime: new Date(Date.now() + 86400000),
+        seatsAvailable: 5,
+        priceCents: 20000,
+        airlineSorobanAddress: 'GAIRLINE',
+      })
+    );
+
+    const passengerRepo = AppDataSource.getRepository(Passenger);
+    const passenger = await passengerRepo.save(
+      passengerRepo.create({
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        sorobanAddress: 'GAPASSENGER',
+      })
+    );
+
+    const bookingRepo = AppDataSource.getRepository(Booking);
+    const booking = await bookingRepo.save(
+      bookingRepo.create({
+        flight,
+        passenger,
+        walletAddress: 'GAUSER',
+        status: 'confirmed',
+        amountCents: 20000,
+      })
+    );
+    bookingId = booking.id;
+  });
+
+  afterAll(async () => {
+    if (AppDataSource.isInitialized) await AppDataSource.destroy();
+  });
+
+  it('rejects fetching messages without auth', async () => {
+    const res = await request(app)
+      .get(`/api/v1/jobs/${bookingId}/messages`)
+      .expect(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns empty messages list for a job', async () => {
+    const res = await request(app)
+      .get(`/api/v1/jobs/${bookingId}/messages`)
+      .set('Authorization', `Bearer ${validToken}`)
+      .expect(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('rejects sending message without auth', async () => {
+    const res = await request(app)
+      .post(`/api/v1/jobs/${bookingId}/messages`)
+      .send({ content: 'Hello' })
+      .expect(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('sends a message successfully', async () => {
+    const res = await request(app)
+      .post(`/api/v1/jobs/${bookingId}/messages`)
+      .set('Authorization', `Bearer ${validToken}`)
+      .send({ content: 'Hello, this is a test message' })
+      .expect(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.content).toBe('Hello, this is a test message');
+    expect(res.body.data.senderAddress).toBe('GAUSER');
+    expect(res.body.data.jobId).toBe(bookingId);
+  });
+
+  it('retrieves sent messages', async () => {
+    const res = await request(app)
+      .get(`/api/v1/jobs/${bookingId}/messages`)
+      .set('Authorization', `Bearer ${validToken}`)
+      .expect(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.data[0].content).toBe('Hello, this is a test message');
+  });
+
+  it('rejects non-participants from sending messages', async () => {
+    const res = await request(app)
+      .post(`/api/v1/jobs/${bookingId}/messages`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ content: 'Unauthorized message' })
+      .expect(403);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('rejects empty message content', async () => {
+    const res = await request(app)
+      .post(`/api/v1/jobs/${bookingId}/messages`)
+      .set('Authorization', `Bearer ${validToken}`)
+      .send({ content: '' })
+      .expect(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('paginates messages', async () => {
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post(`/api/v1/jobs/${bookingId}/messages`)
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ content: `Message ${i + 1}` })
+        .expect(201);
+    }
+
+    const res = await request(app)
+      .get(`/api/v1/jobs/${bookingId}/messages?limit=3`)
+      .set('Authorization', `Bearer ${validToken}`)
+      .expect(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.length).toBeLessThanOrEqual(3);
+    expect(res.body.pagination).toBeDefined();
+    expect(res.body.pagination.hasMore).toBe(true);
+  });
+});

--- a/packages/client/components/messaging/MessageThread.tsx
+++ b/packages/client/components/messaging/MessageThread.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { defaultManager as socketManager } from "@/lib/socket"
+import { Send, MessageSquare } from "lucide-react"
+
+interface Message {
+  id: string
+  jobId: string
+  senderAddress: string
+  content: string
+  createdAt: string
+}
+
+interface MessageThreadProps {
+  jobId: string
+  currentAddress: string
+}
+
+export function MessageThread({ jobId, currentAddress }: MessageThreadProps) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [newMessage, setNewMessage] = useState("")
+  const [loading, setLoading] = useState(true)
+  const [sending, setSending] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    fetchMessages()
+    socketManager.emit("subscribe_job", jobId)
+
+    const handleNewMessage = (msg: Message) => {
+      if (msg.jobId === jobId) {
+        setMessages((prev) => [...prev, msg])
+      }
+    }
+
+    socketManager.on("message:new", handleNewMessage)
+
+    return () => {
+      socketManager.emit("unsubscribe_job", jobId)
+      socketManager.off("message:new", handleNewMessage)
+    }
+  }, [jobId])
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [messages])
+
+  async function fetchMessages() {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/messages`)
+      if (res.ok) {
+        const data = await res.json()
+        setMessages(data.data || [])
+      }
+    } catch (error) {
+      console.error("Failed to fetch messages:", error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function sendMessage() {
+    if (!newMessage.trim() || sending) return
+    setSending(true)
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: newMessage.trim() }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setMessages((prev) => [...prev, data.data])
+        setNewMessage("")
+      }
+    } catch (error) {
+      console.error("Failed to send message:", error)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  function formatTime(dateStr: string) {
+    return new Date(dateStr).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+  }
+
+  function shortenAddress(addr: string) {
+    return addr.length > 12 ? addr.slice(0, 6) + "..." + addr.slice(-4) : addr
+  }
+
+  return (
+    <Card className="flex flex-col h-[500px]">
+      <CardHeader className="border-b px-4 py-3">
+        <CardTitle className="text-base font-serif flex items-center gap-2">
+          <MessageSquare className="h-4 w-4" />
+          Messages
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex-1 flex flex-col p-0">
+        <ScrollArea ref={scrollRef} className="flex-1 p-4">
+          {loading ? (
+            <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+              Loading messages...
+            </div>
+          ) : messages.length === 0 ? (
+            <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+              No messages yet. Start the conversation!
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {messages.map((msg) => {
+                const isOwn = msg.senderAddress === currentAddress
+                return (
+                  <div
+                    key={msg.id}
+                    className={`flex ${isOwn ? "justify-end" : "justify-start"}`}
+                  >
+                    <div
+                      className={`max-w-[75%] rounded-lg px-3 py-2 ${
+                        isOwn
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted"
+                      }`}
+                    >
+                      <p className="text-xs opacity-70 mb-1">
+                        {isOwn ? "You" : shortenAddress(msg.senderAddress)}
+                      </p>
+                      <p className="text-sm">{msg.content}</p>
+                      <p
+                        className={`text-xs mt-1 ${
+                          isOwn ? "text-primary-foreground/70" : "text-muted-foreground"
+                        }`}
+                      >
+                        {formatTime(msg.createdAt)}
+                      </p>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </ScrollArea>
+        <div className="border-t p-3 flex gap-2">
+          <Input
+            value={newMessage}
+            onChange={(e) => setNewMessage(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault()
+                sendMessage()
+              }
+            }}
+            placeholder="Type a message..."
+            className="flex-1"
+          />
+          <Button
+            onClick={sendMessage}
+            disabled={!newMessage.trim() || sending}
+            size="icon"
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
closes #808 
closes #810 
closes #811 
closes #812 


- Message entity with jobId, senderAddress, content, createdAt
- GET /api/v1/jobs/:id/messages — paginated, job participants only
- POST /api/v1/jobs/:id/messages — requires auth, validates participation
- WebSocket message:new event via subscribe_job room
- Frontend MessageThread component with real-time updates
- Messages persist in DB via TypeORM

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
