### PR TITLE
feat(frontend): replace browser alert() with toast notifications

### DIFF
--- a/frontend/components/Toast.tsx
+++ b/frontend/components/Toast.tsx
@@ -14,9 +14,12 @@ interface Toast {
   id: string;
   message: string;
   variant: ToastVariant;
-  /** true once the 3 s timer fires — triggers the slide-out CSS class */
+  /** true once the auto-dismiss timer fires — triggers the slide-out CSS class */
   dismissing: boolean;
 }
+
+/** Toasts auto-dismiss after this long; error toasts are exempt and stay until dismissed. */
+const AUTO_DISMISS_MS = 4000;
 
 interface ToastContextValue {
   success: (message: string) => void;
@@ -60,8 +63,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
       const id = `${Date.now()}-${Math.random()}`;
       setToasts((prev) => [...prev, { id, message, variant, dismissing: false }]);
 
-      // Auto-dismiss after 3 seconds
-      setTimeout(() => dismiss(id), 3000);
+      // Error toasts stay until the user dismisses them; others auto-dismiss.
+      if (variant !== "error") {
+        setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
+      }
     },
     [dismiss]
   );
@@ -72,6 +77,15 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     info: (msg) => add(msg, "info"),
   };
 
+  // Expose an imperative API for code that runs outside the provider's own
+  // descendant tree (e.g. the root App component that renders <ToastProvider>).
+  useEffect(() => {
+    imperativeToast = value;
+    return () => {
+      imperativeToast = null;
+    };
+  });
+
   return (
     <ToastContext.Provider value={value}>
       {children}
@@ -79,6 +93,19 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     </ToastContext.Provider>
   );
 }
+
+// ─── Imperative API ───────────────────────────────────────────────────────────
+// For use outside the React tree rendered under <ToastProvider> (e.g. handlers
+// defined in the component that instantiates the provider itself). Prefer the
+// useToast() hook when calling from a descendant component.
+
+let imperativeToast: ToastContextValue | null = null;
+
+export const toast: ToastContextValue = {
+  success: (msg) => imperativeToast?.success(msg),
+  error: (msg) => imperativeToast?.error(msg),
+  info: (msg) => imperativeToast?.info(msg),
+};
 
 // ─── Visual config per variant ────────────────────────────────────────────────
 

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -22,7 +22,7 @@ import {
   logout,
   registerReferral,
 } from "@/lib/api";
-import { useToast } from "@/components/Toast";
+import { toast } from "@/components/Toast";
 import WalletAccountMonitor from "@/components/WalletAccountMonitor";
 import PWAInstall from "@/components/PWAInstall";
 import "@/styles/globals.css";
