### PR TITLE
#805 [DevOps] Add Prometheus metrics endpoint to backend FIXED

### DIFF
--- a/backend/docs/METRICS.md
+++ b/backend/docs/METRICS.md
@@ -1,0 +1,94 @@
+# Prometheus Metrics
+
+The Express API exports Prometheus metrics on `GET /metrics` in the standard
+text exposition format (`text/plain; version=0.0.4`).
+
+## Required metrics
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `http_requests_total` | counter | `method`, `route`, `status_code` | Total HTTP requests handled by the API |
+| `http_request_duration_ms` | histogram | `method`, `route`, `status_code` | Request latency in **milliseconds** |
+| `active_websocket_connections` | gauge | `channel` | Open WebSocket connections (`realtime`, `scope`) |
+| `pool_query_duration_ms` | histogram | `operation`, `status` | PostgreSQL query latency in **milliseconds** |
+
+### Supporting metrics
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `pool_queries_total` | counter | Queries executed through the shared pool |
+| `pg_pool_total` / `pg_pool_idle` / `pg_pool_waiting` | gauge | Pool saturation |
+| `marketpay_db_connections{state}` | gauge | Pool counts by state |
+| `notification_queue_pending` | gauge | Outbound notification backlog |
+| `marketpay_*` | various | Node.js/process default metrics |
+
+Legacy series (`marketpay_http_requests_total`,
+`marketpay_http_request_duration_seconds`, `ws_connections_active`) are still
+emitted so the pre-existing dashboard and alert rules keep working.
+
+## Cardinality safety
+
+Two mechanisms keep label cardinality bounded:
+
+* **Route labels** use the matched Express pattern (`/api/jobs/:id`). When the
+  router has already unwound (404s, error handlers), the URL is normalised —
+  numeric, UUID, Stellar-key, hex and long opaque segments collapse to `:id`.
+* **SQL labels** use only the leading SQL verb (`select`, `insert`, …). Query
+  text and bind parameters are never used as labels.
+
+## Authentication
+
+`/metrics` is internal-only. Access is granted when **either** check passes:
+
+1. **Shared token** — `Authorization: Bearer <token>` or `X-Metrics-Token`,
+   compared in constant time.
+2. **Internal network** — the caller's IP is loopback or RFC1918/ULA private
+   space.
+
+A presented-but-incorrect token is always rejected, even from inside the
+network. Failures return `401` with a `WWW-Authenticate` challenge (never
+`403`, preserving the CSRF-bypass contract for operational endpoints).
+
+### Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `METRICS_TOKEN` | _(unset)_ | Bearer token required to scrape |
+| `METRICS_SECRET` | _(unset)_ | Legacy alias for `METRICS_TOKEN` |
+| `METRICS_ALLOW_PRIVATE_NETWORK` | `true` | Set `false` to force token auth |
+
+**Recommended production setup:**
+
+```bash
+METRICS_TOKEN=<random-32-byte-secret>
+METRICS_ALLOW_PRIVATE_NETWORK=false
+```
+
+Then uncomment the `authorization` block in
+`monitoring/prometheus/prometheus.yml` and mount the same secret at
+`/run/secrets/metrics_token`.
+
+## Monitoring stack
+
+| File | Purpose |
+| --- | --- |
+| `monitoring/prometheus/prometheus.yml` | `marketpay-backend` scrape job (`backend:4000/metrics`, 15s) |
+| `monitoring/prometheus/rules/alerts.yml` | Alerts on latency, error rate, slow queries, WS spikes, scrape failure |
+| `monitoring/grafana/dashboards/marketpay-backend-metrics.json` | 17-panel dashboard (uid `marketpay-backend-metrics`) |
+
+Grafana auto-provisions dashboards from `/var/lib/grafana/dashboards`, which
+`docker-compose.prod.yml` already mounts from `monitoring/grafana/dashboards`.
+
+## Verification
+
+```bash
+# Unit tests
+npx jest tests/metrics.test.js tests/poolMetrics.test.js --selectProjects unit
+
+# Config validation
+promtool check config monitoring/prometheus/prometheus.yml
+promtool check rules  monitoring/prometheus/rules/alerts.yml
+
+# Live scrape
+curl -H "Authorization: Bearer $METRICS_TOKEN" http://localhost:4000/metrics
+```

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
                 "bull": "^4.16.5",
                 "compression": "^1.8.1",
                 "cors": "^2.8.5",
+                "csrf-csrf": "^4.0.3",
                 "dataloader": "^2.2.3",
                 "date-fns-tz": "^3.2.0",
                 "dompurify": "^3.1.0",

--- a/backend/src/db/pool.js
+++ b/backend/src/db/pool.js
@@ -2,6 +2,14 @@
 
 const { Pool } = require("pg");
 const { requireEnv } = require("../config/env");
+const {
+  sqlOperation,
+  observePoolQuery,
+  dbConnections,
+  pgPoolTotal,
+  pgPoolIdle,
+  pgPoolWaiting,
+} = require("../metrics");
 
 const DATABASE_URL = requireEnv("DATABASE_URL");
 
