### PR TITLE
fix(deps): override bull uuid dependency to resolve @bull-board/ui ad…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4474,13 +4474,16 @@
             }
         },
         "node_modules/bull/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/busboy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,6 +63,11 @@
         "ws": "^8.21.1",
         "zod": "^4.4.3"
     },
+    "overrides": {
+        "bull": {
+            "uuid": "^11.1.1"
+        }
+    },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@stryker-mutator/core": "^9.6.1",


### PR DESCRIPTION
## Summary

- Resolved the moderate advisory (`GHSA-w5hq-g745-h8pq` - `uuid <11.1.1`) reported in `@bull-board/ui` / `@bull-board/api` by adding an npm dependency override for `bull`'s `uuid` dependency to `^11.1.1` in [backend/package.json](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/package.json) and updating [backend/package-lock.json](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/package-lock.json).

## Why

`npm audit` in `backend/` flagged moderate security vulnerabilities in `@bull-board/ui` due to transitive dependencies pulling in `bull` with vulnerable versions of `uuid` (`<11.1.1`). Resolving this transitive vulnerability ensures production dependencies pass `npm audit` cleanly without requiring breaking major upgrades.

## Implementation

- Added `overrides.bull.uuid: "^11.1.1"` in [backend/package.json](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/package.json).
- Regenerated [backend/package-lock.json](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/package-lock.json) with updated dependency trees.
- Audited production dependencies to ensure 0 vulnerabilities remain at the production audit gate.

## Testing

- `npm audit --omit=dev --audit-level=high` (found 0 vulnerabilities)
- `npm run lint` (0 errors)
- `npx jest src/routes/escrow.test.js src/routes/developer.test.js` (passed)

## Scope / Risk

- Strictly limited to [backend/package.json](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/package.json) and [backend/package-lock.json](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/package-lock.json).
- Low risk, non-breaking.

## Issue

Closes #1168
