### PR TITLE
feat(pwa): add install prompt banner for PWA on mobile browsers

### DIFF
--- a/frontend/components/PWAInstall.tsx
+++ b/frontend/components/PWAInstall.tsx
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback } from "react";
+
+export default function PWAInstall() {
+  const [deferredPrompt, setDeferredPrompt] = useState<{
+    prompt: () => Promise<void>;
+    userChoice: Promise<{ outcome: string }>;
+  } | null>(null);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const onInstall = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(
+        e as unknown as {
+          prompt: () => Promise<void>;
+          userChoice: Promise<{ outcome: string }>;
+        }
+      );
+      setShow(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", onInstall);
+    return () => window.removeEventListener("beforeinstallprompt", onInstall);
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+    if (choice?.outcome !== "accepted") setShow(false);
+    setDeferredPrompt(null);
+  }, [deferredPrompt]);
+
+  const handleDismiss = useCallback(() => {
+    setShow(false);
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Install app"
+      className="fixed bottom-4 left-4 right-4 z-50 flex items-center gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 shadow-lg sm:left-auto sm:max-w-sm"
+    >
+      <div className="flex-1">
+        <p className="text-sm font-semibold text-amber-200">
+          Install Stellar MarketPay
+        </p>
+        <p className="text-xs text-amber-600/80">
+          Add to your home screen for a better experience.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={handleInstall}
+          className="rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-ink-900 transition-colors hover:bg-amber-400"
+        >
+          Install
+        </button>
+        <button
+          onClick={handleDismiss}
+          className="rounded-lg px-3 py-1.5 text-xs font-semibold text-amber-400 transition-colors hover:text-amber-300"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/api";
 import { useToast } from "@/components/Toast";
 import WalletAccountMonitor from "@/components/WalletAccountMonitor";
+import PWAInstall from "@/components/PWAInstall";
 import "@/styles/globals.css";
 import { ToastProvider } from "@/components/Toast";
 import { PriceProvider } from "@/contexts/PriceContext";
@@ -284,6 +285,7 @@ function App({ Component, pageProps }: AppProps) {
                 onClose={() => setShortcutsModalOpen(false)}
                 showJobDetailShortcuts={isJobDetailPage}
               />
+              <PWAInstall />
             </div>
           </PriceProvider>
         </ToastProvider>


### PR DESCRIPTION
## Summary

Adds PWA install prompt banner for mobile browsers as specified in issue #860.

## Changes

- Added PWAInstall component in frontend/components/PWAInstall.tsx that shows an install banner on mobile browsers using the beforeinstallprompt event
- Updated frontend/pages/_app.tsx to integrate the PWAInstall component in the app layout
- The banner provides Install and Dismiss options for PWA installation

## Details

The PWA support infrastructure was already in place (next-pwa, manifest.json, service worker, offline page). This change completes the last acceptance criteria by providing a visible install prompt on mobile browsers.

Closes #860