### PR TITLE
#767 [Frontend] Add i18n support for Spanish and French locales FIXED

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,29 @@
+name: Translation completeness
+
+on:
+  pull_request:
+    paths:
+      - "frontend/public/locales/**"
+      - "frontend/components/**"
+      - "frontend/pages/**"
+      - "frontend/scripts/check-translations.mjs"
+  push:
+    branches: [main]
+
+jobs:
+  check-translations:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --legacy-peer-deps --force
+      # Emits GitHub workflow warnings for every English key not represented in
+      # Spanish, French, or Portuguese, then fails so it cannot be overlooked.
+      - run: npm run i18n:check

--- a/frontend/__tests__/LanguageSwitcher.test.tsx
+++ b/frontend/__tests__/LanguageSwitcher.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import { createInstance } from "i18next";
+import LanguageSwitcher from "@/components/LanguageSwitcher";
+
+import en from "@/public/locales/en/common.json";
+import es from "@/public/locales/es/common.json";
+import fr from "@/public/locales/fr/common.json";
+import pt from "@/public/locales/pt/common.json";
+
+function createI18n() {
+  const instance = createInstance();
+  instance.init({
+    lng: "en",
+    fallbackLng: "en",
+    resources: { en: { common: en }, es: { common: es }, fr: { common: fr }, pt: { common: pt } },
+    defaultNS: "common",
+    interpolation: { escapeValue: false },
+  });
+  return instance;
+}
+
+describe("LanguageSwitcher", () => {
+  it("changes the next-i18next language and updates the accessible label", async () => {
+    const i18n = createI18n();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <LanguageSwitcher />
+      </I18nextProvider>,
+    );
+
+    const selector = screen.getByLabelText("Switch Language") as HTMLSelectElement;
+    expect(selector.value).toBe("en");
+    expect(screen.getByRole("option", { name: "Français" })).toBeInTheDocument();
+
+    fireEvent.change(selector, { target: { value: "es" } });
+
+    await waitFor(() => {
+      expect(i18n.language).toBe("es");
+      expect(screen.getByLabelText("Cambiar Idioma")).toBeInTheDocument();
+    });
+    expect(localStorage.getItem("preferredLocale")).toBe("es");
+  });
+});

--- a/frontend/__tests__/i18n.test.ts
+++ b/frontend/__tests__/i18n.test.ts
@@ -1,90 +1,37 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
-const LOCALES_DIR = path.join(__dirname, '../public/locales');
-const EN_DIR = path.join(LOCALES_DIR, 'en');
+const LOCALES_DIR = path.join(__dirname, "../public/locales");
+const REQUIRED_LOCALES = ["es", "fr", "pt"];
 
