### PR TITLE
[Refactor] Migrate backend to TypeScript

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "typeRoots": ["./node_modules/@types", "./src/types"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.js"],
+  "exclude": ["node_modules", "dist", "coverage", "**/*.test.ts", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## Overview

Add TypeScript configuration to the backend to enable incremental migration from JavaScript to TypeScript.

## Related Issue

Closes #828

## Changes

[ADD] backend/tsconfig.json
- Strict mode enabled
- ES2022 target with CommonJS modules
- allowJs for incremental migration
- Source maps and declarations

## Verification

tsc --noEmit passes with no errors