### PR TITLE
#855 [Bug] Fix PostJobForm not resetting after successful submission …

### DIFF
--- a/frontend/__tests__/PostJobForm.test.tsx
+++ b/frontend/__tests__/PostJobForm.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import PostJobForm from "@/components/PostJobForm";
+import { createJob, updateJobEscrowId, getJwtToken } from "@/lib/api";
+import { createEscrowOnChain } from "@/lib/stellar";
+import "@testing-library/jest-dom";
+
+// Mock the required modules
+jest.mock("@/contexts/PriceContext", () => ({
+  usePriceContext: () => ({
+    xlmPriceUsd: 0.12,
+    priceLoading: false,
+    currencyMode: "XLM",
+    setCurrencyMode: jest.fn(),
+  }),
+  PriceProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock("@/lib/api", () => ({
+  createJob: jest.fn(),
+  updateJobEscrowId: jest.fn(),
+  deleteJob: jest.fn(),
+  saveDraft: jest.fn().mockResolvedValue({ id: "draft-123" }),
+  updateDraft: jest.fn().mockResolvedValue({ id: "draft-123" }),
+  getJwtToken: jest.fn(),
+  fetchCategories: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("@/lib/wallet", () => ({
+  performSEP0010Auth: jest.fn().mockResolvedValue({ token: "mock-jwt" }),
+}));
+
+jest.mock("@/lib/stellar", () => ({
+  createEscrowOnChain: jest.fn(),
+}));
+
+const MOCK_PK = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+describe("PostJobForm reset behavior", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    (getJwtToken as jest.Mock).mockReturnValue("mock-jwt");
+    (createJob as jest.Mock).mockResolvedValue({ id: "job-123" });
+    (createEscrowOnChain as jest.Mock).mockResolvedValue({ txHash: "mock-tx-hash" });
+    (updateJobEscrowId as jest.Mock).mockResolvedValue({});
+  });
+
+  it("resets form and clears all step states in the multi-step form on successful job creation", async () => {
+    render(<PostJobForm publicKey={MOCK_PK} />);
+
+    // --- STEP 1: Basic Info ---
+    expect(screen.getByText("Step 1 of 4")).toBeInTheDocument();
+
+    // Fill title and description
+    const titleInput = screen.getByPlaceholderText("e.g. Build a Soroban DEX interface");
+    const descInput = screen.getByPlaceholderText("Describe the work, deliverables, and any context...");
+
+    fireEvent.change(titleInput, { target: { value: "Soroban DEX Interface Implementation" } });
+    fireEvent.change(descInput, { target: { value: "This is a detailed description of the Soroban DEX interface that satisfies the 30 characters limit." } });
+
+    // Click Next
+    const nextBtn1 = screen.getByRole("button", { name: "Next →" });
+    fireEvent.click(nextBtn1);
+
+    // --- STEP 2: Budget & Escrow ---
+    await waitFor(() => {
+      expect(screen.getByText("Step 2 of 4")).toBeInTheDocument();
+    });
+
+    // Default values are valid, so click Next
+    const nextBtn2 = screen.getByRole("button", { name: "Next →" });
+    fireEvent.click(nextBtn2);
+
+    // --- STEP 3: Requirements ---
+    await waitFor(() => {
+      expect(screen.getByText("Step 3 of 4")).toBeInTheDocument();
+    });
+
+    const nextBtn3 = screen.getByRole("button", { name: "Next →" });
+    fireEvent.click(nextBtn3);
+
+    // --- STEP 4: Review & Publish ---
+    await waitFor(() => {
+      expect(screen.getByText("Step 4 of 4")).toBeInTheDocument();
+    });
+
+    // Click Publish Job
+    const publishBtn = screen.getByRole("button", { name: "Publish Job" });
+    fireEvent.click(publishBtn);
+
+    // Verify completion
+    await waitFor(() => {
+      expect(screen.getByText("Job Posted!")).toBeInTheDocument();
+    });
+
+    // Verify localStorage draft is cleared
+    expect(localStorage.getItem("marketpay_post_job_draft")).toBeNull();
+
+    // Now let's click "Post Another Job" to go back to the form and verify that everything was cleared/reset
+    const postAnotherBtn = screen.getByRole("button", { name: "Post Another Job" });
+    fireEvent.click(postAnotherBtn);
+
+    // Verify we are back to Step 1
+    await waitFor(() => {
+      expect(screen.getByText("Step 1 of 4")).toBeInTheDocument();
+    });
+
+    // Verify that the title and description fields are completely empty (reset)
+    const resetTitleInput = screen.getByPlaceholderText("e.g. Build a Soroban DEX interface") as HTMLInputElement;
+    const resetDescInput = screen.getByPlaceholderText("Describe the work, deliverables, and any context...") as HTMLTextAreaElement;
+
+    expect(resetTitleInput.value).toBe("");
+    expect(resetDescInput.value).toBe("");
+  });
+});

--- a/frontend/__tests__/setup/snapshotMocks.tsx
+++ b/frontend/__tests__/setup/snapshotMocks.tsx
@@ -87,6 +87,7 @@ jest.mock("@/components/Toast", () => {
 });
 
 jest.mock("@/lib/api", () => ({
+  fetchCategories: jest.fn().mockResolvedValue([]),
   submitRating: jest.fn().mockResolvedValue({}),
   submitApplication: jest.fn().mockResolvedValue({}),
   fetchProposalTemplates: jest.fn().mockResolvedValue([]),

--- a/frontend/components/PostJobForm.tsx
+++ b/frontend/components/PostJobForm.tsx
@@ -189,6 +189,8 @@ export default function PostJobForm({
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
   const [jobId, setJobId] = useState<string | null>(null);
+  const [postedBudget, setPostedBudget] = useState<string>("");
+  const [postedCurrency, setPostedCurrency] = useState<string>("");
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
@@ -414,8 +416,31 @@ export default function PostJobForm({
       });
       await updateJobEscrowId(createdJobId, hash);
       setTxHash(hash);
+      setPostedBudget(form.budget);
+      setPostedCurrency(form.currency);
       setSubmitStep("complete");
       localStorage.removeItem(DRAFT_STORAGE_KEY);
+
+      // Call form.reset() equivalent and clear step states
+      setForm({
+        title: "",
+        description: "",
+        budget: "50",
+        currency: "XLM",
+        category: initialCategory || "Smart Contracts",
+        skills: "",
+        deadline: "",
+        milestones: [{ description: "Final delivery", amount: "50" }],
+        visibility: "public",
+        screeningQuestions: [""],
+        isRecurring: false,
+        intervalDays: "30",
+        totalReleases: "12",
+      });
+      setCurrentStep(1);
+      setCompletedSteps(new Set());
+      setTouched({});
+      setDraftId(null);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "An unexpected error occurred.";
       if (createdJobId) await deleteJob(createdJobId).catch(() => {});
@@ -430,6 +455,8 @@ export default function PostJobForm({
     setErrorMsg(null);
     setTxHash(null);
     setJobId(null);
+    setPostedBudget("");
+    setPostedCurrency("");
     setCurrentStep(1);
     setCompletedSteps(new Set());
     setForm({
@@ -437,7 +464,7 @@ export default function PostJobForm({
       description: "",
       budget: "50",
       currency: "XLM",
-      category: "Smart Contracts",
+      category: initialCategory || "Smart Contracts",
       skills: "",
       deadline: "",
       visibility: "public",
@@ -463,7 +490,7 @@ export default function PostJobForm({
           <h2 className="text-2xl font-bold text-gray-900 dark:text-amber-100">Job Posted!</h2>
           <p className="text-gray-500 dark:text-amber-700 text-sm">
             Your budget of{" "}
-            <span className="font-semibold text-market-400">{form.budget} {form.currency}</span>{" "}
+            <span className="font-semibold text-market-400">{postedBudget || form.budget} {postedCurrency || form.currency}</span>{" "}
             has been locked in escrow.
           </p>
         </div>

--- a/frontend/components/PostJobFormtypes.ts
+++ b/frontend/components/PostJobFormtypes.ts
@@ -9,6 +9,7 @@ export interface Milestone {
 }
 
 export interface JobFormData {
+  id?: string;
   title: string;
   description: string;
   budget: string;

--- a/frontend/hooks/usePushNotifications.ts
+++ b/frontend/hooks/usePushNotifications.ts
@@ -128,7 +128,7 @@ export function usePushNotifications() {
         throw new Error("Failed to save subscription on backend");
       }
 
-      setState((prev) => ({ ...prev, isSubscribed: true });
+      setState((prev) => ({ ...prev, isSubscribed: true }));
       success("Push notifications enabled");
       return true;
     } catch (err) {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2258,52 +2258,7 @@ export async function registerReferral(
   });
 }
 
-// ─── Saved Searches (Issue #284) ─────────────────────────────────────────────
 
-export interface SavedSearch {
-  id: string;
-  user_address: string;
-  query_params: Record<string, string>;
-  notify_in_app: boolean;
-  notify_email: boolean;
-  last_notified_at: string | null;
-  created_at: string;
-  updated_at: string;
-}
-
-export async function fetchSavedSearches(): Promise<SavedSearch[]> {
-  const { data } = await api.get<{ success: boolean; data: SavedSearch[] }>(
-    "/api/saved-searches"
-  );
-  return data.data;
-}
-
-export async function createSavedSearch(payload: {
-  query_params: Record<string, string>;
-  notify_in_app?: boolean;
-  notify_email?: boolean;
-}): Promise<SavedSearch> {
-  const { data } = await api.post<{ success: boolean; data: SavedSearch }>(
-    "/api/saved-searches",
-    payload
-  );
-  return data.data;
-}
-
-export async function updateSavedSearch(
-  id: string,
-  payload: { notify_in_app?: boolean; notify_email?: boolean }
-): Promise<SavedSearch> {
-  const { data } = await api.patch<{ success: boolean; data: SavedSearch }>(
-    `/api/saved-searches/${id}`,
-    payload
-  );
-  return data.data;
-}
-
-export async function deleteSavedSearch(id: string): Promise<void> {
-  await api.delete(`/api/saved-searches/${id}`);
-}
 
 // ─── Job Boost (Issue #344) ───────────────────────────────────────────────────
 

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -37,6 +37,7 @@ export interface EscrowParams {
   jobId: string;
   budget?: number;
   budgetXlm?: number;
+  currency?: string;
 }
 
 export interface EscrowResult {


### PR DESCRIPTION
## Summary

This PR addresses the data retention issue inside `PostJobForm` where successfully creating a job retained the previously entered data and progress step indicators upon navigating back to it.

Key changes introduced:
1. **State Reset (Equivalent to `form.reset()`)**: Reset the fully-controlled React `form` state back to its initial clean defaults immediately upon successful job creation and transaction publication.
2. **Step State Clearance**: Cleared all multi-step form states: reset `currentStep` back to `1`, cleared `completedSteps` by assigning an empty `Set()`, reset `touched` field tracking back to `{}`, and cleared the local `draftId`.
3. **Success State Preservation**: Integrated `postedBudget` and `postedCurrency` cache states to store final metrics before form clearing, allowing the completion screen to display accurate budget and asset details.
4. **Unit Test Coverage**: Created `frontend/__tests__/PostJobForm.test.tsx` to simulate full multi-step validation, submission, success screens, and verify that the form successfully resets to pristine fields upon clicking "Post Another Job".
5. **Codebase Maintenance**: Corrected pre-existing typescript typing bugs in `stellar.ts` (`EscrowParams`), fixed a syntax typo in `usePushNotifications.ts`, and removed duplicate functions inside `api.ts` to ensure 100% clean builds.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue

Closes #855 

## Testing

- [x] Tested locally on Testnet (and local testing environments)
- [x] No TypeScript / Rust errors (Fixed compiling, typing, and syntax errors across the modified files)
- [x] Docs updated if needed

## Screenshots (if UI change)

* **Success Screen**: Dynamically displays the correctly posted budget (e.g. `50 XLM`) using saved references even after the main form state is fully reset.
* **Navigation Back / Reset Form Screen**: Clicking "Post Another Job" or returning via browser navigation seamlessly renders a completely blank Step 1 form with progress reset to step 1.