-/**
- * Flattens a nested object into a flat dictionary with dot-notation keys.
- */
-function flattenObject(obj: Record<string, any>, prefix = ''): Record<string, string> {
-  return Object.keys(obj).reduce((acc: Record<string, string>, k: string) => {
-    const pre = prefix.length ? prefix + '.' : '';
-    if (typeof obj[k] === 'object' && obj[k] !== null && !Array.isArray(obj[k])) {
-      Object.assign(acc, flattenObject(obj[k], pre + k));
+function flattenObject(obj: Record<string, unknown>, prefix = ""): Record<string, unknown> {
+  return Object.entries(obj).reduce((result: Record<string, unknown>, [key, value]) => {
+    const keyPath = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      Object.assign(result, flattenObject(value as Record<string, unknown>, keyPath));
     } else {
-      acc[pre + k] = obj[k];
+      result[keyPath] = value;
     }
-    return acc;
+    return result;
   }, {});
 }
 
-/**
- * Sets a value in a nested object based on a dot-notation key path.
- */
-function setNestedValue(obj: Record<string, any>, keyPath: string, value: string) {
-  const keys = keyPath.split('.');
-  let current = obj;
-  for (let i = 0; i < keys.length - 1; i++) {
-    const k = keys[i];
-    if (!current[k]) current[k] = {};
-    current = current[k];
-  }
-  current[keys[keys.length - 1]] = value;
-}
+describe("i18n translations completeness", () => {
+  const english = flattenObject(
+    JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, "en/common.json"), "utf-8")),
+  );
 
-describe('i18n translations completeness', () => {
-  it('should have all keys in all supported languages with <= 5% missing', () => {
-    const enCommonPath = path.join(EN_DIR, 'common.json');
-    const enCommon = JSON.parse(fs.readFileSync(enCommonPath, 'utf-8'));
-    const enKeys = flattenObject(enCommon);
-    const totalEnKeys = Object.keys(enKeys).length;
+  it.each(REQUIRED_LOCALES)("has every English key translated in %s", (locale) => {
+    const translated = flattenObject(
+      JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, locale, "common.json"), "utf-8")),
+    );
 
-    // Get all language directories except English
-    const languages = fs
-      .readdirSync(LOCALES_DIR)
-      .filter((dir) => dir !== 'en' && fs.statSync(path.join(LOCALES_DIR, dir)).isDirectory());
+    const missing = Object.keys(english).filter((key) => !(key in translated));
+    const placeholders = Object.entries(translated)
+      .filter(([, value]) => typeof value === "string" && value.includes("[TRANSLATE]"))
+      .map(([key]) => key);
 
-    languages.forEach((lang) => {
-      const langCommonPath = path.join(LOCALES_DIR, lang, 'common.json');
-      let langCommon: Record<string, any> = {};
-
-      if (fs.existsSync(langCommonPath)) {
-        langCommon = JSON.parse(fs.readFileSync(langCommonPath, 'utf-8'));
-      }
-
-      const langKeys = flattenObject(langCommon);
-      let missingCount = 0;
-      const missingKeyPaths: string[] = [];
-      let wasModified = false;
-
-      // Verify every key in en/ exists in this language namespace
-      Object.entries(enKeys).forEach(([keyPath, enValue]) => {
-        if (!(keyPath in langKeys)) {
-          missingCount++;
-          missingKeyPaths.push(keyPath);
-          // Auto-generate stub translations for missing keys (marked [TRANSLATE])
-          setNestedValue(langCommon, keyPath, `[TRANSLATE] ${enValue}`);
-          wasModified = true;
-        }
-      });
-
-      // Write changes back to auto-generate stubs if any keys were missing
-      if (wasModified) {
-        fs.writeFileSync(langCommonPath, JSON.stringify(langCommon, null, 2) + '\n', 'utf-8');
-      }
-
-      const missingPercentage = missingCount / totalEnKeys;
-
-      // Reports missing keys per language
-      if (missingCount > 0) {
-        console.warn(
-          `Language '${lang}' is missing ${missingCount} keys (${(missingPercentage * 100).toFixed(2)}%):\n${missingKeyPaths.map((k) => `  - ${k}`).join('\n')}`
-        );
-      }
-
-      // CI fails if any language is missing > 5% of keys
-      expect(missingPercentage).toBeLessThanOrEqual(0.05);
-    });
+    expect(missing).toEqual([]);
+    expect(placeholders).toEqual([]);
   });
 });

--- a/frontend/components/LanguageSwitcher.tsx
+++ b/frontend/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@
  * components/LanguageSwitcher.tsx
  * Navbar language selector with localStorage persistence (#282).
  */
+import { useRouter } from "next/router";
 import { useTranslation } from "@/lib/i18n";
 
 const LOCALES = [
@@ -16,12 +17,19 @@ interface LanguageSwitcherProps {
 }
 
 export default function LanguageSwitcher({ className = "" }: LanguageSwitcherProps) {
+  const router = useRouter();
   const { t, i18n } = useTranslation("common");
 
-  const switchLanguage = (lang: string) => {
-    i18n.changeLanguage(lang);
+  const switchLanguage = async (lang: string) => {
+    await i18n.changeLanguage(lang);
     if (typeof window !== "undefined") {
       localStorage.setItem("preferredLocale", lang);
+    }
+
+    // Keep Next.js locale routing in sync with the next-i18next instance while
+    // preserving the current path, query string, and hash.
+    if (router.locale !== lang) {
+      await router.push(router.asPath, router.asPath, { locale: lang });
     }
   };
 

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -9,7 +9,6 @@ import clsx from "clsx";
 import { useTranslation } from "@/lib/i18n";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import FaucetButton from "@/components/FaucetButton";
-import i18next from "@/lib/i18n";
 import { usePriceContext } from "@/contexts/PriceContext";
 import NotificationBell from "@/components/NotificationBell";
 
@@ -33,7 +32,7 @@ const STELLAR_NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet";
 
 export default function Navbar({ publicKey, onConnect, onDisconnect }: NavbarProps) {
   const router = useRouter();
-  const { t, i18n } = useTranslation("common");
+  const { t } = useTranslation("common");
   const [hasNotification, setHasNotification] = useState(false);
   const [hasJobAlertBadge, setHasJobAlertBadge] = useState(false);
   const { currencyMode, setCurrencyMode, priceLoading } = usePriceContext();
@@ -111,11 +110,6 @@ export default function Navbar({ publicKey, onConnect, onDisconnect }: NavbarPro
     setMobileMenuOpen(false);
   }, [router.pathname]);
 
-  const switchLanguage = (lang: string) => {
-    localStorage.setItem("preferredLocale", lang);
-    i18next.changeLanguage(lang);
-  };
-
   return (
     <nav className="sticky top-0 z-50 border-b border-[rgba(251,191,36,0.10)] bg-ink-900/85 backdrop-blur-xl">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between gap-2 sm:gap-4">
@@ -168,18 +162,9 @@ export default function Navbar({ publicKey, onConnect, onDisconnect }: NavbarPro
         {/* Spacer */}
         <div className="flex-1 md:flex-none" />
 
-        {/* Language Switcher - hidden on mobile, visible on tablet+ */}
+        {/* Language selector */}
         <div className="hidden sm:flex items-center">
-          <select
-            value={i18n.language}
-            onChange={(e) => switchLanguage(e.target.value)}
-            className="bg-market-900/40 border border-amber-900/30 rounded px-2 py-1 text-xs text-amber-100 cursor-pointer min-h-[44px]"
-          >
-            <option value="en">EN</option>
-            <option value="es">ES</option>
-            <option value="fr">FR</option>
-            <option value="pt">PT</option>
-          </select>
+          <LanguageSwitcher />
         </div>
         {/* Currency Toggle */}
         <div className="hidden md:flex items-center">
@@ -223,19 +208,6 @@ export default function Navbar({ publicKey, onConnect, onDisconnect }: NavbarPro
               </svg>
             )}
           </button>
-        </div>
-
-        {/* Language Switcher */}
-        <div className="hidden md:flex items-center">
-          <select
-            value={i18n.language}
-            onChange={(e) => i18n.changeLanguage(e.target.value)}
-            className="bg-market-900/40 border border-amber-900/30 rounded px-2 py-1 text-xs text-amber-100 cursor-pointer"
-            aria-label={t("language.switch") as string}
-          >
-            <option value="en">{t("language.english")}</option>
-            <option value="es">{t("language.spanish")}</option>
-          </select>
         </div>
 
         {/* Wallet - responsive */}
@@ -309,17 +281,9 @@ export default function Navbar({ publicKey, onConnect, onDisconnect }: NavbarPro
               </Link>
             ))}
 
-            {/* Mobile Language Switcher */}
+            {/* Mobile language selector */}
             <div className="flex items-center px-3 py-2">
-              <select
-                value={i18n.language}
-                onChange={(e) => switchLanguage(e.target.value)}
-                className="bg-market-900/40 border border-amber-900/30 rounded px-2 py-2 text-xs text-amber-100 cursor-pointer w-full min-h-[44px]"
-                aria-label={t("language.switch") as string}
-              >
-                <option value="en">{t("language.english")}</option>
-                <option value="es">{t("language.spanish")}</option>
-              </select>
+              <LanguageSwitcher className="bg-market-900/40 border border-amber-900/30 rounded px-2 py-2 text-xs text-amber-100 cursor-pointer w-full min-h-[44px]" />
             </div>
 
             {/* Mobile Disconnect Button */}

--- a/frontend/hooks/usePushNotifications.ts
+++ b/frontend/hooks/usePushNotifications.ts
@@ -128,7 +128,7 @@ export function usePushNotifications() {
         throw new Error("Failed to save subscription on backend");
       }
 
-      setState((prev) => ({ ...prev, isSubscribed: true });
+      setState((prev) => ({ ...prev, isSubscribed: true }));
       success("Push notifications enabled");
       return true;
     } catch (err) {

--- a/frontend/lib/i18n.js
+++ b/frontend/lib/i18n.js
@@ -1,69 +1,8 @@
 /**
- * lib/i18n.js
- * i18next setup with browser language detection and localStorage persistence (#282).
+ * Shared next-i18next exports.
+ *
+ * `appWithTranslation` in pages/_app.tsx supplies the configured i18next
+ * instance to these hooks. Keeping this small adapter preserves the existing
+ * application import path while ensuring components re-render on locale changes.
  */
-import i18next from "i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
-import { initReactI18next } from "react-i18next";
-
-const resources = {
-  en: { common: require("../public/locales/en/common.json") },
-  es: { common: require("../public/locales/es/common.json") },
-  fr: { common: require("../public/locales/fr/common.json") },
-  pt: { common: require("../public/locales/pt/common.json") },
-};
-
-// Node.js 18+ exposes navigator.language reflecting the OS locale. If we
-// run LanguageDetector on the server it picks up the OS locale (e.g. "es")
-// and SSR renders translated text in that language, while the client (which
-// starts from fallbackLng "en" before the detector fires) renders "en" —
-// causing a React hydration mismatch. Skip the detector during SSR and pin
-// the server to "en"; the detector only runs in the browser where it can
-// safely read localStorage/navigator without affecting the SSR output.
-const isBrowser = typeof window !== "undefined";
-
-if (isBrowser) {
-  i18next.use(LanguageDetector);
-}
-
-i18next.use(initReactI18next).init({
-  resources,
-  lng: isBrowser ? undefined : "en",
-  fallbackLng: "en",
-  supportedLngs: ["en", "es", "fr", "pt"],
-  ns: ["common"],
-  defaultNS: "common",
-  detection: isBrowser
-    ? {
-        order: ["localStorage", "navigator"],
-        lookupLocalStorage: "preferredLocale",
-        caches: ["localStorage"],
-      }
-    : undefined,
-  interpolation: { escapeValue: false },
-});
-
-i18next.on("languageChanged", (lng) => {
-  if (typeof window !== "undefined") {
-    localStorage.setItem("preferredLocale", lng);
-  }
-});
-
-export default i18next;
-
-export function useTranslation(ns = "common") {
-  const i18n = i18next;
-  const t = (key, options) => {
-      if (typeof i18n.getFixedT === 'function') {
-          return i18n.getFixedT(null, ns)(key, options);
-      }
-      return key;
-  };
-  return { t, i18n, ready: i18n.isInitialized };
-}
-
-export function appWithTranslation(Component) {
-  return function WrappedComponent(props) {
-    return Component(props);
-  };
-}
+export { appWithTranslation, useTranslation } from "next-i18next";

--- a/frontend/next-i18next.config.js
+++ b/frontend/next-i18next.config.js
@@ -1,7 +1,15 @@
 /**
- * next-i18next configuration (#282).
- * Locales are loaded client-side via lib/i18n.js; Next.js routing locales are in next.config.mjs.
+ * next-i18next configuration.
+ * Resources are bundled so every Pages Router page can translate immediately;
+ * serverSideTranslations is therefore not required on each existing page.
  */
+const resources = {
+  en: { common: require("./public/locales/en/common.json") },
+  es: { common: require("./public/locales/es/common.json") },
+  fr: { common: require("./public/locales/fr/common.json") },
+  pt: { common: require("./public/locales/pt/common.json") },
+};
+
 module.exports = {
   i18n: {
     defaultLocale: "en",
@@ -10,4 +18,13 @@ module.exports = {
   localePath: typeof window === "undefined" ? "./public/locales" : "/locales",
   defaultNS: "common",
   fallbackLng: "en",
+  resources,
+  interpolation: {
+    escapeValue: false,
+  },
+  detection: {
+    order: ["localStorage", "navigator"],
+    lookupLocalStorage: "preferredLocale",
+    caches: ["localStorage"],
+  },
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "i18next": "^26.3.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "next": "14.2.3",
+        "next-i18next": "^15.4.2",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.2.0",
@@ -3003,9 +3004,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
@@ -3023,26 +3021,6 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
@@ -3109,7 +3087,6 @@
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
       "os": [
         "win32"
       ],
@@ -4278,6 +4255,15 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
+      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -4821,6 +4807,28 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@shuding/opentype.js/node_modules/fflate": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.5.tgz",
+      "integrity": "sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g==",
       "license": "MIT"
     },
     "node_modules/@simplewebauthn/browser": {
@@ -6362,6 +6370,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -7079,6 +7099,20 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/og": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.6.8.tgz",
+      "integrity": "sha512-e4kQK9mP8ntpo3dACWirGod/hHv4qO5JMj9a/0a2AZto7b4persj5YP7t1Er372gTtYFTYxNhMx34jRvHooglw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.4.0",
+        "satori": "0.12.2",
+        "yoga-wasm-web": "0.3.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
@@ -7465,35 +7499,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/adjust-sourcemap-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
-      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "regex-parser": "^2.2.11"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/adjust-sourcemap-loader/node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -7842,49 +7847,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.4.tgz",
-      "integrity": "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/assert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-nan": "^1.3.2",
-        "object-is": "^1.1.5",
-        "object.assign": "^4.1.4",
-        "util": "^0.12.5"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/asn1.js": {
@@ -9004,16 +8966,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -9284,46 +9236,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color-string": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
-      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/color-string/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/color/node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -9393,6 +9305,17 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -9563,6 +9486,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.16.tgz",
+      "integrity": "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/css-loader": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
@@ -9614,6 +9567,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-what": {
@@ -10140,61 +10104,6 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dom-converter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
-      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "utila": "~0.4"
-      }
-    },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domain-browser": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.23.0.tgz",
-      "integrity": "sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==",
-      "dev": true,
-      "license": "Artistic-2.0",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "license": "MIT"
     },
@@ -12324,31 +12233,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "node_modules/hash-base": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
-      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -12371,6 +12255,18 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -12382,6 +12278,21 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hsl-to-hex": {
       "version": "1.0.0",
@@ -12626,6 +12537,12 @@
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.7.tgz",
+      "integrity": "sha512-nN2TIycyR/d+OVuLm1ugPyOlMprqPRnQ7QktBgn44F3H8l7TeTH4ffHJ7nUsd4QVJfetWW7/VZ3s+4g7FoAZUA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -15357,6 +15274,42 @@
         }
       }
     },
+    "node_modules/next-i18next": {
+      "version": "15.4.2",
+      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-15.4.2.tgz",
+      "integrity": "sha512-zgRxWf7kdXtM686ecGIBQL+Bq0+DqAhRlasRZ3vVF0TmrNTWkVhs52n//oU3Fj5O7r/xOKkECDUwfOuXVwTK/g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@types/hoist-non-react-statics": "^3.3.6",
+        "core-js": "^3",
+        "hoist-non-react-statics": "^3.3.2",
+        "i18next-fs-backend": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.7.13",
+        "next": ">= 12.0.0",
+        "react": ">= 17.0.2",
+        "react-i18next": ">= 13.5.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -15438,59 +15391,6 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-polyfill-webpack-plugin": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-2.0.1.tgz",
-      "integrity": "sha512-ZUMiCnZkP1LF0Th2caY6J/eKKoA0TefpoVa68m/LQU1I/mE8rGt4fNYGgNuCcK+aG8P8P43nbeJ2RqJMOL/Y1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert": "^2.0.0",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^6.0.3",
-        "console-browserify": "^1.2.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.12.0",
-        "domain-browser": "^4.22.0",
-        "events": "^3.3.0",
-        "filter-obj": "^2.0.2",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
-        "path-browserify": "^1.0.1",
-        "process": "^0.11.10",
-        "punycode": "^2.1.1",
-        "querystring-es3": "^0.2.1",
-        "readable-stream": "^4.0.0",
-        "stream-browserify": "^3.0.0",
-        "stream-http": "^3.2.0",
-        "string_decoder": "^1.3.0",
-        "timers-browserify": "^2.0.12",
-        "tty-browserify": "^0.0.1",
-        "type-fest": "^2.14.0",
-        "url": "^0.11.0",
-        "util": "^0.12.4",
-        "vm-browserify": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": ">=5"
-      }
-    },
-    "node_modules/node-polyfill-webpack-plugin/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/node-polyfill-webpack-plugin": {
       "version": "2.0.1",
@@ -15931,6 +15831,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
       }
     },
     "node_modules/parse-json": {
@@ -16376,179 +16286,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.21"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-loader": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.2.1.tgz",
-      "integrity": "sha512-k98jtRzthjj3f76MYTs9JTpRqV1RaaMhEU0Lpw9OTmQZQdppg4B30VZ74BojuBHt3F4KyubHJoXCMUeM8Bqeow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^9.0.0",
-        "jiti": "^2.5.1",
-        "semver": "^7.6.2"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
-        "postcss": "^7.0.0 || ^8.0.1",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-loader/node_modules/cosmiconfig": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-loader/node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/postcss-modules-extract-imports": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
-      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
-      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^7.0.0",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-modules-scope": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
-      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-load-config": {
@@ -17945,6 +17682,34 @@
           "optional": true
         }
       }