@@ -350,10 +350,10 @@ function App({ Component, pageProps }: AppProps) {
         persistPublicKey(pk);
         await maybeRegisterReferral(pk);
       } else {
-        alert("Wallet connected, but authentication failed.");
+        toast.error("Wallet connected, but authentication failed.");
       }
     } else if (error) {
-      alert(error);
+      toast.error(error);
     }
   };
 

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -25,6 +25,7 @@ import {
 import { shortenAddress, timeAgo } from "@/utils/format";
 import dynamic from "next/dynamic";
 import Admin2FAModal from "@/components/Admin2FAModal";
+import { useToast } from "@/components/Toast";
 
 // Dynamic import for heavy AdminAnalytics component
 const AdminAnalytics = dynamic(() => import("@/components/AdminAnalytics"), {
@@ -112,6 +113,7 @@ function formatAuditTarget(target?: string | null) {
 
 export default function AdminDashboard({ publicKey }: AdminPageProps) {
   const router = useRouter();
+  const toast = useToast();
   const [activeTab, setActiveTab] = useState<ActiveTab>("analytics");
   const [disputes, setDisputes] = useState<any[]>([]);
   const [reports, setReports] = useState<any[]>([]);
@@ -627,7 +629,7 @@ export default function AdminDashboard({ publicKey }: AdminPageProps) {
                   <button
                     onClick={async () => {
                       await generateCostReport();
-                      alert("Cost report generation triggered. Check audit log.");
+                      toast.success("Cost report generation triggered. Check audit log.");
                     }}
                     className="btn-ghost text-sm py-2 px-5"
                   >

--- a/frontend/pages/assessments/create.tsx
+++ b/frontend/pages/assessments/create.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { api } from "@/lib/api/client";
 import { getApiErrorMessage } from "@/lib/api/client";
+import { useToast } from "@/components/Toast";
 
 type QuestionType = "multiple_choice" | "short_answer";
 
@@ -26,6 +27,7 @@ const emptyQuestion = (): Question => ({
 
 export default function CreateAssessment({ publicKey }: CreateAssessmentProps) {
   const router = useRouter();
+  const toast = useToast();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [timeLimitMinutes, setTimeLimitMinutes] = useState(15);
@@ -73,7 +75,7 @@ export default function CreateAssessment({ publicKey }: CreateAssessmentProps) {
       });
 
       if (response.data.success) {
-        alert('Assessment created successfully!');
+        toast.success('Assessment created successfully!');
         router.push(`/assessments/project/${response.data.data.id}/results`);
       } else {
         setError('Failed to create assessment.');

--- a/frontend/pages/assessments/project/[id].tsx
+++ b/frontend/pages/assessments/project/[id].tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { api, getApiErrorMessage } from "@/lib/api/client";
+import { useToast } from "@/components/Toast";
 
 interface AssessmentQuestion {
   question: string;
@@ -27,6 +28,7 @@ interface TakeAssessmentProps {
 
 export default function TakeAssessment({ publicKey }: TakeAssessmentProps) {
   const router = useRouter();
+  const toast = useToast();
   const { id } = router.query;
 
   const [assessment, setAssessment] = useState<ProjectAssessment | null>(null);
@@ -100,7 +102,7 @@ export default function TakeAssessment({ publicKey }: TakeAssessmentProps) {
         answers
       });
       if (response.data.success) {
-        alert('Assessment submitted successfully!');
+        toast.success('Assessment submitted successfully!');
         router.push('/dashboard');
       }
     } catch (err) {

--- a/frontend/pages/assessments/project/[id]/results.tsx
+++ b/frontend/pages/assessments/project/[id]/results.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { api, getApiErrorMessage } from "@/lib/api/client";
+import { useToast } from "@/components/Toast";
 
 interface AssessmentResult {
   id: string;
@@ -19,6 +20,7 @@ interface AssessmentResultsProps {
 
 export default function AssessmentResults({ publicKey }: AssessmentResultsProps) {
   const router = useRouter();
+  const toast = useToast();
   const { id } = router.query;
 
   const [results, setResults] = useState<AssessmentResult[]>([]);
@@ -61,7 +63,7 @@ export default function AssessmentResults({ publicKey }: AssessmentResultsProps)
               // Copy link to clipboard
               const link = `${window.location.origin}/assessments/project/${id}`;
               navigator.clipboard.writeText(link);
-              alert('Assessment link copied to clipboard! Send this to freelancers.');
+              toast.success('Assessment link copied to clipboard! Send this to freelancers.');
             }}
             className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
           >

--- a/frontend/pages/freelancers/[publicKey].tsx
+++ b/frontend/pages/freelancers/[publicKey].tsx
@@ -24,6 +24,7 @@ import {
   type EarningPayment,
 } from "@/lib/api";
 import StateMessage from "@/components/StateMessage";
+import { useToast } from "@/components/Toast";
 import {
   availabilityStatusLabel,
   availabilitySummary,
@@ -77,6 +78,7 @@ export default function PublicFreelancerProfilePage({
   publicKey: string | null;
 }) {
   const router = useRouter();
+  const toast = useToast();
   const rawKey =
     typeof router.query.publicKey === "string" ? router.query.publicKey : "";
 
@@ -120,7 +122,7 @@ export default function PublicFreelancerProfilePage({
       setEndorsements(refreshed);
     } catch (error: unknown) {
       console.error("Endorsement error:", error);
-      alert(error instanceof Error ? error.message : "Failed to endorse skill");
+      toast.error(error instanceof Error ? error.message : "Failed to endorse skill");
     } finally {
       setEndorsingSkill(null);
     }


### PR DESCRIPTION
closes #760
Routes all remaining alert() calls through the existing Toast system instead of native browser dialogs. Bumps auto-dismiss to 4s and makes error toasts persist until manually dismissed. Adds an imperative toast API for the one call site (_app.tsx) that instantiates ToastProvider itself and can't use the useToast() hook.

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed


