### PR TITLE
test(e2e): cover the Freighter wallet connection flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,40 @@ jobs:
       - name: Build
         run: npm run build
 
+  e2e-wallet:
+    name: Frontend E2E — Wallet Connection
+    runs-on: ubuntu-latest
+    needs: secrets-scan
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # Scoped to the wallet-connection flow (issue: e2e coverage for Freighter
+      # connect / unavailable / disconnect). The older suites are not gated yet.
+      - name: Run wallet connection e2e tests
+        run: npx playwright test wallet-connection --project=chromium
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
   contracts:
     name: Soroban Contracts — marketpay-contract
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,13 @@ jobs:
       run:
         working-directory: frontend
 
+    env:
+      NEXT_PUBLIC_USE_CONTRACT_MOCK: "true"
+      NEXT_PUBLIC_API_URL: http://localhost:4000
+      NEXT_PUBLIC_STELLAR_NETWORK: testnet
+      NEXT_PUBLIC_HORIZON_URL: https://horizon-testnet.stellar.org
+      NEXT_PUBLIC_CONTRACT_ID: CMOCKCONTRACTID
+
     steps:
       - uses: actions/checkout@v4
 

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -403,7 +403,10 @@ function App({ Component, pageProps }: AppProps) {
             </Head>
             <OfflineBanner />
             <div className="min-h-screen bg-lines" style={{ backgroundColor: "var(--bg)" }}>
-              <Navbar publicKey={publicKey} onConnect={handleConnect} onDisconnect={() => setPublicKey(null)} />
+              {/* handleWalletDisconnect clears the persisted key; a bare
+                  setPublicKey(null) lets the storage-rehydration effect below
+                  instantly restore the session, so Disconnect appears dead. */}
+              <Navbar publicKey={publicKey} onConnect={handleConnect} onDisconnect={handleWalletDisconnect} />
               <MobileTabBar publicKey={publicKey} />
               <main id="main-content">
                 <Component {...pageProps} publicKey={publicKey} onConnect={handleConnect} />

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
       NEXT_PUBLIC_HORIZON_URL: "https://horizon-testnet.stellar.org",
       NEXT_PUBLIC_CONTRACT_ID: "CMOCKCONTRACTID",
+      SKIP_API_CALLS: "true",
     },
   },
   projects: [

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -14,14 +14,18 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined, // Changed from 2 to 1 (sequential in CI to reduce race conditions)
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL: "http://127.0.0.1:3100",
     trace: "on-first-retry",
     actionTimeout: 20_000, // Added explicit action timeout
     navigationTimeout: 30_000, // Added explicit navigation timeout
+    bypassCSP: true,
   },
   webServer: {
-    command: "npm run dev",
-    url: "http://127.0.0.1:3000",
+    // Dedicated port + direct next invocation: `npm run dev` shells out to
+    // `cp`, which does not exist on Windows, and keeps the e2e server isolated
+    // from anything already bound to the default dev port.
+    command: "npx next dev -p 3100",
+    url: "http://127.0.0.1:3100",
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,
     env: {

--- a/frontend/tests/e2e/wallet-connection.spec.ts
+++ b/frontend/tests/e2e/wallet-connection.spec.ts
@@ -59,6 +59,18 @@ async function seedStableUiState(page: Page) {
 }
 
 /**
+ * Force the Next.js server to render in English.  Without this the
+ * Accept-Language header from headless Chromium on Linux CI can cause the
+ * server to render a non-English locale, producing a hydration-error overlay
+ * that blocks the entire page.
+ */
+async function ensureEnglishLocale(page: Page) {
+  await page.context().addCookies([
+    { name: "NEXT_LOCALE", value: "en", domain: "127.0.0.1", path: "/" },
+  ]);
+}
+
+/**
  * Intercept every backend/network call the flow touches.
  *
  * Layer 1: XHR patch — the axios client targets NEXT_PUBLIC_API_URL
@@ -143,7 +155,9 @@ test.describe("Wallet connection (Freighter)", () => {
     await mockFreighter(page);
     await seedStableUiState(page);
     await installApiMocks(page);
+    await ensureEnglishLocale(page);
     await page.goto("/");
+    await page.waitForLoadState("networkidle");
 
     const connectButton = page.getByRole("button", { name: "Connect Wallet" });
     await expect(connectButton).toBeVisible();
@@ -173,7 +187,9 @@ test.describe("Wallet connection (Freighter)", () => {
     // is exactly how a browser without the extension behaves.
     await seedStableUiState(page);
     await installApiMocks(page);
+    await ensureEnglishLocale(page);
     await page.goto("/");
+    await page.waitForLoadState("networkidle");
 
     // Home hero opens the WalletConnect card.
     await page.getByRole("button", { name: "Get Started Free" }).click();
@@ -192,7 +208,9 @@ test.describe("Wallet connection (Freighter)", () => {
     await mockFreighter(page);
     await seedStableUiState(page);
     await installApiMocks(page);
+    await ensureEnglishLocale(page);
     await page.goto("/");
+    await page.waitForLoadState("networkidle");
 
     await page.getByRole("button", { name: "Connect Wallet" }).click();
     await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();

--- a/frontend/tests/e2e/wallet-connection.spec.ts
+++ b/frontend/tests/e2e/wallet-connection.spec.ts
@@ -156,7 +156,7 @@ test.describe("Wallet connection (Freighter)", () => {
     // Disconnect action appears. The key renders twice (desktop + mobile
     // spans), so match the pill button instead of the raw text.
     await expect(
-      page.getByRole("button", { name: new RegExp(SHORTENED_KEY.replace(/\./g, "\\.")) })
+      page.getByRole("button", { name: SHORTENED_KEY }),
     ).toBeVisible();
     await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
     await expect(connectButton).not.toBeVisible();

--- a/frontend/tests/e2e/wallet-connection.spec.ts
+++ b/frontend/tests/e2e/wallet-connection.spec.ts
@@ -1,0 +1,206 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * E2E coverage for the Freighter wallet connection flow — the entry point for
+ * every authenticated action in the app.
+ *
+ * The Freighter browser extension isn't available in CI, so `window.freighter`
+ * is stubbed before any page script runs (page.addInitScript). The stub starts
+ * in the "not yet allowed" state so the app's auto-connect-on-mount is a no-op,
+ * which means the explicit "Connect Wallet" click is what actually signs the
+ * user in.
+ *
+ * Backend traffic uses the same dual-layer mock as the other suites:
+ *   Layer 1 — XHR patch intercepting axios before any HTTP traffic (avoids the
+ *             cross-origin wall between the Next.js origin and the API base URL).
+ *   Layer 2 — page.route() safety nets for external origins (Horizon, CoinGecko).
+ */
+
+const PUBLIC_KEY = "GCFXWALLETTESTADDRESS1234567890EXAMPLEABCDEF";
+// Navbar renders shortenAddress(publicKey): first 6 + "..." + last 6 chars.
+const SHORTENED_KEY = "GCFXWA...ABCDEF";
+
+/**
+ * Stub the Freighter extension injected script. Mirrors the real lifecycle:
+ * `isAllowed()` is false until `requestAccess()` is approved, exactly like a
+ * first-time connection in a real browser.
+ */
+async function mockFreighter(page: Page) {
+  await page.addInitScript(({ publicKey }) => {
+    const state = { allowed: false };
+    (window as any).freighter = {
+      isConnected: async () => ({ isConnected: true }),
+      isAllowed: async () => ({ isAllowed: state.allowed }),
+      requestAccess: async () => {
+        state.allowed = true;
+        return { error: null };
+      },
+      getPublicKey: async () => (state.allowed ? { publicKey } : { publicKey: "" }),
+      signTransaction: async () => ({ signedTransaction: "mock-signed-challenge-xdr" }),
+    };
+  }, { publicKey: PUBLIC_KEY });
+}
+
+/**
+ * Keep first-run UI (onboarding wizard, checklist) out of the way — this suite
+ * covers the wallet flow, not the tour.
+ */
+async function seedStableUiState(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "marketpay_onboarding_completed",
+      JSON.stringify({ hasSeenWelcome: true }),
+    );
+    localStorage.setItem(
+      "marketpay_onboarding_wizard",
+      JSON.stringify({ completed: true, dismissed: true }),
+    );
+  });
+}
+
+/**
+ * Intercept every backend/network call the flow touches.
+ *
+ * Layer 1: XHR patch — the axios client targets NEXT_PUBLIC_API_URL
+ * (http://localhost:4000), a different origin from the app, so real requests
+ * would need CORS/preflight handling. Patching XHR answers axios in-page with
+ * the exact response shapes lib/api expects. The async setTimeout keeps the
+ * responses genuinely asynchronous like the network would be.
+ */
+async function installApiMocks(page: Page) {
+  await page.addInitScript(() => {
+    const origOpen = XMLHttpRequest.prototype.open;
+    const origSend = XMLHttpRequest.prototype.send;
+
+    XMLHttpRequest.prototype.open = function (method, url) {
+      (this as any).__url = typeof url === "string" ? url : (url as any).href;
+      (this as any).__method = method;
+      return origOpen.apply(this, arguments as any);
+    };
+
+    XMLHttpRequest.prototype.send = function () {
+      const url = (this as any).__url || "";
+      const method = (this as any).__method || "GET";
+      const xhr = this;
+
+      if (url.includes("/api/")) {
+        const pathname = new URL(url, window.location.origin).pathname;
+        let responseData: unknown = { success: true, data: [] };
+        let status = 200;
+
+        // Order matters: csrf-token lives under /api/auth/*.
+        if (pathname === "/api/auth/csrf-token") {
+          responseData = { csrfToken: "test-csrf-token" };
+        } else if (pathname === "/api/auth") {
+          // SEP-0010 pair: challenge on GET, JWT verification on POST.
+          if (method === "POST") responseData = { success: true, token: "jwt-token" };
+          else responseData = { transaction: "challenge-xdr" };
+        } else if (pathname.startsWith("/api/profiles/")) {
+          const pk = pathname.split("/").pop();
+          responseData = { success: true, data: { publicKey: pk, role: "both" } };
+        }
+
+        setTimeout(() => {
+          Object.defineProperty(xhr, "readyState", { value: 4, configurable: true });
+          Object.defineProperty(xhr, "status", { value: status, configurable: true });
+          Object.defineProperty(xhr, "responseText", { value: JSON.stringify(responseData), configurable: true });
+          xhr.dispatchEvent(new Event("readystatechange"));
+          xhr.dispatchEvent(new Event("load"));
+          xhr.dispatchEvent(new Event("loadend"));
+        }, 10);
+        return;
+      }
+
+      return origSend.apply(this, arguments as any);
+    };
+  });
+
+  // Layer 2 safety nets for external origins. CORS headers are included so
+  // the page can actually read the mocked responses.
+
+  // Keep the navbar's balance lookups offline-deterministic (it falls back to
+  // 0.00 XLM / USDC when Horizon doesn't know the account).
+  await page.route("https://horizon-testnet.stellar.org/**", (route) =>
+    route.fulfill({
+      status: 404,
+      headers: { "Access-Control-Allow-Origin": "*" },
+      contentType: "application/json",
+      body: "{}",
+    }),
+  );
+  await page.route("https://api.coingecko.com/**", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "Access-Control-Allow-Origin": "*" },
+      contentType: "application/json",
+      body: JSON.stringify({ stellar: { usd: 0.12 } }),
+    }),
+  );
+}
+
+test.describe("Wallet connection (Freighter)", () => {
+  test('clicking "Connect Wallet" approves the mocked Freighter and signs the user in', async ({ page }) => {
+    await mockFreighter(page);
+    await seedStableUiState(page);
+    await installApiMocks(page);
+    await page.goto("/");
+
+    const connectButton = page.getByRole("button", { name: "Connect Wallet" });
+    await expect(connectButton).toBeVisible();
+
+    // Approve happens inside the stubbed extension — the click must drive the
+    // full chain: requestAccess → getPublicKey → SEP-0010 challenge/sign/verify.
+    await connectButton.click();
+
+    // Authenticated navbar: address pill replaces the Connect button and a
+    // Disconnect action appears. The key renders twice (desktop + mobile
+    // spans), so match the pill button instead of the raw text.
+    await expect(
+      page.getByRole("button", { name: new RegExp(SHORTENED_KEY.replace(/\./g, "\\.")) })
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
+    await expect(connectButton).not.toBeVisible();
+
+    // Session persisted so a reload restores authenticated state.
+    const storedKey = await page.evaluate(() =>
+      localStorage.getItem("smp_wallet_public_key"),
+    );
+    expect(storedKey).toBe(PUBLIC_KEY);
+  });
+
+  test("with Freighter unavailable the UI shows the Install Freighter guidance", async ({ page }) => {
+    // Deliberately NO mockFreighter — window.freighter stays undefined, which
+    // is exactly how a browser without the extension behaves.
+    await seedStableUiState(page);
+    await installApiMocks(page);
+    await page.goto("/");
+
+    // Home hero opens the WalletConnect card.
+    await page.getByRole("button", { name: "Get Started Free" }).click();
+    await expect(page.getByRole("heading", { name: "Connect Wallet" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Install Freighter/i })).toBeVisible();
+
+    // Attempting to connect without the extension sends the user to
+    // freighter.app to install it.
+    const popupPromise = page.waitForEvent("popup", { timeout: 15_000 });
+    await page.getByRole("button", { name: "Connect Freighter Wallet" }).click();
+    const popup = await popupPromise;
+    expect(popup.url()).toContain("freighter.app");
+  });
+
+  test("disconnecting the wallet returns the UI to the unauthenticated state", async ({ page }) => {
+    await mockFreighter(page);
+    await seedStableUiState(page);
+    await installApiMocks(page);
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Connect Wallet" }).click();
+    await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Disconnect" }).click();
+
+    await expect(page.getByRole("button", { name: "Connect Wallet" })).toBeVisible();
+    await expect(page.getByText(SHORTENED_KEY)).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Disconnect" })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION

## Summary
Adds Playwright e2e coverage for the Freighter wallet connection flow — the entry point for every authenticated action. The browser extension is stubbed via `page.addInitScript`, covering all three acceptance paths:

- **Connect**: clicking "Connect Wallet" drives the full chain (`requestAccess` → `getPublicKey` → SEP-0010 challenge/sign/verify) and lands in the authenticated navbar state
- **Wallet unavailable**: UI points the user to freighter.app to install it
- **Disconnect**: UI returns to the unauthenticated state

While writing the disconnect test, a real app bug surfaced and is fixed here: the Navbar used an inline `setPublicKey(null)` that left `smp_wallet_public_key` in localStorage, so the storage-rehydration effect instantly restored the session and Disconnect appeared dead. It's now wired to the existing `handleWalletDisconnect`.

Test-infra adjustments (no app behavior change): dedicated e2e port + Windows-safe webServer command in `playwright.config.ts`, and `bypassCSP: true` so injected mocks can run under the nonce-based CSP served by middleware. CI gets an `e2e-wallet` job running the spec against Chromium.

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #797

## Testing
- [ ] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [x] Docs updated if needed

*(Verified: `tsc --noEmit` clean, lint clean, `npx playwright test wallet-connection` 3/3 passing locally against the dev server; CI runs the same suite.)*


## Screenshots (if UI change)
Nil