+    },
+    "node_modules/satori": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.12.2.tgz",
+      "integrity": "sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.16",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex": "^10.2.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-wasm-web": "^0.3.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/satori/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -21159,6 +20924,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
+    "node_modules/yoga-wasm-web": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
+      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
       "license": "MIT"
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "test:e2e": "playwright test",
     "analyze": "ANALYZE=true next build",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build -o storybook-static"
+    "storybook:build": "storybook build -o storybook-static",
+    "i18n:check": "node scripts/check-translations.mjs --strict"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",
@@ -36,6 +37,7 @@
     "i18next": "^26.3.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "next": "14.2.3",
+    "next-i18next": "^15.4.2",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -32,7 +32,9 @@ import { ThemeProvider, useTheme } from "@/contexts/ThemeContext";
 import OfflineBanner from "@/components/OfflineBanner";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useBackgroundSync } from "@/hooks/useBackgroundSync";
-import "../lib/i18n";
+import { appWithTranslation } from "next-i18next";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const nextI18NextConfig = require("../next-i18next.config.js");
 
 const WALLET_PUBLIC_KEY_STORAGE_KEY = "smp_wallet_public_key";
 const REF_STORAGE_KEY = "smp_referrer";
@@ -292,4 +294,4 @@ function App({ Component, pageProps }: AppProps) {
   );
 }
 
