### PR TITLE
fix(test): pass CSRF in aiScorer.test.js via shared helper

### DIFF
--- a/backend/src/routes/aiScorer.test.js
+++ b/backend/src/routes/aiScorer.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const request = require("supertest");
+const { fetchCsrf, applyCsrf } = require("../testUtils/csrfTestHelpers");
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -72,18 +73,22 @@ describe("POST /api/ai/score-job", () => {
   });
 
   it("returns 400 when description is missing", async () => {
-    const res = await request(app)
-      .post("/api/ai/score-job")
-      .send({});
+    const csrf = await fetchCsrf(app);
+    const res = await applyCsrf(
+      request(app).post("/api/ai/score-job").send({}),
+      csrf
+    );
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("Job description required");
   });
 
   it("returns 400 when description is empty string", async () => {
-    const res = await request(app)
-      .post("/api/ai/score-job")
-      .send({ description: "   " });
+    const csrf = await fetchCsrf(app);
+    const res = await applyCsrf(
+      request(app).post("/api/ai/score-job").send({ description: "   " }),
+      csrf
+    );
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("Job description required");
@@ -110,9 +115,13 @@ describe("POST /api/ai/score-job", () => {
       }),
     });
 
-    const res = await request(app)
-      .post("/api/ai/score-job")
-      .send({ description: "Build a Soroban smart contract for escrow with milestone-based payments" });
+    const csrf = await fetchCsrf(app);
+    const res = await applyCsrf(
+      request(app)
+        .post("/api/ai/score-job")
+        .send({ description: "Build a Soroban smart contract for escrow with milestone-based payments" }),
+      csrf
+    );
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -126,9 +135,13 @@ describe("POST /api/ai/score-job", () => {
   it("falls back to default score when fetch throws a network error", async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
 
-    const res = await request(app)
-      .post("/api/ai/score-job")
-      .send({ description: "We need a website built with React and Node.js" });
+    const csrf = await fetchCsrf(app);
+    const res = await applyCsrf(
+      request(app)
+        .post("/api/ai/score-job")
+        .send({ description: "We need a website built with React and Node.js" }),
+      csrf
+    );
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -150,9 +163,13 @@ describe("POST /api/ai/score-job", () => {
       text: jest.fn().mockResolvedValue("Internal Server Error"),
     });
 
-    const res = await request(app)
-      .post("/api/ai/score-job")
-      .send({ description: "We need a website built with React and Node.js" });
+    const csrf = await fetchCsrf(app);
+    const res = await applyCsrf(
+      request(app)
+        .post("/api/ai/score-job")
+        .send({ description: "We need a website built with React and Node.js" }),
+      csrf
+    );
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -167,9 +184,13 @@ describe("POST /api/ai/score-job", () => {
       }),
     });
 
-    const res = await request(app)
-      .post("/api/ai/score-job")
-      .send({ description: "Build a Soroban DEX with AMM functionality and integrated wallet" });
+    const csrf = await fetchCsrf(app);
+    const res = await applyCsrf(
+      request(app)
+        .post("/api/ai/score-job")
+        .send({ description: "Build a Soroban DEX with AMM functionality and integrated wallet" }),
+      csrf
+    );
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);

--- a/backend/src/testUtils/csrfTestHelpers.js
+++ b/backend/src/testUtils/csrfTestHelpers.js
@@ -1,0 +1,66 @@
+"use strict";
+
+/**
+ * src/testUtils/csrfTestHelpers.js
+ *
+ * Shared helpers for tests that need to call state-mutating routes protected
+ * by the csrf-csrf double-submit middleware.
+ *
+ * Usage:
+ *   const { fetchCsrf, applyCsrf, getCookie } = require("../testUtils/csrfTestHelpers");
+ *
+ *   const csrf = await fetchCsrf(app);
+ *   const req = request(app).post("/api/ai/score-job").send(body);
+ *   const res = await applyCsrf(req, csrf);
+ *
+ *   // or inline:
+ *   const res = await applyCsrf(
+ *     request(app).post("/api/foo").send({ a: 1 }),
+ *     await fetchCsrf(app)
+ *   );
+ */
+
+function getCookie(res, name) {
+  return (res.headers["set-cookie"] || [])
+    .find((cookie) => cookie.startsWith(`${name}=`))
+    ?.split(";")[0];
+}
+
+async function fetchCsrf(app) {
+  const request = require("supertest");
+  const res = await request(app).get("/api/auth/csrf-token");
+  if (res.status !== 200) {
+    throw new Error(
+      `fetchCsrf: GET /api/auth/csrf-token returned ${res.status}` +
+        (res.body?.error ? `: ${res.body.error}` : "")
+    );
+  }
+  if (typeof res.body?.csrfToken !== "string") {
+    throw new Error(
+      `fetchCsrf: expected body.csrfToken to be a string, got ${typeof res?.body?.csrfToken}`
+    );
+  }
+  const cookie = getCookie(res, "csrf-token");
+  return { token: res.body.csrfToken, cookie };
+}
+
+function applyCsrf(req, csrf) {
+  if (!csrf) {
+    throw new Error(
+      "applyCsrf: missing csrf argument — call fetchCsrf(app) first"
+    );
+  }
+  if (csrf.cookie) {
+    req = req.set("Cookie", csrf.cookie);
+  }
+  if (csrf.token) {
+    req = req.set("X-CSRF-Token", csrf.token);
+  }
+  return req;
+}
+
+module.exports = {
+  getCookie,
+  fetchCsrf,
+  applyCsrf,
+};