@@ -24,6 +32,77 @@ const pool = new Pool({
 pool.on("error", (err) => {
   console.error("[pg] Unexpected pool error:", err.message);
 });
+
+// ─── Query latency instrumentation (pool_query_duration_ms) ───────────────────
+// Wrap `pool.query` so every statement executed through the shared pool is
+// timed, regardless of which service issued it. Only the leading SQL verb is
+// used as a label, keeping metric cardinality bounded and never exposing query
+// parameters. Callback-style invocations are passed through untouched by pg.
+const originalQuery = pool.query.bind(pool);
+
+pool.query = function instrumentedQuery(...args) {
+  const operation = sqlOperation(args[0]);
+  const start = process.hrtime.bigint();
+
+  /**
+   * Convert the elapsed time since `start` into fractional milliseconds.
+   *
+   * @returns {number} elapsed milliseconds
+   */
+  const elapsedMs = () => Number(process.hrtime.bigint() - start) / 1e6;
+
+  // Callback form: pg invokes the callback instead of returning a promise.
+  const last = args[args.length - 1];
+  if (typeof last === "function") {
+    const done = last;
+    args[args.length - 1] = function instrumentedCallback(err, result) {
+      observePoolQuery(operation, err ? "error" : "success", elapsedMs());
+      return done(err, result);
+    };
+    return originalQuery(...args);
+  }
+
+  let result;
+  try {
+    result = originalQuery(...args);
+  } catch (err) {
+    observePoolQuery(operation, "error", elapsedMs());
+    throw err;
+  }
+
+  if (!result || typeof result.then !== "function") {
+    observePoolQuery(operation, "success", elapsedMs());
+    return result;
+  }
+
+  return result.then(
+    (value) => {
+      observePoolQuery(operation, "success", elapsedMs());
+      return value;
+    },
+    (err) => {
+      observePoolQuery(operation, "error", elapsedMs());
+      throw err;
+    }
+  );
+};
+
+// ─── Pool saturation gauges ───────────────────────────────────────────────────
+// Scrape-time collectors keep the gauges accurate without a polling timer.
+dbConnections.collect = function collectDbConnections() {
+  this.set({ state: "total" }, pool.totalCount);
+  this.set({ state: "idle" }, pool.idleCount);
+  this.set({ state: "waiting" }, pool.waitingCount);
+};
+pgPoolTotal.collect = function collectPgPoolTotal() {
+  this.set(pool.totalCount);
+};
+pgPoolIdle.collect = function collectPgPoolIdle() {
+  this.set(pool.idleCount);
+};
+pgPoolWaiting.collect = function collectPgPoolWaiting() {
+  this.set(pool.waitingCount);
+};
 
 function getPoolStats() {
   return {

--- a/backend/src/metrics.js
+++ b/backend/src/metrics.js
@@ -1,0 +1,304 @@
+/**
+ * src/metrics.js
+ * Stellar MarketPay — centralised Prometheus metrics registry.
+ *
+ * Owns the single `prom-client` Registry used by the API process and every
+ * metric exported on `GET /metrics`.
+ *
+ * Metrics required by the observability spec:
+ *   • http_requests_total              (counter)
+ *   • http_request_duration_ms         (histogram, milliseconds)
+ *   • active_websocket_connections     (gauge)
+ *   • pool_query_duration_ms           (histogram, milliseconds)
+ *
+ * Legacy `marketpay_*` series are kept alongside the canonical names so the
+ * pre-existing Grafana dashboard and Prometheus alert rules keep working.
+ *
+ * This module intentionally has NO internal dependencies other than
+ * `prom-client` so that low-level modules (e.g. `src/db/pool.js`) can require
+ * it without creating an import cycle.
+ */
+"use strict";
+
+const promClient = require("prom-client");
+
+// ─── Registry ─────────────────────────────────────────────────────────────────
+const registry = new promClient.Registry();
+
+promClient.collectDefaultMetrics({
+  register: registry,
+  prefix: "marketpay_",
+});
+
+/**
+ * Idempotent metric factory.
+ *
+ * Jest re-requires modules between suites and `horizonClient.js` registers its
+ * own histogram on the default registry; re-creating a metric with a name that
+ * already exists throws. Returning the existing instance keeps `require()`
+ * safe under any load order.
+ *
+ * @param {Function} Ctor   prom-client metric constructor
+ * @param {object}   config metric configuration
+ * @returns {object} the registered metric
+ */
+function createMetric(Ctor, config) {
+  const existing = registry.getSingleMetric(config.name);
+  if (existing) return existing;
+  return new Ctor({ ...config, registers: [registry] });
+}
+
+// ─── HTTP metrics ─────────────────────────────────────────────────────────────
+const HTTP_LABELS = ["method", "route", "status_code"];
+
+/** Total HTTP requests handled by the API. */
+const httpRequestsTotal = createMetric(promClient.Counter, {
+  name: "http_requests_total",
+  help: "Total HTTP requests handled by the API",
+  labelNames: HTTP_LABELS,
+});
+
+/** HTTP request latency in milliseconds. */
+const httpRequestDurationMs = createMetric(promClient.Histogram, {
+  name: "http_request_duration_ms",
+  help: "HTTP request duration in milliseconds",
+  labelNames: HTTP_LABELS,
+  buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+});
+
+// Legacy series (kept for existing dashboards / alert rules).
+const legacyHttpRequestsTotal = createMetric(promClient.Counter, {
+  name: "marketpay_http_requests_total",
+  help: "Total HTTP requests handled by the API (legacy name)",
+  labelNames: HTTP_LABELS,
+});
+
+const legacyHttpRequestDurationSeconds = createMetric(promClient.Histogram, {
+  name: "marketpay_http_request_duration_seconds",
+  help: "HTTP request duration in seconds (legacy name)",
+  labelNames: HTTP_LABELS,
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+});
+
+// ─── WebSocket metrics ────────────────────────────────────────────────────────
+/** Number of currently open WebSocket connections, by channel. */
+const activeWebsocketConnections = createMetric(promClient.Gauge, {
+  name: "active_websocket_connections",
+  help: "Currently open WebSocket connections",
+  labelNames: ["channel"],
+});
+
+// Legacy unlabelled gauge (realtime channel only).
+const legacyWsConnectionsActive = createMetric(promClient.Gauge, {
+  name: "ws_connections_active",
+  help: "Active WebSocket connections (legacy name)",
+});
+
+// ─── Database pool metrics ────────────────────────────────────────────────────
+/** PostgreSQL query latency in milliseconds. */
+const poolQueryDurationMs = createMetric(promClient.Histogram, {
+  name: "pool_query_duration_ms",
+  help: "PostgreSQL pool query duration in milliseconds",
+  labelNames: ["operation", "status"],
+  buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000],
+});
+
+/** Total PostgreSQL queries executed through the shared pool. */
+const poolQueriesTotal = createMetric(promClient.Counter, {
+  name: "pool_queries_total",
+  help: "Total PostgreSQL queries executed through the shared pool",
+  labelNames: ["operation", "status"],
+});
+
+const dbConnections = createMetric(promClient.Gauge, {
+  name: "marketpay_db_connections",
+  help: "Current PostgreSQL pool connection counts",
+  labelNames: ["state"],
+});
+
+const pgPoolTotal = createMetric(promClient.Gauge, {
+  name: "pg_pool_total",
+  help: "Total PostgreSQL pool connections",
+});
+
+const pgPoolIdle = createMetric(promClient.Gauge, {
+  name: "pg_pool_idle",
+  help: "Idle PostgreSQL pool connections",
+});
+
+const pgPoolWaiting = createMetric(promClient.Gauge, {
+  name: "pg_pool_waiting",
+  help: "Waiting PostgreSQL pool requests",
+});
+
+const notificationQueuePending = createMetric(promClient.Gauge, {
+  name: "notification_queue_pending",
+  help: "Pending notifications in the queue",
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SQL_VERB = /^[\s(]*(select|insert|update|delete|with|begin|commit|rollback|create|alter|drop|truncate|copy|explain|set|listen|notify)\b/i;
+
+/**
+ * Derive a low-cardinality label from a SQL string.
+ *
+ * Only the leading verb is used — never the full statement — so the metric
+ * cannot explode in cardinality or leak query parameters.
+ *
+ * @param {string|object} sql query text or pg query config
+ * @returns {string} lowercase SQL verb, or "other"
+ */
+function sqlOperation(sql) {
+  const text = typeof sql === "string" ? sql : sql && sql.text;
+  if (typeof text !== "string") return "other";
+  const match = SQL_VERB.exec(text);
+  return match ? match[1].toLowerCase() : "other";
+}
+
+// Segment patterns that represent a variable path parameter. Anything matching
+// is collapsed to ":id" so URLs like /api/jobs/8123 do not each become their
+// own time series.
+const NUMERIC_SEGMENT = /^\d+$/;
+const UUID_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const STELLAR_SEGMENT = /^[GMC][A-Z2-7]{55}$/;
+const HEX_SEGMENT = /^[0-9a-f]{16,}$/i;
+const LONG_OPAQUE_SEGMENT = /^(?=.*\d)[A-Za-z0-9_-]{16,}$/;
+
+/**
+ * Collapse a concrete request path into a bounded-cardinality route label.
+ *
+ * Used when Express cannot give us the matched route pattern (404s, and error
+ * responses written after the router has unwound `req.baseUrl`).
+ *
+ * @param {string} rawPath request path, e.g. "/api/jobs/8123/bids"
+ * @returns {string} normalised label, e.g. "/api/jobs/:id/bids"
+ */
+function normalizeRoutePath(rawPath) {
+  if (typeof rawPath !== "string" || !rawPath) return "/";
+  const [pathOnly] = rawPath.split("?");
+  const segments = pathOnly.split("/").filter(Boolean).map((segment) => {
+    const decoded = (() => {
+      try {
+        return decodeURIComponent(segment);
+      } catch {
+        return segment;
+      }
+    })();
+    if (
+      NUMERIC_SEGMENT.test(decoded) ||
+      UUID_SEGMENT.test(decoded) ||
+      STELLAR_SEGMENT.test(decoded) ||
+      HEX_SEGMENT.test(decoded) ||
+      LONG_OPAQUE_SEGMENT.test(decoded)
+    ) {
+      return ":id";
+    }
+    // Hard cap on segment length so a pathological URL cannot bloat a label.
+    return decoded.length > 40 ? ":id" : decoded;
+  });
+  return segments.length ? `/${segments.join("/")}` : "/";
+}
+
+/**
+ * Choose the best bounded-cardinality route label for a request.
+ *
+ * Express exposes the matched pattern on `req.route.path`, but by the time a
+ * response is written by an error handler the router has already restored
+ * `req.baseUrl` to "" — yielding a truncated label such as ":id" instead of
+ * "/api/jobs/:id". We therefore accept the matched pattern only when it has the
+ * same number of path segments as the actual URL, and otherwise fall back to a
+ * normalised version of the URL itself.
+ *
+ * @param {string|null} matchedPattern `${req.baseUrl}${req.route.path}` if known
+ * @param {string}      originalUrl    the full request URL
+ * @returns {string} route label
+ */
+function resolveRouteLabel(matchedPattern, originalUrl) {
+  const normalized = normalizeRoutePath(originalUrl);
+  if (!matchedPattern) return normalized;
+
+  const segmentCount = (value) => value.split("/").filter(Boolean).length;
+  if (segmentCount(matchedPattern) !== segmentCount(normalized)) {
+    return normalized;
+  }
+  return matchedPattern;
+}
+
+/**
+ * Record one HTTP request in both the canonical and legacy series.
+ *
+ * @param {object} labels          metric labels
+ * @param {string} labels.method   HTTP method
+ * @param {string} labels.route    matched route (never the raw URL)
+ * @param {string} labels.status_code response status
+ * @param {number} durationMs      wall-clock duration in milliseconds
+ */
+function observeHttpRequest(labels, durationMs) {
+  httpRequestsTotal.inc(labels);
+  httpRequestDurationMs.observe(labels, durationMs);
+  legacyHttpRequestsTotal.inc(labels);
+  legacyHttpRequestDurationSeconds.observe(labels, durationMs / 1000);
+}
+
+/**
+ * Record one pool query.
+ *
+ * @param {string} operation  SQL verb label
+ * @param {string} status     "success" | "error"
+ * @param {number} durationMs wall-clock duration in milliseconds
+ */
+function observePoolQuery(operation, status, durationMs) {
+  poolQueryDurationMs.observe({ operation, status }, durationMs);
+  poolQueriesTotal.inc({ operation, status });
+}
+
+/**
+ * Update the WebSocket gauges for a channel.
+ *
+ * @param {string} channel channel name ("realtime", "scope", …)
+ * @param {number} count   number of open sockets on that channel
+ */
+function setWebsocketConnections(channel, count) {
+  activeWebsocketConnections.set({ channel }, count);
+  if (channel === "realtime") legacyWsConnectionsActive.set(count);
+}
+
+/**
+ * Render the registry in Prometheus text exposition format.
+ *
+ * @returns {Promise<string>} metrics payload
+ */
+function renderMetrics() {
+  return registry.metrics();
+}
+
+module.exports = {
+  promClient,
+  registry,
+  contentType: registry.contentType,
+  // canonical metrics
+  httpRequestsTotal,
+  httpRequestDurationMs,
+  activeWebsocketConnections,
+  poolQueryDurationMs,
+  poolQueriesTotal,
+  // supporting metrics
+  dbConnections,
+  pgPoolTotal,
+  pgPoolIdle,
+  pgPoolWaiting,
+  notificationQueuePending,
+  // legacy aliases
+  legacyHttpRequestsTotal,
+  legacyHttpRequestDurationSeconds,
+  legacyWsConnectionsActive,
+  // helpers
+  normalizeRoutePath,
+  resolveRouteLabel,
+  sqlOperation,
+  observeHttpRequest,
+  observePoolQuery,
+  setWebsocketConnections,
+  renderMetrics,
+};

--- a/backend/src/middleware/metricsAuth.js
+++ b/backend/src/middleware/metricsAuth.js
@@ -1,0 +1,153 @@
+/**
+ * src/middleware/metricsAuth.js
+ *
+ * Internal-only authentication guard for `GET /metrics`.
+ *
+ * The Prometheus exposition endpoint leaks operational detail (route names,
+ * error rates, queue depth, pool saturation) and must never be world-readable.
+ * Access is granted when EITHER check passes:
+ *
+ *   1. Shared secret — `Authorization: Bearer <METRICS_TOKEN>` or
+ *      `X-Metrics-Token: <METRICS_TOKEN>`, compared in constant time.
+ *      (`METRICS_SECRET` is accepted as a legacy alias.)
+ *   2. Internal network — the caller's IP is loopback or RFC1918/ULA private
+ *      space, i.e. the scrape comes from inside the compose/k8s network.
+ *      Disable with `METRICS_ALLOW_PRIVATE_NETWORK=false` to force token auth.
+ *
+ * Failures return 401 with a `WWW-Authenticate` challenge (never 403, so the
+ * CSRF bypass assertions for operational endpoints remain valid).
+ */
+"use strict";
+
+const crypto = require("crypto");
+const { getClientIp } = require("../utils/clientIp");
+
+/**
+ * Compare two strings without leaking length or content through timing.
+ *
+ * @param {string} a first value
+ * @param {string} b second value
+ * @returns {boolean} true when the values are identical
+ */
+function timingSafeEqual(a, b) {
+  const bufA = Buffer.from(String(a), "utf8");
+  const bufB = Buffer.from(String(b), "utf8");
+  if (bufA.length !== bufB.length) {
+    // Still perform a comparison so the branch cost is constant-ish.
+    crypto.timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Extract a bearer / header token from the request.
+ *
+ * @param {import("express").Request} req incoming request
+ * @returns {string} presented token, or "" when absent
+ */
+function presentedToken(req) {
+  const header = req.headers.authorization || "";
+  if (header.startsWith("Bearer ")) return header.slice(7).trim();
+  const custom = req.headers["x-metrics-token"];
+  return typeof custom === "string" ? custom.trim() : "";
+}
+
+/**
+ * Normalise an IPv4-mapped IPv6 address ("::ffff:10.0.0.5" → "10.0.0.5").
+ *
+ * @param {string} ip raw address
+ * @returns {string} normalised address
+ */
+function normaliseIp(ip) {
+  const value = String(ip || "").trim();
+  return value.startsWith("::ffff:") ? value.slice(7) : value;
+}
+
+/**
+ * Is the address loopback or private (non-routable) space?
+ *
+ * @param {string} rawIp client address
+ * @returns {boolean} true when the caller is on an internal network
+ */
+function isInternalIp(rawIp) {
+  const ip = normaliseIp(rawIp);
+  if (!ip) return false;
+  if (ip === "::1" || ip === "localhost") return true;
+
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(ip);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if (a === 127) return true;                      // loopback
+    if (a === 10) return true;                       // 10.0.0.0/8
+    if (a === 192 && b === 168) return true;         // 192.168.0.0/16
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    if (a === 169 && b === 254) return true;         // link-local
+    return false;
+  }
+
+  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10)
+  const lower = ip.toLowerCase();
+  return lower.startsWith("fc") || lower.startsWith("fd") || lower.startsWith("fe8");
+}
+
+/**
+ * Read the configured metrics token (supports the legacy env name).
+ *
+ * @returns {string} configured token, or "" when unset
+ */
+function configuredToken() {
+  return (process.env.METRICS_TOKEN || process.env.METRICS_SECRET || "").trim();
+}
+
+/**
+ * Are private-network scrapes allowed without a token?
+ *
+ * @returns {boolean} true unless explicitly disabled
+ */
+function privateNetworkAllowed() {
+  const flag = (process.env.METRICS_ALLOW_PRIVATE_NETWORK || "").trim().toLowerCase();
+  return flag !== "false" && flag !== "0" && flag !== "no";
+}
+
+/**
+ * Express middleware enforcing internal-only access to `/metrics`.
+ *
+ * @param {import("express").Request}  req  request
+ * @param {import("express").Response} res  response
+ * @param {Function}                   next next handler
+ * @returns {void}
+ */
+function metricsAuth(req, res, next) {
+  const token = configuredToken();
+  const presented = presentedToken(req);
+
+  if (token && presented && timingSafeEqual(presented, token)) {
+    return next();
+  }
+
+  // A presented-but-wrong token is always a hard failure, even from inside the
+  // network — it signals a misconfigured or malicious scraper.
+  if (token && presented) {
+    res.set("WWW-Authenticate", 'Bearer realm="metrics"');
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  let clientIp = "";
+  try {
+    clientIp = getClientIp(req);
+  } catch {
+    clientIp = req.ip || "";
+  }
+
+  if (privateNetworkAllowed() && isInternalIp(clientIp)) {
+    return next();
+  }
+
+  res.set("WWW-Authenticate", 'Bearer realm="metrics"');
+  return res.status(401).json({ error: "Unauthorized" });
+}
+
+module.exports = metricsAuth;
+module.exports.metricsAuth = metricsAuth;
+module.exports.isInternalIp = isInternalIp;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -15,7 +15,8 @@ const rateLimit = require("express-rate-limit");
 const { getClientIp } = require("./utils/clientIp");
 const { WebSocketServer } = require("ws");
 const { sendEmail, smtpTransport } = require("./utils/email");
-const promClient = require("prom-client");
+const metrics = require("./metrics");
+const metricsAuth = require("./middleware/metricsAuth");
 const swaggerUi = require('swagger-ui-express');
 const swaggerSpecs = require('./config/swagger');
 const { requestLoggerMiddleware, xRequestIdMiddleware, logError, createServiceLogger } = require('./utils/logger');
@@ -74,80 +75,20 @@ const STELLAR_NETWORK = requireChoice("STELLAR_NETWORK", ["testnet", "mainnet"],
   fallback: "testnet",
 });
 
-const metricsRegistry = new promClient.Registry();
-promClient.collectDefaultMetrics({
-  register: metricsRegistry,
-  prefix: "marketpay_",
-});
+// ─── Prometheus metrics ───────────────────────────────────────────────────────
+// The registry and every metric live in ./metrics so that low-level modules
+// (e.g. src/db/pool.js) can record into the same registry without importing
+// the server and creating a require cycle.
+const {
+  registry: metricsRegistry,
+  notificationQueuePending,
+  resolveRouteLabel,
+  observeHttpRequest,
+  setWebsocketConnections,
+  renderMetrics,
+} = metrics;
 
-const httpRequestsTotal = new promClient.Counter({
-  name: "marketpay_http_requests_total",
-  help: "Total HTTP requests handled by the API",
-  labelNames: ["method", "route", "status_code"],
-  registers: [metricsRegistry],
-});
-
-const httpRequestDurationSeconds = new promClient.Histogram({
-  name: "marketpay_http_request_duration_seconds",
-  help: "HTTP request duration in seconds",
-  labelNames: ["method", "route", "status_code"],
-  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5],
-  registers: [metricsRegistry],
-});
-
-const dbConnectionGauge = new promClient.Gauge({
-  name: "marketpay_db_connections",
-  help: "Current PostgreSQL pool connection counts",
-  labelNames: ["state"],
-  registers: [metricsRegistry],
-});
-
-dbConnectionGauge.collect = function collectDbConnections() {
-  this.set({ state: "total" }, pool.totalCount);
-  this.set({ state: "idle" }, pool.idleCount);
-  this.set({ state: "waiting" }, pool.waitingCount);
-};
-
-const pgPoolTotal = new promClient.Gauge({
-  name: "pg_pool_total",
-  help: "Total PostgreSQL pool connections",
-  registers: [metricsRegistry],
-});
-
-const pgPoolIdle = new promClient.Gauge({
-  name: "pg_pool_idle",
-  help: "Idle PostgreSQL pool connections",
-  registers: [metricsRegistry],
-});
-
-const pgPoolWaiting = new promClient.Gauge({
-  name: "pg_pool_waiting",
-  help: "Waiting PostgreSQL pool requests",
-  registers: [metricsRegistry],
-});
-
-pgPoolTotal.collect = function collectPgPoolTotal() {
-  this.set(pool.totalCount);
-};
-pgPoolIdle.collect = function collectPgPoolIdle() {
-  this.set(pool.idleCount);
-};
-pgPoolWaiting.collect = function collectPgPoolWaiting() {
-  this.set(pool.waitingCount);
-};
-
-const wsConnectionsActive = new promClient.Gauge({
-  name: "ws_connections_active",
-  help: "Active WebSocket connections",
-  registers: [metricsRegistry],
-});
-
-const notificationQueuePending = new promClient.Gauge({
-  name: "notification_queue_pending",
-  help: "Pending notifications in the queue",
-  registers: [metricsRegistry],
-});
-
+// Pool connection gauges are attached in src/db/pool.js (where the pool lives).
 notificationQueuePending.collect = async function collectNotificationQueue() {
   try {
     const { rows } = await pool.query(
@@ -202,13 +143,28 @@ const realtimeClients = new Set();
 const userClients = new Map(); // userAddress -> Set<WebSocket>
 const scopeSessionClients = new Map();
 
+/**
+ * Publish the current WebSocket connection counts to
+ * `active_websocket_connections` (labelled by channel).
+ *
+ * Called on every connect/disconnect so the gauge never drifts.
+ *
+ * @returns {void}
+ */
+function refreshWsMetrics() {
+  let scopeCount = 0;
+  for (const clients of scopeSessionClients.values()) scopeCount += clients.size;
+  setWebsocketConnections("realtime", realtimeClients.size);
+  setWebsocketConnections("scope", scopeCount);
+}
+
 function broadcastRealtime(event, payload) {
   const message = JSON.stringify({ event, payload });
   serviceLogger.debug({ event, payload }, 'Broadcasting realtime message');
   for (const ws of realtimeClients) {
     if (ws.readyState === WS_OPEN) ws.send(message);
   }
-  wsConnectionsActive.set(realtimeClients.size);
+  refreshWsMetrics();
 }
 
 async function upsertScopeSession(sessionId, patch) {
@@ -338,28 +294,53 @@ app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpecs, {
 app.use(cors(createCorsOptions()));
 app.use(doubleCsrfProtection);
 
+// ─── HTTP request instrumentation ─────────────────────────────────────────────
+// Records http_requests_total and http_request_duration_ms (plus the legacy
+// marketpay_* series) for every request except the scrape endpoint itself.
 app.use((req, res, next) => {
   if (req.path === "/metrics") {
     return next();
   }
 
-  const endTimer = httpRequestDurationSeconds.startTimer();
-  res.on("finish", () => {
-    const routeLabel = req.route?.path
-      ? `${req.baseUrl || ""}${req.route.path}`
-      : req.path;
-    const statusCode = String(res.statusCode);
+  const start = process.hrtime.bigint();
 
-    httpRequestsTotal.inc({
-      method: req.method,
-      route: routeLabel,
-      status_code: statusCode,
-    });
-    endTimer({
-      method: req.method,
-      route: routeLabel,
-      status_code: statusCode,
-    });
+  // Express restores `req.baseUrl` once the router unwinds, so by the time the
+  // "finish" event fires the mount path is gone. Snapshot the label while the
+  // handler is still on the stack (res.end runs inside the route).
+  let routeSnapshot = null;
+  const originalEnd = res.end;
+  res.end = function captureRoute(...args) {
+    if (routeSnapshot === null && req.route?.path) {
+      routeSnapshot =
+        `${req.baseUrl || ""}${req.route.path}`.replace(/\/$/, "") || "/";
+    }
+    return originalEnd.apply(this, args);
+  };
+
+  res.on("finish", () => {
+    // Prefer the matched route pattern ("/api/jobs/:id") over the raw path so
+    // path parameters never explode label cardinality.
+    // resolveRouteLabel prefers the matched Express pattern and falls back to
+    // a normalised URL (ids collapsed to ":id") for 404s and error responses,
+    // where Express has already discarded the route mount prefix.
+    const routeLabel = resolveRouteLabel(routeSnapshot, req.originalUrl || req.path);
+
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+
+    observeHttpRequest(
+      {
+        method: req.method,
+        route: routeLabel,
+        status_code: String(res.statusCode),
+      },
+      durationMs
+    );
+  });
+
+  res.on("close", () => {
+    // Restore the original end() if the response was aborted before finishing,
+    // so no wrapper leaks onto a pooled response object.
+    res.end = originalEnd;
   });
 
   next();
@@ -373,18 +354,14 @@ app.use(rateLimit({
   keyGenerator: (req) => getClientIp(req),
 }));
 
-app.get("/metrics", async (req, res, next) => {
+// ─── GET /metrics — Prometheus text exposition (internal auth required) ───────
+// Guarded by src/middleware/metricsAuth.js: a shared bearer token
+// (METRICS_TOKEN) or an internal/private source IP. Never publicly readable.
+app.get("/metrics", metricsAuth, async (req, res, next) => {
   try {
-    const metricsSecret = process.env.METRICS_SECRET;
-    if (metricsSecret) {
-      const authHeader = req.headers.authorization || "";
-      const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
-      if (token !== metricsSecret) {
-        return res.status(401).json({ error: "Unauthorized" });
-      }
-    }
     res.set("Content-Type", metricsRegistry.contentType);
-    res.end(await metricsRegistry.metrics());
+    res.set("Cache-Control", "no-store");
+    res.end(await renderMetrics());
   } catch (error) {
     next(error);
   }
@@ -460,11 +437,11 @@ wsServer.on("connection", async (ws, request) => {
 
   if (url.pathname === "/ws/realtime") {
     realtimeClients.add(ws);
-    wsConnectionsActive.set(realtimeClients.size);
+    refreshWsMetrics();
     sendJson(ws, "connected", { channel: "realtime" });
     ws.on("close", () => {
       realtimeClients.delete(ws);
-      wsConnectionsActive.set(realtimeClients.size);
+      refreshWsMetrics();
     });
     return;
   }
@@ -479,6 +456,7 @@ wsServer.on("connection", async (ws, request) => {
 
     const clients = getScopeSessionSet(sessionId);
     clients.add(ws);
+    refreshWsMetrics();
 
     let session = await loadScopeSession(sessionId);
     if (!session) {
@@ -541,6 +519,7 @@ wsServer.on("connection", async (ws, request) => {
 
     ws.on("close", async () => {
       clients.delete(ws);
+      refreshWsMetrics();
       const freshSession = await loadScopeSession(sessionId);
       if (!freshSession) return;
       const nextCursors = { ...(freshSession.cursors || {}) };

--- a/backend/src/utils/horizonClient.js
+++ b/backend/src/utils/horizonClient.js
@@ -11,9 +11,13 @@
 
 const pLimit = require("p-limit");
 const promClient = require("prom-client");
+const { registry: appRegistry } = require("../metrics");
 
 // ── Prometheus histogram ─────────────────────────────────────────────────────
 // Guard against double-registration if the module is hot-reloaded in tests.
+// Registered on BOTH the default register (backwards compatibility for
+// existing tests) and the app registry that backs `GET /metrics`, so Horizon
+// latency is actually scrapeable.
 let horizonLatency;
 const existingMetric = promClient.register.getSingleMetric(
   "stellar_marketpay_horizon_request_duration_seconds"
@@ -26,6 +30,7 @@ if (existingMetric) {
     help: "Latency of Horizon API requests in seconds",
     labelNames: ["method", "status"],
     buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+    registers: [promClient.register, appRegistry],
   });
 }
 

--- a/backend/tests/metrics.test.js
+++ b/backend/tests/metrics.test.js
@@ -1,0 +1,427 @@
+"use strict";
+
+/**
+ * backend/tests/metrics.test.js
+ *
+ * Prometheus observability tests.
+ *
+ * Verifies:
+ *   - prom-client is installed and the shared registry is wired up.
+ *   - All four required metrics are registered and exported:
+ *       http_requests_total, http_request_duration_ms,
+ *       active_websocket_connections, pool_query_duration_ms
+ *   - `renderMetrics()` emits valid Prometheus text exposition format.
+ *   - The `/metrics` internal-auth guard accepts a valid bearer token /
+ *     internal IP and rejects everything else.
+ *   - Monitoring config (prometheus.yml + Grafana dashboard) is present,
+ *     parseable and references the exported metric names.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const express = require("express");
+const request = require("supertest");
+
+const metrics = require("../src/metrics");
+const metricsAuth = require("../src/middleware/metricsAuth");
+
+const REQUIRED_METRICS = [
+  "http_requests_total",
+  "http_request_duration_ms",
+  "active_websocket_connections",
+  "pool_query_duration_ms",
+];
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const MONITORING = path.join(REPO_ROOT, "monitoring");
+
+describe("Prometheus metrics", () => {
+  describe("prom-client dependency", () => {
+    it("is declared in backend package.json dependencies", () => {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8")
+      );
+      expect(pkg.dependencies).toHaveProperty("prom-client");
+    });
+
+    it("is resolvable at runtime", () => {
+      expect(() => require("prom-client")).not.toThrow();
+    });
+  });
+
+  describe("registry", () => {
+    it("exposes a prom-client Registry with the text content type", () => {
+      expect(metrics.registry).toBeDefined();
+      expect(typeof metrics.registry.metrics).toBe("function");
+      expect(metrics.registry.contentType).toContain("text/plain");
+    });
+
+    it("collects Node.js default metrics under the marketpay_ prefix", async () => {
+      const output = await metrics.renderMetrics();
+      expect(output).toContain("marketpay_process_cpu_user_seconds_total");
+    });
+  });
+
+  describe.each(REQUIRED_METRICS)("required metric %s", (name) => {
+    it("is registered on the shared registry", () => {
+      expect(metrics.registry.getSingleMetric(name)).toBeTruthy();
+    });
+
+    it("appears in the rendered exposition output", async () => {
+      const output = await metrics.renderMetrics();
+      expect(output).toContain(`# HELP ${name}`);
+      expect(output).toContain(`# TYPE ${name}`);
+    });
+  });
+
+  describe("exposition format", () => {
+    it("emits parseable Prometheus text format", async () => {
+      const output = await metrics.renderMetrics();
+      const lines = output.split("\n").filter(Boolean);
+      expect(lines.length).toBeGreaterThan(0);
+      for (const line of lines) {
+        // Every line is a comment or `name{labels} value [timestamp]`.
+        expect(line.startsWith("#") || /^[a-zA-Z_:][a-zA-Z0-9_:]*(\{.*\})?\s+\S+/.test(line)).toBe(true);
+      }
+    });
+  });
+
+  describe("observeHttpRequest", () => {
+    it("increments the counter and the histogram together", async () => {
+      const labels = { method: "GET", route: "/__test__/http", status_code: "200" };
+      metrics.observeHttpRequest(labels, 42);
+
+      const counter = await metrics.httpRequestsTotal.get();
+      const sample = counter.values.find((v) => v.labels.route === "/__test__/http");
+      expect(sample).toBeTruthy();
+      expect(sample.value).toBeGreaterThanOrEqual(1);
+
+      const hist = await metrics.httpRequestDurationMs.get();
+      const sum = hist.values.find(
+        (v) => v.metricName === "http_request_duration_ms_sum" && v.labels.route === "/__test__/http"
+      );
+      expect(sum).toBeTruthy();
+      expect(sum.value).toBeCloseTo(42, 3);
+    });
+
+    it("also feeds the legacy marketpay_* series in seconds", async () => {
+      metrics.observeHttpRequest(
+        { method: "GET", route: "/__test__/legacy", status_code: "200" },
+        2000
+      );
+      const hist = await metrics.legacyHttpRequestDurationSeconds.get();
+      const sum = hist.values.find(
+        (v) =>
+          v.metricName === "marketpay_http_request_duration_seconds_sum" &&
+          v.labels.route === "/__test__/legacy"
+      );
+      expect(sum.value).toBeCloseTo(2, 3);
+    });
+  });
+
+  describe("observePoolQuery", () => {
+    it("records duration and count under the operation label", async () => {
+      metrics.observePoolQuery("select", "success", 12.5);
+
+      const hist = await metrics.poolQueryDurationMs.get();
+      const sum = hist.values.find(
+        (v) =>
+          v.metricName === "pool_query_duration_ms_sum" &&
+          v.labels.operation === "select" &&
+          v.labels.status === "success"
+      );
+      expect(sum).toBeTruthy();
+      expect(sum.value).toBeGreaterThanOrEqual(12.5);
+    });
+
+    it("labels failures with status=error", async () => {
+      metrics.observePoolQuery("insert", "error", 3);
+      const counter = await metrics.poolQueriesTotal.get();
+      const sample = counter.values.find(
+        (v) => v.labels.operation === "insert" && v.labels.status === "error"
+      );
+      expect(sample).toBeTruthy();
+    });
+  });
+
+  describe("sqlOperation", () => {
+    it.each([
+      ["SELECT * FROM jobs", "select"],
+      ["  insert into jobs values (1)", "insert"],
+      ["UPDATE jobs SET x = 1", "update"],
+      ["DELETE FROM jobs", "delete"],
+      ["WITH cte AS (SELECT 1) SELECT * FROM cte", "with"],
+      ["BEGIN", "begin"],
+    ])("maps %s to %s", (sql, expected) => {
+      expect(metrics.sqlOperation(sql)).toBe(expected);
+    });
+
+    it("accepts a pg query config object", () => {
+      expect(metrics.sqlOperation({ text: "SELECT 1" })).toBe("select");
+    });
+
+    it("returns 'other' for unrecognised or non-string input", () => {
+      expect(metrics.sqlOperation(null)).toBe("other");
+      expect(metrics.sqlOperation(123)).toBe("other");
+      expect(metrics.sqlOperation("VACUUM ANALYZE")).toBe("other");
+    });
+
+    it("never embeds query parameters in the label (bounded cardinality)", () => {
+      const op = metrics.sqlOperation("SELECT * FROM users WHERE email = 'a@b.c'");
+      expect(op).toBe("select");
+      expect(op).not.toContain("@");
+    });
+  });
+
+  describe("normalizeRoutePath", () => {
+    it.each([
+      ["/api/jobs/8123", "/api/jobs/:id"],
+      ["/api/jobs/8123/bids", "/api/jobs/:id/bids"],
+      ["/api/disputes/3fa85f64-5717-4562-b3fc-2c963f66afa6", "/api/disputes/:id"],
+      ["/api/profiles/GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV", "/api/profiles/:id"],
+      ["/api/jobs", "/api/jobs"],
+      ["/api/jobs?status=open", "/api/jobs"],
+      ["/", "/"],
+      ["", "/"],
+    ])("normalises %s to %s", (input, expected) => {
+      expect(metrics.normalizeRoutePath(input)).toBe(expected);
+    });
+
+    it("bounds cardinality across many distinct ids", () => {
+      const labels = new Set();
+      for (let i = 0; i < 500; i += 1) {
+        labels.add(metrics.normalizeRoutePath(`/api/jobs/${i}`));
+      }
+      expect(labels.size).toBe(1);
+    });
+
+    it("caps pathologically long segments", () => {
+      expect(metrics.normalizeRoutePath(`/api/${"a".repeat(200)}`)).toBe("/api/:id");
+    });
+
+    it("handles malformed percent-encoding without throwing", () => {
+      expect(() => metrics.normalizeRoutePath("/api/%E0%A4%A")).not.toThrow();
+    });
+  });
+
+  describe("resolveRouteLabel", () => {
+    it("prefers the matched Express pattern", () => {
+      expect(metrics.resolveRouteLabel("/api/jobs/:id", "/api/jobs/8123")).toBe("/api/jobs/:id");
+    });
+
+    it("falls back to the normalised URL when the pattern lost its mount prefix", () => {
+      // Express restores req.baseUrl to "" before error handlers respond, so a
+      // bare ":id" pattern must not become the label.
+      expect(metrics.resolveRouteLabel("/:id", "/api/jobs/8123")).toBe("/api/jobs/:id");
+    });
+
+    it("falls back to the normalised URL when no pattern matched (404)", () => {
+      expect(metrics.resolveRouteLabel(null, "/nope")).toBe("/nope");
+    });
+  });
+
+  describe("setWebsocketConnections", () => {
+    it("sets the gauge per channel", async () => {
+      metrics.setWebsocketConnections("realtime", 7);
+      metrics.setWebsocketConnections("scope", 3);
+
+      const gauge = await metrics.activeWebsocketConnections.get();
+      const realtime = gauge.values.find((v) => v.labels.channel === "realtime");
+      const scope = gauge.values.find((v) => v.labels.channel === "scope");
+      expect(realtime.value).toBe(7);
+      expect(scope.value).toBe(3);
+    });
+
+    it("mirrors the realtime channel to the legacy gauge", async () => {
+      metrics.setWebsocketConnections("realtime", 11);
+      const legacy = await metrics.legacyWsConnectionsActive.get();
+      expect(legacy.values[0].value).toBe(11);
+    });
+  });
+});
+
+describe("GET /metrics internal auth", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  /**
+   * Build a minimal Express app that mounts the real metrics route.
+   *
+   * @returns {import("express").Express} configured app
+   */
+  function buildApp() {
+    const app = express();
+    app.get("/metrics", metricsAuth, async (req, res) => {
+      res.set("Content-Type", metrics.registry.contentType);
+      res.end(await metrics.renderMetrics());
+    });
+    return app;
+  }
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("allows loopback scrapes when private-network access is enabled", async () => {
+    delete process.env.METRICS_TOKEN;
+    delete process.env.METRICS_SECRET;
+    const res = await request(buildApp()).get("/metrics");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/plain");
+    expect(res.text).toContain("http_requests_total");
+  });
+
+  it("accepts a valid bearer token", async () => {
+    process.env.METRICS_TOKEN = "super-secret-scrape-token";
+    const res = await request(buildApp())
+      .get("/metrics")
+      .set("Authorization", "Bearer super-secret-scrape-token");
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts the X-Metrics-Token header", async () => {
+    process.env.METRICS_TOKEN = "super-secret-scrape-token";
+    const res = await request(buildApp())
+      .get("/metrics")
+      .set("X-Metrics-Token", "super-secret-scrape-token");
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an invalid bearer token with 401", async () => {
+    process.env.METRICS_TOKEN = "super-secret-scrape-token";
+    const res = await request(buildApp())
+      .get("/metrics")
+      .set("Authorization", "Bearer wrong-token");
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toContain("Bearer");
+  });
+
+  it("rejects tokens of a different length without throwing", async () => {
+    process.env.METRICS_TOKEN = "super-secret-scrape-token";
+    const res = await request(buildApp())
+      .get("/metrics")
+      .set("Authorization", "Bearer x");
+    expect(res.status).toBe(401);
+  });
+
+  it("requires a token when private-network access is disabled", async () => {
+    process.env.METRICS_TOKEN = "super-secret-scrape-token";
+    process.env.METRICS_ALLOW_PRIVATE_NETWORK = "false";
+    const denied = await request(buildApp()).get("/metrics");
+    expect(denied.status).toBe(401);
+
+    const allowed = await request(buildApp())
+      .get("/metrics")
+      .set("Authorization", "Bearer super-secret-scrape-token");
+    expect(allowed.status).toBe(200);
+  });
+
+  it("still honours the legacy METRICS_SECRET env name", async () => {
+    delete process.env.METRICS_TOKEN;
+    process.env.METRICS_SECRET = "legacy-secret";
+    const res = await request(buildApp())
+      .get("/metrics")
+      .set("Authorization", "Bearer legacy-secret");
+    expect(res.status).toBe(200);
+  });
+
+  it("never responds 403 (so the CSRF bypass contract holds)", async () => {
+    process.env.METRICS_TOKEN = "t";
+    const res = await request(buildApp())
+      .get("/metrics")
+      .set("Authorization", "Bearer nope");
+    expect(res.status).not.toBe(403);
+  });
+
+  describe("isInternalIp", () => {
+    it.each(["127.0.0.1", "::1", "10.1.2.3", "192.168.0.7", "172.16.5.9", "172.31.0.1", "fd00::1"])(
+      "treats %s as internal",
+      (ip) => expect(metricsAuth.isInternalIp(ip)).toBe(true)
+    );
+
+    it.each(["8.8.8.8", "1.1.1.1", "172.32.0.1", "203.0.113.5", "2606:4700::1", ""])(
+      "treats %s as external",
+      (ip) => expect(metricsAuth.isInternalIp(ip)).toBe(false)
+    );
+
+    it("normalises IPv4-mapped IPv6 addresses", () => {
+      expect(metricsAuth.isInternalIp("::ffff:10.0.0.5")).toBe(true);
+      expect(metricsAuth.isInternalIp("::ffff:8.8.8.8")).toBe(false);
+    });
+  });
+});
+
+describe("monitoring configuration", () => {
+  describe("prometheus.yml", () => {
+    const file = path.join(MONITORING, "prometheus", "prometheus.yml");
+
+    it("exists", () => {
+      expect(fs.existsSync(file)).toBe(true);
+    });
+
+    it("defines a marketpay-backend scrape job on /metrics", () => {
+      const raw = fs.readFileSync(file, "utf8");
+      expect(raw).toContain("job_name: marketpay-backend");
+      expect(raw).toContain("metrics_path: /metrics");
+      expect(raw).toContain("backend:4000");
+    });
+
+    it("documents how to enable bearer-token scraping", () => {
+      const raw = fs.readFileSync(file, "utf8");
+      expect(raw).toMatch(/METRICS_TOKEN/);
+    });
+  });
+
+  describe("alert rules", () => {
+    const file = path.join(MONITORING, "prometheus", "rules", "alerts.yml");
+
+    it("alerts on the new metric names", () => {
+      const raw = fs.readFileSync(file, "utf8");
+      expect(raw).toContain("http_request_duration_ms_bucket");
+      expect(raw).toContain("pool_query_duration_ms_bucket");
+      expect(raw).toContain("active_websocket_connections");
+    });
+  });
+
+  describe("Grafana dashboard", () => {
+    const file = path.join(MONITORING, "grafana", "dashboards", "marketpay-backend-metrics.json");
+
+    it("exists and is valid JSON", () => {
+      expect(fs.existsSync(file)).toBe(true);
+      expect(() => JSON.parse(fs.readFileSync(file, "utf8"))).not.toThrow();
+    });
+
+    it("has the required dashboard fields", () => {
+      const dash = JSON.parse(fs.readFileSync(file, "utf8"));
+      expect(typeof dash.uid).toBe("string");
+      expect(typeof dash.title).toBe("string");
+      expect(Array.isArray(dash.panels)).toBe(true);
+      expect(dash.panels.length).toBeGreaterThan(0);
+      expect(typeof dash.schemaVersion).toBe("number");
+    });
+
+    it("gives every panel a unique id and a grid position", () => {
+      const dash = JSON.parse(fs.readFileSync(file, "utf8"));
+      const ids = dash.panels.map((p) => p.id);
+      expect(new Set(ids).size).toBe(ids.length);
+      for (const panel of dash.panels) {
+        expect(panel.gridPos).toBeDefined();
+        expect(typeof panel.gridPos.w).toBe("number");
+      }
+    });
+
+    it("charts all four required metrics", () => {
+      const raw = fs.readFileSync(file, "utf8");
+      for (const name of REQUIRED_METRICS) {
+        expect(raw).toContain(name);
+      }
+    });
+
+    it("is picked up by the dashboards provisioning path", () => {
+      const provisioning = fs.readFileSync(
+        path.join(MONITORING, "grafana", "provisioning", "dashboards", "dashboards.yml"),
+        "utf8"
+      );
+      expect(provisioning).toContain("/var/lib/grafana/dashboards");
+    });
+  });
+});

--- a/backend/tests/poolMetrics.test.js
+++ b/backend/tests/poolMetrics.test.js
@@ -1,0 +1,137 @@
+"use strict";
+
+/**
+ * backend/tests/poolMetrics.test.js
+ *
+ * Verifies that `src/db/pool.js` instruments every query with
+ * `pool_query_duration_ms` without changing the pg Pool contract.
+ *
+ * The underlying `pg` driver is mocked so the suite runs with no database.
+ */
+
+const metrics = require("../src/metrics");
+
+// ── Mock pg so no real connection is ever opened ─────────────────────────────
+jest.mock("pg", () => {
+  /** Minimal stand-in for pg.Pool. */
+  class FakePool {
+    constructor(options) {
+      this.options = options;
+      this.totalCount = 3;
+      this.idleCount = 2;
+      this.waitingCount = 0;
+      this.listeners = {};
+      this.calls = [];
+    }
+
+    on(event, handler) {
+      this.listeners[event] = handler;
+    }
+
+    query(...args) {
+      this.calls.push(args);
+      const last = args[args.length - 1];
+      const text = typeof args[0] === "string" ? args[0] : (args[0] && args[0].text) || "";
+
+      if (text.includes("BOOM")) {
+        const err = new Error("query failed");
+        if (typeof last === "function") return last(err);
+        return Promise.reject(err);
+      }
+
+      const result = { rows: [{ ok: 1 }], rowCount: 1 };
+      if (typeof last === "function") return last(null, result);
+      return Promise.resolve(result);
+    }
+  }
+  return { Pool: FakePool };
+});
+
+const pool = require("../src/db/pool");
+
+/**
+ * Read the observed count for a pool_query_duration_ms label set.
+ *
+ * @param {string} operation SQL verb label
+ * @param {string} status    "success" | "error"
+ * @returns {Promise<number>} number of observations
+ */
+async function queryCount(operation, status) {
+  const data = await metrics.poolQueryDurationMs.get();
+  const sample = data.values.find(
+    (v) =>
+      v.metricName === "pool_query_duration_ms_count" &&
+      v.labels.operation === operation &&
+      v.labels.status === status
+  );
+  return sample ? sample.value : 0;
+}
+
+describe("pool query instrumentation (pool_query_duration_ms)", () => {
+  it("still returns query results unchanged", async () => {
+    const res = await pool.query("SELECT 1");
+    expect(res.rows[0].ok).toBe(1);
+    expect(res.rowCount).toBe(1);
+  });
+
+  it("records a successful SELECT under operation=select,status=success", async () => {
+    const before = await queryCount("select", "success");
+    await pool.query("SELECT * FROM jobs WHERE id = $1", [1]);
+    const after = await queryCount("select", "success");
+    expect(after).toBe(before + 1);
+  });
+
+  it("labels the SQL verb, not the full statement", async () => {
+    await pool.query("UPDATE jobs SET title = $1 WHERE id = $2", ["x", 1]);
+    const data = await metrics.poolQueryDurationMs.get();
+    const labels = data.values.map((v) => v.labels.operation);
+    expect(labels).toContain("update");
+    expect(labels.every((l) => !String(l).includes("jobs"))).toBe(true);
+  });
+
+  it("records failures under status=error and still rejects", async () => {
+    const before = await queryCount("select", "error");
+    await expect(pool.query("SELECT BOOM")).rejects.toThrow("query failed");
+    const after = await queryCount("select", "error");
+    expect(after).toBe(before + 1);
+  });
+
+  it("supports the pg query-config object form", async () => {
+    const before = await queryCount("insert", "success");
+    await pool.query({ text: "INSERT INTO jobs (title) VALUES ($1)", values: ["t"] });
+    const after = await queryCount("insert", "success");
+    expect(after).toBe(before + 1);
+  });
+
+  it("supports the callback form", (done) => {
+    queryCount("delete", "success").then((before) => {
+      pool.query("DELETE FROM jobs WHERE id = $1", [1], (err, result) => {
+        expect(err).toBeNull();
+        expect(result.rowCount).toBe(1);
+        queryCount("delete", "success").then((after) => {
+          expect(after).toBe(before + 1);
+          done();
+        });
+      });
+    });
+  });
+
+  it("records a duration greater than zero", async () => {
+    await pool.query("SELECT 1");
+    const data = await metrics.poolQueryDurationMs.get();
+    const sum = data.values.find((v) => v.metricName === "pool_query_duration_ms_sum");
+    expect(sum.value).toBeGreaterThan(0);
+  });
+
+  it("keeps getPoolStats working", () => {
+    const stats = pool.getPoolStats();
+    expect(stats).toEqual({ total: 3, idle: 2, waiting: 0 });
+  });
+
+  it("populates the pool saturation gauges at scrape time", async () => {
+    const output = await metrics.renderMetrics();
+    expect(output).toContain("pg_pool_total 3");
+    expect(output).toContain("pg_pool_idle 2");
+    expect(output).toContain('marketpay_db_connections{state="total"} 3');
+  });
+});

--- a/monitoring/grafana/dashboards/marketpay-backend-metrics.json
+++ b/monitoring/grafana/dashboards/marketpay-backend-metrics.json
@@ -1,0 +1,1364 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "name": "Annotations & Alerts",
+        "type": "dashboard",
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "enable": true,
+        "hide": true,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        }
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "uid": "marketpay-backend-metrics",
+  "title": "MarketPay Backend Metrics",
+  "description": "Prometheus metrics exported by the Stellar MarketPay Express API on GET /metrics: http_requests_total, http_request_duration_ms, active_websocket_connections and pool_query_duration_ms.",
+  "tags": [
+    "marketpay",
+    "backend",
+    "prometheus"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "1h"
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
+      {
+        "name": "route",
+        "label": "Route",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "query": {
+          "query": "label_values(http_requests_total{job=\"marketpay-backend\"}, route)",
+          "refId": "route"
+        },
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false,
+        "options": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Golden Signals",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Request Rate",
+      "description": "Total HTTP requests per second served by the Express API.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(http_requests_total{job=\"marketpay-backend\"}[5m]))",
+          "format": "time_series",
+          "legendFormat": "req/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Error Rate (5xx)",
+      "description": "Percentage of requests returning a 5xx response.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "100 * sum(rate(http_requests_total{job=\"marketpay-backend\",status_code=~\"5..\"}[5m])) / clamp_min(sum(rate(http_requests_total{job=\"marketpay-backend\"}[5m])), 0.001)",
+          "format": "time_series",
+          "legendFormat": "5xx %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "p99 Latency",
+      "description": "99th percentile HTTP request duration (http_request_duration_ms).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_ms_bucket{job=\"marketpay-backend\"}[5m])) by (le))",
+          "format": "time_series",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 2000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Active WebSocket Connections",
+      "description": "Currently open WebSocket connections across all channels.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(active_websocket_connections{job=\"marketpay-backend\"})",
+          "format": "time_series",
+          "legendFormat": "connections"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "HTTP Traffic",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "http_requests_total \u2014 rate by status code",
+      "description": "Request throughput broken down by HTTP status code.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (status_code) (rate(http_requests_total{job=\"marketpay-backend\"}[5m]))",
+          "format": "time_series",
+          "legendFormat": "{{status_code}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "http_request_duration_ms \u2014 latency quantiles",
+      "description": "p50 / p95 / p99 request latency in milliseconds.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_ms_bucket{job=\"marketpay-backend\"}[5m])) by (le))",
+          "format": "time_series",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_ms_bucket{job=\"marketpay-backend\"}[5m])) by (le))",
+          "format": "time_series",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_ms_bucket{job=\"marketpay-backend\"}[5m])) by (le))",
+          "format": "time_series",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Top 10 routes by request rate",
+      "description": "Busiest API routes.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, sum by (route, method) (rate(http_requests_total{job=\"marketpay-backend\"}[5m])))",
+          "format": "time_series",
+          "legendFormat": "{{method}} {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Slowest routes (p95)",
+      "description": "Routes with the highest p95 latency.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, histogram_quantile(0.95, sum by (route, le) (rate(http_request_duration_ms_bucket{job=\"marketpay-backend\"}[5m]))))",
+          "format": "time_series",
+          "legendFormat": "{{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "WebSockets",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "active_websocket_connections \u2014 by channel",
+      "description": "Open WebSocket connections per channel (realtime, scope).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "active_websocket_connections{job=\"marketpay-backend\"}",
+          "format": "time_series",
+          "legendFormat": "{{channel}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "WebSocket connection churn",
+      "description": "Rate of change in open WebSocket connections \u2014 spikes indicate mass reconnects.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(deriv(active_websocket_connections{job=\"marketpay-backend\"}[5m]))",
+          "format": "time_series",
+          "legendFormat": "delta/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "type": "row",
+      "title": "Database",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "pool_query_duration_ms \u2014 quantiles",
+      "description": "PostgreSQL query latency through the shared pool.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(pool_query_duration_ms_bucket{job=\"marketpay-backend\"}[5m])) by (le))",
+          "format": "time_series",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(pool_query_duration_ms_bucket{job=\"marketpay-backend\"}[5m])) by (le))",
+          "format": "time_series",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(pool_query_duration_ms_bucket{job=\"marketpay-backend\"}[5m])) by (le))",
+          "format": "time_series",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Query rate by operation",
+      "description": "Queries per second grouped by SQL verb.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (operation) (rate(pool_queries_total{job=\"marketpay-backend\"}[5m]))",
+          "format": "time_series",
+          "legendFormat": "{{operation}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Connection pool saturation",
+      "description": "Total / idle / waiting PostgreSQL pool connections.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pg_pool_total{job=\"marketpay-backend\"}",
+          "format": "time_series",
+          "legendFormat": "total"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pg_pool_idle{job=\"marketpay-backend\"}",
+          "format": "time_series",
+          "legendFormat": "idle"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "pg_pool_waiting{job=\"marketpay-backend\"}",
+          "format": "time_series",
+          "legendFormat": "waiting"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Failed queries",
+      "description": "Rate of queries that threw an error.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (operation) (rate(pool_queries_total{job=\"marketpay-backend\",status=\"error\"}[5m]))",
+          "format": "time_series",
+          "legendFormat": "{{operation}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "type": "row",
+      "title": "Process & Queues",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "panels": []
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Node.js heap usage",
+      "description": "V8 heap consumption of the API process.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 50
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "marketpay_nodejs_heap_size_used_bytes{job=\"marketpay-backend\"}",
+          "format": "time_series",
+          "legendFormat": "heap used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "marketpay_nodejs_heap_size_total_bytes{job=\"marketpay-backend\"}",
+          "format": "time_series",
+          "legendFormat": "heap total"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Event loop lag (p99)",
+      "description": "Event loop lag \u2014 sustained values above 100ms indicate CPU starvation.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 50
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "marketpay_nodejs_eventloop_lag_p99_seconds{job=\"marketpay-backend\"}",
+          "format": "time_series",
+          "legendFormat": "p99 lag"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Pending notifications",
+      "description": "Depth of the outbound notification queue.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 50
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "notification_queue_pending{job=\"marketpay-backend\"}",
+          "format": "time_series",
+          "legendFormat": "pending"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    }
+  ]
+}

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,18 +1,64 @@
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
+  external_labels:
+    project: stellar-marketpay
+    environment: production
 
 rule_files:
   - /etc/prometheus/rules/*.yml
 
 scrape_configs:
+  # ── Stellar MarketPay Express API ───────────────────────────────────────────
+  # The backend exposes the Prometheus text format on GET /metrics. The
+  # endpoint requires internal auth (see backend/src/middleware/metricsAuth.js):
+  # either a bearer token OR a private-network source IP. Inside the compose /
+  # k8s network the scrape already originates from private space, so this job
+  # works out of the box.
+  #
+  # To ENFORCE token auth instead (recommended when the backend is reachable
+  # from outside the private network):
+  #   1. Set METRICS_TOKEN=<secret> and METRICS_ALLOW_PRIVATE_NETWORK=false on
+  #      the backend service.
+  #   2. Mount the same secret into this container, e.g. in
+  #      docker-compose.prod.yml:
+  #        secrets: [metrics_token]
+  #   3. Uncomment the `authorization` block below.
   - job_name: marketpay-backend
     metrics_path: /metrics
+    scheme: http
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    honor_labels: false
+    # authorization:
+    #   type: Bearer
+    #   credentials_file: /run/secrets/metrics_token
     static_configs:
       - targets:
           - backend:4000
+        labels:
+          service: marketpay-backend
+          component: api
+    metric_relabel_configs:
+      # Drop very-high-cardinality Node.js GC buckets we never chart.
+      - source_labels: [__name__]
+        regex: marketpay_nodejs_gc_duration_seconds_bucket
+        action: drop
 
+  # ── Host metrics ────────────────────────────────────────────────────────────
   - job_name: node-exporter
     static_configs:
       - targets:
           - node-exporter:9100
+        labels:
+          service: node-exporter
+          component: host
+
+  # ── Prometheus self-monitoring ──────────────────────────────────────────────
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090
+        labels:
+          service: prometheus
+          component: monitoring

--- a/monitoring/prometheus/rules/alerts.yml
+++ b/monitoring/prometheus/rules/alerts.yml
@@ -45,3 +45,50 @@ groups:
         annotations:
           summary: "High CPU utilization detected"
           description: "Compute resources are above 80% utilization — review right-sizing recommendations."
+
+  - name: marketpay-backend-metrics
+    rules:
+      - alert: BackendMetricsEndpointDown
+        expr: up{job="marketpay-backend"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "MarketPay /metrics scrape is failing"
+          description: "Prometheus cannot scrape the backend metrics endpoint. Check METRICS_TOKEN / network reachability."
+
+      - alert: HighRequestLatencyMs
+        expr: histogram_quantile(0.99, sum(rate(http_request_duration_ms_bucket{job="marketpay-backend"}[5m])) by (le)) > 2000
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "MarketPay p99 request latency above 2000ms"
+          description: "The 99th percentile of http_request_duration_ms has exceeded 2s for more than 10 minutes."
+
+      - alert: HighApiErrorRate
+        expr: 100 * sum(rate(http_requests_total{job="marketpay-backend",status_code=~"5.."}[5m])) / clamp_min(sum(rate(http_requests_total{job="marketpay-backend"}[5m])), 0.001) > 5
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "MarketPay 5xx error rate above 5%"
+          description: "More than 5% of requests are returning 5xx responses."
+
+      - alert: SlowDatabaseQueries
+        expr: histogram_quantile(0.95, sum(rate(pool_query_duration_ms_bucket{job="marketpay-backend"}[5m])) by (le)) > 500
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL p95 query latency above 500ms"
+          description: "pool_query_duration_ms p95 has exceeded 500ms for more than 10 minutes."
+
+      - alert: WebSocketConnectionsSpike
+        expr: sum(active_websocket_connections{job="marketpay-backend"}) > 5000
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unusually high number of open WebSocket connections"
+          description: "active_websocket_connections has been above 5000 for 15 minutes — check for reconnect storms or leaked sockets."


### PR DESCRIPTION
**Summary**

Exposes the Express API on `GET /metrics` in Prometheus text exposition format behind internal-only authentication, and wires four metrics end-to-end into the existing `monitoring/` stack.

Metrics *partially* existed but were misnamed, mis-united, incomplete, and unauthenticated by default — so this is a correctness-and-security fix, not a greenfield build:

- **Security hole closed.** The `/metrics` guard only ran when `METRICS_SECRET` was set, and that variable is referenced nowhere else in the repo — so on every real deployment the endpoint was fully public, leaking route names, error rates, queue depth and pool saturation. It also compared tokens with `!==` (timing oracle). Now constant-time `crypto.timingSafeEqual` plus private-IP gating.
- **Names/units corrected.** `marketpay_http_request_duration_seconds` → `http_request_duration_ms`; `ws_connections_active` → `active_websocket_connections`.
- **`pool_query_duration_ms` created from nothing.** All 449 `pool.query` call sites instrumented via one wrapper, zero service-file edits.
- **WebSocket gauge leak fixed.** `scope` sockets were never counted and never decremented on close, so the gauge drifted upward forever.
- **Cardinality explosion prevented.** Express restores `req.baseUrl` to `""` before error handlers respond, so `/api/jobs/8123` emitted `route="/"` and `route="/:id"`; labels are now `"/api/jobs/:id"`.

Backwards compatible — legacy `marketpay_*` and `ws_connections_active` series still emit, so the pre-existing dashboard and alert rules keep working untouched.

**Type**

- **☑ Bug fix**
- **☑ New feature**
- ☐ Documentation
- ☐ Refactor
- ☐ Smart contract change

**Related Issue**

Closes #___ ← *replace with the metrics issue number; it wasn't in what you shared.*

**Testing**

- **☑ Tested locally on Testnet** — N/A in substance: backend-only observability, no Stellar/Soroban interaction. Validated instead against a real Prometheus v2.55.1: `promtool check config` SUCCESS, `check rules` SUCCESS (10 rules), live scrape target **UP** with `lastError=''`, all four metrics ingested into the TSDB, **24/24** dashboard queries and **10/10** alert expressions valid. Auth matrix: no-creds → 401, wrong token → 401, truncated token → 401, correct Bearer → 200, correct `X-Metrics-Token` → 200.
- **☑ No TypeScript / Rust errors** — lint diff vs upstream **30 → 30, identical**; all six added/modified files ESLint-clean. Tests: **228 → 310 passing**, failing-suite set byte-identical (`diff` clean), so **+82 tests, zero regressions**.
- **☑ Docs updated if needed** — added `backend/docs/METRICS.md` (metric tables, cardinality rationale, auth/env vars, verification commands).

**Screenshots (if UI change)**

No UI change. Grafana auto-provisions `monitoring/grafana/dashboards/marketpay-backend-metrics.json` (17 panels: Golden Signals, HTTP Traffic, WebSockets, Database, Process & Queues) from the mount already declared in `docker-compose.prod.yml`.

---

**Files:** *Added* — `backend/src/metrics.js`, `backend/src/middleware/metricsAuth.js`, `backend/tests/metrics.test.js`, `backend/tests/poolMetrics.test.js`, `monitoring/grafana/dashboards/marketpay-backend-metrics.json`, `backend/docs/METRICS.md`. *Modified* — `backend/src/server.js`, `backend/src/db/pool.js`, `backend/src/utils/horizonClient.js`, `monitoring/prometheus/prometheus.yml`, `monitoring/prometheus/rules/alerts.yml`, `backend/package-lock.json`.

**Two flags for reviewers:**

1. I used `monitoring/prometheus/prometheus.yml`, not the `monitoring/prometheus.yml` literally named in the issue — the nested path is what `docker-compose.prod.yml:172` actually mounts. A file at the literal path would be dead config Prometheus never reads.
2. `server.js` **cannot boot on `main` today**, unrelated to this work: `PriceAlertService` is imported as a default but exported as a named property, and `broadcastToUser` is used at line 234 but never defined. Both reproduce on a clean checkout. I validated against a temporarily patched copy and reverted it — worth a separate ticket, since the production server is currently un-startable.

CLOSE #805 