-export default App;
+export default appWithTranslation(App, nextI18NextConfig);

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -10,7 +10,7 @@
     "connectWallet": "Connecter le portefeuille",
     "disconnect": "Déconnecter",
     "skipToContent": "Aller au contenu principal",
-    "browseFreelancers": "[TRANSLATE] Browse Freelancers"
+    "browseFreelancers": "Parcourir les freelances"
   },
   "jobs": {
     "title": "Parcourir les offres",

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -10,7 +10,7 @@
     "connectWallet": "Conectar carteira",
     "disconnect": "Desconectar",
     "skipToContent": "Ir para o conteúdo principal",
-    "browseFreelancers": "[TRANSLATE] Browse Freelancers"
+    "browseFreelancers": "Explorar freelancers"
   },
   "jobs": {
     "title": "Explorar vagas",

--- a/frontend/scripts/check-translations.mjs
+++ b/frontend/scripts/check-translations.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Reports locale keys that were added to English but not translated yet.
+ *
+ * The command intentionally has no side effects: it never writes placeholder
+ * strings into a translator-maintained locale file. CI runs this command with
+ * `--strict`, making a missing or placeholder translation actionable.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const localesRoot = path.join(root, "public", "locales");
+const sourceLocale = "en";
+const requiredLocales = ["es", "fr", "pt"];
+const strict = process.argv.includes("--strict");
+
+function flatten(object, prefix = "") {
+  return Object.entries(object).reduce((result, [key, value]) => {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      Object.assign(result, flatten(value, fullKey));
+    } else {
+      result[fullKey] = value;
+    }
+    return result;
+  }, {});
+}
+
+const english = flatten(JSON.parse(fs.readFileSync(path.join(localesRoot, sourceLocale, "common.json"), "utf8")));
+let hasProblems = false;
+
+for (const locale of requiredLocales) {
+  const filename = path.join(localesRoot, locale, "common.json");
+  if (!fs.existsSync(filename)) {
+    console.warn(`::warning file=${filename}::Missing ${locale} locale file.`);
+    hasProblems = true;
+    continue;
+  }
+
+  const translated = flatten(JSON.parse(fs.readFileSync(filename, "utf8")));
+  const missing = Object.keys(english).filter((key) => !(key in translated));
+  const placeholders = Object.entries(translated)
+    .filter(([, value]) => typeof value === "string" && value.includes("[TRANSLATE]"))
+    .map(([key]) => key);
+
+  for (const key of missing) {
+    console.warn(`::warning file=${filename}::${locale} is missing translation key '${key}'.`);
+  }
+  for (const key of placeholders) {
+    console.warn(`::warning file=${filename}::${locale} has an unfinished translation for '${key}'.`);
+  }
+  hasProblems ||= missing.length > 0 || placeholders.length > 0;
+}
+
+if (!hasProblems) {
+  console.log("All required locale files contain every English key and no translation placeholders.");
+}
+
+if (hasProblems && strict) process.exitCode = 1;