### PR DESCRIPTION
## Overview

All 6 tests in `src/routes/aiScorer.test.js` fail on `main` with `403 invalid csrf token`. `POST /api/ai/score-job` is covered by the csrf-csrf double-submit middleware (it is not under `/api/auth` or `/api/public`), but the supertest requests never fetch a CSRF bootstrap token or attach the required `csrf-token` cookie + `X-CSRF-Token` headers, so the middleware correctly rejects every request with `EBADCSRFTOKEN`.

This PR fixes the suite by adding the shared `fetchCsrf(app)` / `applyCsrf(req, csrf)` helpers the issue description calls for in `src/testUtils/`, then wires every POST in `aiScorer.test.js` through the same real round-trip the frontend uses (get CSRF cookie/token from `/api/auth/csrf-token`, replay both on the state-mutating request).

## Related Issue

Closes #1077

## Changes

### Shared CSRF test harness

- **[ADD]** `backend/src/testUtils/csrfTestHelpers.js`
  - `getCookie(res, name)` — extracts a named `Set-Cookie` header value, matching the helper `auth.test.js` uses.
  - `fetchCsrf(app)` — GETs `/api/auth/csrf-token` (the CSRF bootstrap route explicitly exempted by `middleware/csrf.js`) and returns `{ token, cookie }`. Validates HTTP 200 and that `body.csrfToken` is a string, so a broken harness throws a clear error instead of producing 403s later.
  - `applyCsrf(req, csrf)` — composes over any `supertest` request to attach the `Cookie` and `X-CSRF-Token` headers. Throws when `csrf` is missing, so tests fail fast on copy/paste forgetfulness instead of with a cryptic 403.

### Failing suite wired up

- **[MODIFY]** `backend/src/routes/aiScorer.test.js`
  - Each of the 6 `POST /api/ai/score-job` calls now does `const csrf = await fetchCsrf(app);` followed by `await applyCsrf(request(app).post(...).send(...), csrf)`, preserving the exact request payloads and expectations.

## Verification Results

Exact reproduce step from the issue:

```
cd backend && npx jest src/routes/aiScorer.test.js
Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Time:        16.319 s
```

Extra harness sanity check against the existing `tests/csrf.test.js` (same CSRF middleware, real round-trips):

```
npx jest tests/csrf.test.js
Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
```

CI-gate simulation (matches `ci.yml`):

```
npm run lint  ->  exit 0  (full backend lint: src tests __tests__)
npx jest --selectProjects unit --forceExit
  -> Unit reports pre-existing 23 suites / 58 tests failing (all outside this suite; the
     workflow marks this step continue-on-error: true per line 81 of ci.yml). The aiScorer
     suite itself is 6/6 green.
Frontend + contracts jobs: no files touched, so unchanged and expected green.
```

| Acceptance Criteria | Status |
|---|---|
| `npx jest src/routes/aiScorer.test.js` passes after this PR | Passed — 6/6 tests passing, 1 suite passing |
| Tests fetch a real CSRF token from `/api/auth/csrf-token` before POSTing | Passed — `fetchCsrf(app)` + `applyCsrf()` used on every POST |
| Reusable helper lives in `src/testUtils/` so other suites can adopt it (per issue umbrella note) | Passed — `csrfTestHelpers.js` exports `fetchCsrf`/`applyCsrf`/`getCookie` with input validation |
| No lint regressions | Passed — `npm run lint` = exit 0 (backend wide) |
| No frontend / contract changes | Passed — only backend `src/routes/aiScorer.test.js` + new `src/testUtils/csrfTestHelpers.js` touched |
