### PR TITLE
chore: add .editorconfig for consistent indentation and line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps maintain consistent coding styles across different editors.
+# https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# JavaScript / TypeScript / JSON
+[*.{js,jsx,ts,tsx,json,jsonc}]
+indent_style = space
+indent_size = 2
+
+# Rust
+[*.rs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
## Summary
add .editorconfig for consistent indentation and line endings
Contributors use different editors (VS Code, Vim, IntelliJ) without a
shared config, causing indentation and line-ending mismatches that
create noisy diffs.
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [✔ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #740 

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
