### PR TITLE
[Bug] Fix Freighter wallet disconnect not clearing session

### DIFF
--- a/frontend/__tests__/wallet-account-monitor.test.tsx
+++ b/frontend/__tests__/wallet-account-monitor.test.tsx
@@ -1,11 +1,4 @@
-/**
- * __tests__/wallet-account-monitor.test.tsx
- * Issue #499 — Tests for WalletAccountMonitor: Freighter account change and
- * disconnection handling using a mock Freighter API.
- */
 import { render, act, waitFor } from "@testing-library/react";
-
-// ── Module mocks (hoisted by Jest) ────────────────────────────────────────────
 
 jest.mock("@/lib/wallet", () => ({
   subscribeToAccountChanges: jest.fn().mockReturnValue(() => {}),
@@ -26,7 +19,10 @@ jest.mock("@/components/Toast", () => ({
   ToastProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-// ── Imports after mocks ───────────────────────────────────────────────────────
+const mockRouterPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
 
 import WalletAccountMonitor from "@/components/WalletAccountMonitor";
 import * as walletLib from "@/lib/wallet";
@@ -35,12 +31,13 @@ import * as apiLib from "@/lib/api";
 const MOCK_PK = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 const MOCK_PK_B = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
 
-describe("WalletAccountMonitor (#499)", () => {
+describe("WalletAccountMonitor", () => {
   let onDisconnect: jest.Mock;
 
   beforeEach(() => {
     onDisconnect = jest.fn();
     jest.clearAllMocks();
+    mockRouterPush.mockClear();
     localStorage.clear();
     localStorage.setItem("smp_wallet_public_key", MOCK_PK);
   });
@@ -88,12 +85,13 @@ describe("WalletAccountMonitor (#499)", () => {
     expect(onDisconnect).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onDisconnect when wallet disconnects (event delivers null)", async () => {
+  it("calls onDisconnect, clears JWT, and redirects when wallet disconnects", async () => {
     let capturedCb: ((pk: string | null) => void) | null = null;
     jest.spyOn(walletLib, "subscribeToAccountChanges").mockImplementation((cb) => {
       capturedCb = cb;
       return () => {};
     });
+    const setJwtSpy = jest.spyOn(apiLib, "setJwtToken");
 
     render(
       <WalletAccountMonitor currentPublicKey={MOCK_PK} onDisconnect={onDisconnect} />,
@@ -101,7 +99,9 @@ describe("WalletAccountMonitor (#499)", () => {
 
     await act(async () => { capturedCb!(null); });
 
+    expect(setJwtSpy).toHaveBeenCalledWith(null);
     expect(onDisconnect).toHaveBeenCalledTimes(1);
+    expect(mockRouterPush).toHaveBeenCalledWith("/");
   });
 
   it("does NOT call onDisconnect when the same account key is reported", async () => {
@@ -136,6 +136,26 @@ describe("WalletAccountMonitor (#499)", () => {
     jest.useRealTimers();
   });
 
+  it("polls isConnected every 30s and disconnects when Freighter reports not connected", async () => {
+    jest.useFakeTimers();
+    jest.spyOn(walletLib, "subscribeToAccountChanges").mockReturnValue(null);
+    jest.spyOn(walletLib, "getConnectedPublicKey").mockResolvedValue(MOCK_PK);
+    jest.spyOn(walletLib, "isFreighterInstalled").mockResolvedValue(false);
+
+    render(
+      <WalletAccountMonitor currentPublicKey={MOCK_PK} onDisconnect={onDisconnect} />,
+    );
+
+    await act(async () => { jest.advanceTimersByTime(31000); });
+
+    await waitFor(() => {
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+      expect(mockRouterPush).toHaveBeenCalledWith("/");
+    });
+
+    jest.useRealTimers();
+  });
+
   it("does nothing when currentPublicKey is null", () => {
     render(
       <WalletAccountMonitor currentPublicKey={null} onDisconnect={onDisconnect} />,
@@ -144,7 +164,7 @@ describe("WalletAccountMonitor (#499)", () => {
     expect(onDisconnect).not.toHaveBeenCalled();
   });
 
-  it("stops polling after unmount (no spurious onDisconnect calls)", () => {
+  it("stops polling after unmount", () => {
     jest.useFakeTimers();
     jest.spyOn(walletLib, "subscribeToAccountChanges").mockReturnValue(null);
     jest.spyOn(walletLib, "getConnectedPublicKey").mockResolvedValue(MOCK_PK);

--- a/frontend/components/WalletAccountMonitor.tsx
+++ b/frontend/components/WalletAccountMonitor.tsx
@@ -1,12 +1,13 @@
 /**
  * components/WalletAccountMonitor.tsx
  * Monitors Freighter wallet account changes and disconnections.
- * Listens for accountChanged event and prompts re-authentication on change.
+ * Listens for accountChanged event, polls isConnected(), and polls getConnectedPublicKey.
  */
 import { useEffect } from "react";
-import { subscribeToAccountChanges } from "@/lib/wallet";
+import { subscribeToAccountChanges, isFreighterInstalled } from "@/lib/wallet";
 import { setJwtToken } from "@/lib/api";
 import { useToast } from "@/components/Toast";
+import { useRouter } from "next/router";
 
 const WALLET_PUBLIC_KEY_STORAGE_KEY = "smp_wallet_public_key";
 
@@ -20,6 +21,17 @@ export default function WalletAccountMonitor({
   onDisconnect,
 }: Props) {
   const { info } = useToast();
+  const router = useRouter();
+
+  function handleDisconnect() {
+    setJwtToken(null);
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(WALLET_PUBLIC_KEY_STORAGE_KEY);
+    }
+    onDisconnect();
+    info("Your wallet was disconnected");
+    router.push("/");
+  }
 
   useEffect(() => {
     if (!currentPublicKey) return;
@@ -29,8 +41,9 @@ export default function WalletAccountMonitor({
 
     const handleAccountChanged = (newKey: string | null) => {
       if (cancelled) return;
-      if (!newKey || newKey !== currentPublicKey) {
-        // Clear JWT and persisted state
+      if (!newKey) {
+        handleDisconnect();
+      } else if (newKey !== currentPublicKey) {
         setJwtToken(null);
         if (typeof window !== "undefined") {
           localStorage.removeItem(WALLET_PUBLIC_KEY_STORAGE_KEY);
@@ -40,12 +53,10 @@ export default function WalletAccountMonitor({
       }
     };
 
-    // Use subscribeToAccountChanges if available, otherwise poll
     const cleanup = subscribeToAccountChanges(handleAccountChanged);
     if (cleanup) {
       unsubscribe = cleanup;
     } else {
-      // Fallback: poll every 3 seconds
       const interval = setInterval(async () => {
         const { getConnectedPublicKey: getPk } = await import("@/lib/wallet");
         const pk = await getPk();
@@ -54,11 +65,25 @@ export default function WalletAccountMonitor({
       unsubscribe = () => clearInterval(interval);
     }
 
+    // Poll isConnected() every 30 seconds as additional safeguard
+    const connectionCheck = setInterval(async () => {
+      if (cancelled) return;
+      try {
+        const connected = await isFreighterInstalled();
+        if (!connected) {
+          handleDisconnect();
+        }
+      } catch {
+        handleDisconnect();
+      }
+    }, 30000);
+
     return () => {
       cancelled = true;
       unsubscribe?.();
+      clearInterval(connectionCheck);
     };
-  }, [currentPublicKey, onDisconnect, info]);
+  }, [currentPublicKey, onDisconnect, info, router]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

When a user disconnects their Freighter wallet externally (locking Freighter or disabling the extension), the app continued showing them as authenticated with no redirect or session clear.

## Changes

### WalletAccountMonitor (`frontend/components/WalletAccountMonitor.tsx`)
- Separated disconnect (null key) from account change (different key) handling
- On disconnect: clears JWT, removes persisted key, redirects to `/`, shows toast "Your wallet was disconnected"
- Added 30-second `isConnected()` polling as additional safeguard alongside existing 3-second `getConnectedPublicKey` polling

### Tests (`frontend/__tests__/wallet-account-monitor.test.tsx`)
- Updated disconnect test to verify redirect to `/`
- Added test for 30-second `isConnected()` polling detecting disconnection

Closes #854