### PR TITLE
fix(ci): fix deploy-storybook and visual-regression workflows

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps
 
       - run: npm run storybook:build
 
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/configure-pages@v4
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: 'storybook'
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Run visual regression tests (light mode)
         run: npx playwright test tests/e2e/visual-regression.spec.ts --project=chromium
         continue-on-error: true
+        env:
+          NEXT_PUBLIC_STELLAR_NETWORK: testnet
+          NEXT_PUBLIC_HORIZON_URL: https://horizon-testnet.stellar.org
+          NEXT_PUBLIC_API_URL: http://localhost:4000
+          NEXT_PUBLIC_USE_CONTRACT_MOCK: "true"
+          NEXT_PUBLIC_CONTRACT_ID: CMOCKCONTRACTID
 
       - name: Run visual regression tests (dark mode)
         run: npx playwright test tests/e2e/visual-regression.spec.ts --project=chromium-dark


### PR DESCRIPTION
Closes #798

---

## What

Three CI workflow fixes found during a full audit of all four GitHub Actions workflows.

## Changes

### deploy-storybook.yml
- **
pm ci -> 
pm ci --legacy-peer-deps** - Storybook v8 introduces peer dependency conflicts. The ccessibility.yml workflow already uses this flag; without it the install step fails.
- **ctions/upload-pages-artifact@v3 -> @v4** - v3 was deprecated and stopped working on January 30 2025. The deploy job fails at every push to main.

### visual-regression.yml
- **Added missing NEXT_PUBLIC_* env vars to the light mode test step** - The dark mode step had all five vars but the light mode step had none. Without NEXT_PUBLIC_USE_CONTRACT_MOCK=true the webServer boots without the contract mock and attempts to reach live Stellar contracts, causing light mode to fail while dark mode passes.

## Workflows not changed
- ccessibility.yml - structurally correct
- uzz.yml - correct, dtolnay/rust-toolchain@nightly and ctions/cache@v4 are valid