### PR DESCRIPTION
## Summary

Adds and completes frontend internationalization support using `next-i18next`.

- Configures `next-i18next` with English, Spanish, French, and Portuguese locale resources.
- Wraps the application with `appWithTranslation`.
- Updates `LanguageSwitcher` to:
  - Switch i18next language.
  - Update the Next.js locale route.
  - Persist the selected locale in `localStorage`.
- Reuses the shared language selector in desktop and mobile navigation.
- Completes unfinished French and Portuguese translations.
- Adds translation-completeness validation and a GitHub Actions CI workflow.
- Adds tests for locale completeness and language-switching behavior.
- Fixes an existing syntax error in `usePushNotifications.ts`.

## Type

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Smart contract change

## Related Issue

Close #767 

## Testing

- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [x] i18n translation validation passes: `npm run i18n:check`
- [x] Language switcher and i18n tests pass:
  ```bash
  npm test -- --runInBand __tests__/LanguageSwitcher.test.tsx __tests__/i18n.test.ts
  ```
- [ ] Docs updated if needed

> Note: A full frontend build/type-check remains blocked by unrelated pre-existing lint and TypeScript errors in dashboard, notification, job-status, and API modules. The i18n-specific validation and tests pass.



Language selector is available in the navbar on desktop and mobile layouts, supporting:

- English
- Español
- Français
- Português