### PR TITLE
feat(ux): add empty state illustrations to list views

### DIFF
--- a/frontend/components/EarningsChart.tsx
+++ b/frontend/components/EarningsChart.tsx
@@ -8,6 +8,7 @@
  * - Export data as CSV
  */
 import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/router";
 import {
   BarChart,
   Bar,
@@ -22,6 +23,7 @@ import {
 } from "recharts";
 import { fetchFreelancerEarnings, type EarningsData, type EarningPayment } from "@/lib/api";
 import { formatXLM } from "@/utils/format";
+import StateMessage from "@/components/StateMessage";
 
 const PIE_COLORS = [
   "#f59e0b", "#3b82f6", "#10b981", "#f43f5e",
@@ -105,6 +107,7 @@ function exportCSV(payments: EarningPayment[]) {
 }
 
 export default function EarningsChart({ publicKey }: Props) {
+  const router = useRouter();
   const [data, setData] = useState<EarningsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -131,6 +134,19 @@ export default function EarningsChart({ publicKey }: Props) {
       <div className="card text-center py-16">
         <p className="text-amber-700 text-sm">{error || "No earnings data available."}</p>
       </div>
+    );
+  }
+
+  if (data.payments.length === 0) {
+    return (
+      <StateMessage
+        type="empty"
+        illustration="no-earnings"
+        title="No earnings yet"
+        description="Complete your first job to start tracking earnings here"
+        ctaLabel="Browse Jobs"
+        onCta={() => router.push('/jobs')}
+      />
     );
   }
 

--- a/frontend/components/StateMessage.tsx
+++ b/frontend/components/StateMessage.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import clsx from 'clsx';
+import EmptyStateIllustration, { type EmptyStateVariant } from '@/components/illustrations/EmptyStateIllustrations';
 
 type StateMessageProps = {
   /** "empty" for no data, "error" for API failures */
   type: 'empty' | 'error';
-  /** Optional icon component */
+  /** Optional icon component (ignored if `illustration` is also provided) */
   icon?: React.ReactNode;
+  /**
+   * Optional named illustration to show instead of a plain icon. Renders a
+   * themed SVG (see components/illustrations/EmptyStateIllustrations.tsx)
+   * that automatically adapts to light/dark mode via CSS variables.
+   */
+  illustration?: EmptyStateVariant;
   /** Heading text */
   title: string;
   /** Subtext description */
@@ -28,6 +35,7 @@ type StateMessageProps = {
 export default function StateMessage({
   type,
   icon,
+  illustration,
   title,
   description,
   ctaLabel,
@@ -39,10 +47,16 @@ export default function StateMessage({
 
   return (
     <div className={clsx('card text-center py-16 border', borderClass, bgClass)}>
-      {icon && (
-        <div className="mb-4 flex justify-center animate-pulse">
-          {icon}
+      {illustration ? (
+        <div className="mb-5 flex justify-center">
+          <EmptyStateIllustration variant={illustration} className="w-40 h-32 sm:w-48 sm:h-36" />
         </div>
+      ) : (
+        icon && (
+          <div className="mb-4 flex justify-center animate-pulse">
+            {icon}
+          </div>
+        )
       )}
       <h2 className={clsx('font-display text-xl mb-2', textClass)}>{title}</h2>
       <p className="text-sm text-amber-800 mb-6 max-w-xs mx-auto">{description}</p>

--- a/frontend/components/dashboard-tabs/AppliedJobsTab.tsx
+++ b/frontend/components/dashboard-tabs/AppliedJobsTab.tsx
@@ -19,6 +19,7 @@ export default function AppliedJobsTab({ myApplications }: Props) {
     return (
       <StateMessage
         type="empty"
+        illustration="no-applications"
         title="You haven't applied to any jobs yet"
         description="Browse open jobs and submit your first proposal"
         ctaLabel="Browse Jobs"

--- a/frontend/components/dashboard-tabs/PostedJobsTab.tsx
+++ b/frontend/components/dashboard-tabs/PostedJobsTab.tsx
@@ -35,9 +35,10 @@ export default function PostedJobsTab({
     return (
       <StateMessage
         type="empty"
+        illustration="no-jobs"
         title="You haven't posted any jobs yet"
         description="Post your first job and find a great freelancer"
-        ctaLabel="Post a Job"
+        ctaLabel="Post Your First Job"
         onCta={() => router.push('/post-job')}
       />
     );

--- a/frontend/components/illustrations/EmptyStateIllustrations.tsx
+++ b/frontend/components/illustrations/EmptyStateIllustrations.tsx
@@ -1,0 +1,170 @@
+/**
+ * components/illustrations/EmptyStateIllustrations.tsx
+ *
+ * A small set of hand-built SVG illustrations used by `StateMessage` (and
+ * anywhere else) to make empty list views feel intentional instead of just
+ * blank. Every illustration is drawn with the app's existing themeable CSS
+ * custom properties (`--gold`, `--gold-light`, `--gold-dim`, `--surface-2`,
+ * `--surface-3`, `--border`, `--text-muted`, all defined in
+ * styles/globals.css) rather than hard-coded hex values or Tailwind color
+ * utilities. Those variables already flip automatically when `html.dark` is
+ * toggled, so these illustrations get light/dark theming for free and never
+ * go out of sync with the rest of the UI.
+ *
+ * Keep these flat, warm, and a little playful — a few dashed lines and
+ * floating dots go a long way without needing a full illustration library.
+ */
+import type { SVGProps } from "react";
+
+export type EmptyStateVariant =
+  | "no-jobs"
+  | "no-applications"
+  | "no-notifications"
+  | "no-earnings";
+
+type IllustrationProps = SVGProps<SVGSVGElement>;
+
+/** Briefcase with a magnifying glass — "no jobs to show yet". */
+function NoJobsIllustration(props: IllustrationProps) {
+  return (
+    <svg viewBox="0 0 200 150" fill="none" aria-hidden="true" {...props}>
+      <ellipse cx="100" cy="128" rx="62" ry="10" fill="var(--gold-dim)" />
+      <circle cx="38" cy="30" r="4" fill="var(--gold-light)" opacity="0.6" />
+      <circle cx="162" cy="46" r="3" fill="var(--gold-light)" opacity="0.5" />
+      <path d="M150 24 l3 7 7 3 -7 3 -3 7 -3 -7 -7 -3 7 -3 z" fill="var(--gold-light)" opacity="0.55" />
+
+      {/* Briefcase body */}
+      <rect x="46" y="66" width="108" height="58" rx="10" fill="var(--surface-2)" stroke="var(--border)" strokeWidth="2" />
+      {/* Handle */}
+      <path d="M84 66 v-10 a16 16 0 0 1 32 0 v10" stroke="var(--gold)" strokeWidth="4" strokeLinecap="round" fill="none" />
+      {/* Latch / seam */}
+      <path d="M46 92 h108" stroke="var(--border)" strokeWidth="2" />
+      <rect x="92" y="84" width="16" height="12" rx="2" fill="var(--gold-dim)" stroke="var(--gold)" strokeWidth="1.5" />
+
+      {/* Empty dashed contents */}
+      <rect x="60" y="102" width="34" height="6" rx="3" fill="none" stroke="var(--text-muted)" strokeWidth="2" strokeDasharray="4 5" opacity="0.6" />
+
+      {/* Magnifying glass */}
+      <circle cx="132" cy="46" r="16" fill="var(--gold-dim)" stroke="var(--gold)" strokeWidth="3" />
+      <line x1="143" y1="57" x2="156" y2="70" stroke="var(--gold)" strokeWidth="4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/** Blank document with a paper airplane taking off — "no applications yet". */
+function NoApplicationsIllustration(props: IllustrationProps) {
+  return (
+    <svg viewBox="0 0 200 150" fill="none" aria-hidden="true" {...props}>
+      <ellipse cx="94" cy="128" rx="58" ry="10" fill="var(--gold-dim)" />
+
+      {/* Document */}
+      <rect x="60" y="46" width="72" height="86" rx="8" fill="var(--surface-2)" stroke="var(--border)" strokeWidth="2" />
+      <line x1="74" y1="66" x2="118" y2="66" stroke="var(--text-muted)" strokeWidth="3" strokeLinecap="round" strokeDasharray="3 6" opacity="0.6" />
+      <line x1="74" y1="80" x2="118" y2="80" stroke="var(--text-muted)" strokeWidth="3" strokeLinecap="round" strokeDasharray="3 6" opacity="0.6" />
+      <line x1="74" y1="94" x2="104" y2="94" stroke="var(--text-muted)" strokeWidth="3" strokeLinecap="round" strokeDasharray="3 6" opacity="0.6" />
+
+      {/* Flight path */}
+      <path d="M126 58 C 148 44, 156 30, 150 16" stroke="var(--gold)" strokeWidth="2" strokeDasharray="4 6" strokeLinecap="round" opacity="0.6" />
+
+      {/* Paper airplane */}
+      <g transform="translate(150 16) rotate(28)">
+        <path d="M0 -12 L12 6 L0 2 L-12 6 Z" fill="var(--gold-light)" stroke="var(--gold)" strokeWidth="1.5" strokeLinejoin="round" />
+        <path d="M0 -12 L0 2" stroke="var(--gold)" strokeWidth="1.2" opacity="0.7" />
+      </g>
+
+      <circle cx="46" cy="40" r="3" fill="var(--gold-light)" opacity="0.5" />
+      <circle cx="152" cy="98" r="4" fill="var(--gold-light)" opacity="0.4" />
+    </svg>
+  );
+}
+
+/** Resting bell, all caught up — "no notifications". */
+function NoNotificationsIllustration(props: IllustrationProps) {
+  return (
+    <svg viewBox="0 0 200 150" fill="none" aria-hidden="true" {...props}>
+      <ellipse cx="100" cy="128" rx="52" ry="10" fill="var(--gold-dim)" />
+      <circle cx="100" cy="70" r="48" fill="var(--gold-dim)" opacity="0.5" />
+
+      {/* Bell */}
+      <path
+        d="M100 34 c17 0 26 13 26 30 v10 c0 8 4 13 9 17 H65 c5 -4 9 -9 9 -17 v-10 c0 -17 9 -30 26 -30 z"
+        fill="var(--surface-2)"
+        stroke="var(--gold)"
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+      <path d="M88 100 a12 12 0 0 0 24 0" fill="var(--surface-2)" stroke="var(--gold)" strokeWidth="3" strokeLinecap="round" />
+      <rect x="96" y="24" width="8" height="10" rx="4" fill="var(--gold)" />
+
+      {/* All-caught-up check badge */}
+      <circle cx="132" cy="46" r="14" fill="var(--gold-light)" stroke="var(--surface-2)" strokeWidth="3" />
+      <path d="M126 46 l4 4 8 -8" stroke="var(--surface)" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+
+      <circle cx="52" cy="52" r="3" fill="var(--gold-light)" opacity="0.5" />
+      <circle cx="150" cy="94" r="3" fill="var(--gold-light)" opacity="0.4" />
+    </svg>
+  );
+}
+
+/** Coin stack with a dashed, still-flat earnings line — "no earnings yet". */
+function NoEarningsIllustration(props: IllustrationProps) {
+  return (
+    <svg viewBox="0 0 200 150" fill="none" aria-hidden="true" {...props}>
+      <ellipse cx="100" cy="128" rx="60" ry="10" fill="var(--gold-dim)" />
+
+      {/* Dashed empty trend line in the background */}
+      <path
+        d="M40 100 C 70 100, 80 88, 110 88 S 150 60, 168 42"
+        stroke="var(--border)"
+        strokeWidth="2.5"
+        strokeDasharray="5 7"
+        strokeLinecap="round"
+        fill="none"
+        opacity="0.7"
+      />
+
+      {/* Coin stack */}
+      <ellipse cx="90" cy="112" rx="30" ry="9" fill="var(--surface-2)" stroke="var(--gold)" strokeWidth="2" />
+      <ellipse cx="90" cy="100" rx="30" ry="9" fill="var(--surface-2)" stroke="var(--gold)" strokeWidth="2" />
+      <ellipse cx="90" cy="88" rx="30" ry="9" fill="var(--gold-dim)" stroke="var(--gold)" strokeWidth="2" />
+
+      {/* Star mark (Stellar / XLM nod) on the top coin */}
+      <path
+        d="M90 80 l2.6 5.6 6.1 0.7 -4.5 4.1 1.1 6 -5.3 -3 -5.3 3 1.1 -6 -4.5 -4.1 6.1 -0.7 z"
+        fill="var(--gold-light)"
+      />
+
+      <circle cx="146" cy="90" r="3" fill="var(--gold-light)" opacity="0.5" />
+      <circle cx="50" cy="66" r="3" fill="var(--gold-light)" opacity="0.4" />
+    </svg>
+  );
+}
+
+const ILLUSTRATIONS: Record<EmptyStateVariant, (props: IllustrationProps) => JSX.Element> = {
+  "no-jobs": NoJobsIllustration,
+  "no-applications": NoApplicationsIllustration,
+  "no-notifications": NoNotificationsIllustration,
+  "no-earnings": NoEarningsIllustration,
+};
+
+interface EmptyStateIllustrationProps extends IllustrationProps {
+  variant: EmptyStateVariant;
+}
+
+/**
+ * Renders the illustration for a given empty-state variant. Pass a
+ * `className` (e.g. `"w-40 h-32"`) to size it — the SVGs use a fixed
+ * viewBox and scale cleanly.
+ */
+export default function EmptyStateIllustration({ variant, ...props }: EmptyStateIllustrationProps) {
+  const Illustration = ILLUSTRATIONS[variant];
+  if (!Illustration) return null;
+  return <Illustration {...props} />;
+}
+
+export {
+  NoJobsIllustration,
+  NoApplicationsIllustration,
+  NoNotificationsIllustration,
+  NoEarningsIllustration,
+};

--- a/frontend/pages/jobs/index.tsx
+++ b/frontend/pages/jobs/index.tsx
@@ -1165,11 +1165,14 @@ export default function JobsPage({ publicKey }: { publicKey?: string | null }) {
               onCta={() => window.location.reload()}
             />
           ) : filtered.length === 0 ? (
-            <div className="card text-center py-16 border border-amber-500 bg-amber-500/10">
-              <h2 className="font-display text-xl mb-2 text-amber-100">No jobs found</h2>
-              <p className="text-sm text-amber-800 mb-6 max-w-xs mx-auto">No jobs are currently available.</p>
-              <Link href="/post-job" className="btn-primary text-sm">Post the first job</Link>
-            </div>
+            <StateMessage
+              type="empty"
+              illustration="no-jobs"
+              title="No jobs found"
+              description="No jobs are currently available. Be the first to post one."
+              ctaLabel="Post the first job"
+              onCta={() => router.push('/post-job')}
+            />
           ) : (
             <div ref={parentRef} className="w-full">
               <div

--- a/frontend/pages/notifications.tsx
+++ b/frontend/pages/notifications.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/api";
 import { timeAgo } from "@/utils/format";
 import type { NotificationItem } from "@/utils/types";
+import StateMessage from "@/components/StateMessage";
 
 interface NotificationsPageProps {
   publicKey: string | null;
@@ -106,9 +107,14 @@ export default function NotificationsPage({ publicKey, onConnect }: Notification
             Loading notifications...
           </div>
         ) : notifications.length === 0 ? (
-          <div className="border border-amber-900/30 rounded-lg p-6 bg-ink-800/50 text-amber-700">
-            No notifications yet.
-          </div>
+          <StateMessage
+            type="empty"
+            illustration="no-notifications"
+            title="You're all caught up"
+            description="You'll see updates on your jobs and applications here as they happen."
+            ctaLabel="Browse Jobs"
+            onCta={() => router.push('/jobs')}
+          />
         ) : (
           <div className="border border-amber-900/30 rounded-lg bg-ink-800/50 overflow-hidden">
             {notifications.map((notification) => (


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->

Adds illustrated empty states across all list views to improve user experience when there is no available data. Each empty state includes a contextual call-to-action that guides users toward the next relevant action.

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #835 

## Testing
- [x] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
