### PR TITLE
test: add route tests for src/routes/transactions.js

### DIFF
--- a/backend/src/routes/transactions.test.js
+++ b/backend/src/routes/transactions.test.js
@@ -1,0 +1,297 @@
+"use strict";
+
+/**
+ * src/routes/transactions.test.js
+ *
+ * Route-level test suite for /api/transactions endpoints.
+ * Covers, per the shared route-testing scope:
+ *   - Happy path with a valid payload (CSV export streamed end-to-end)
+ *   - Authentication / authorisation rejection (verifyJWT guard plus the
+ *     own-account-only rule on GET /export)
+ *   - Validation failure (400) for malformed query payloads
+ *   - Not-found paths (unknown sub-route; Horizon account with no history)
+ *
+ * All GETs are non-mutating, so no CSRF token is required. The Horizon HTTP
+ * dependency is stubbed via global.fetch; the Postgres pool is replaced with
+ * the shared pgMock (required transitively by auth/rate-limiter middleware).
+ */
+
+// The export rate limiter is configured when the router module is first
+// required — scale it up so the suite never trips the 10 req/min ceiling.
+process.env.RATE_LIMIT_SCALE = process.env.RATE_LIMIT_SCALE || "1000";
+process.env.HORIZON_URL =
+  process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
+
+jest.mock("../db/pool", () => {
+  const { createPgMock } = require("../testUtils/pgMock");
+  return createPgMock();
+});
+
+const pool = require("../db/pool");
+const jwt = require("jsonwebtoken");
+const express = require("express");
+const request = require("supertest");
+const transactionsRoutes = require("./transactions");
+
+// Setup minimal Express test application
+const app = express();
+app.use("/api/transactions", transactionsRoutes);
+
+// Structured error handler
+app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+  const status = err.statusCode || err.status || 500;
+  res.status(status).json({
+    error: err.message,
+    code: err.code || "INTERNAL_ERROR",
+  });
+});
+
+// Valid 56-char G... addresses generated synthetically
+const USER_ADDRESS = "G" + "A".repeat(55);
+const OTHER_ADDRESS = "G" + "B".repeat(55);
+
+const CSV_HEADER =
+  "id,hash,ledger,created_at,from,to,amount,asset,memo,memo_type,successful,type\n";
+
+/**
+ * Mint a bearer token the same way src/routes/auth.js issues them.
+ */
+function bearerToken(publicKey) {
+  return jwt.sign({ publicKey }, process.env.JWT_SECRET, { expiresIn: "15m" });
+}
+
+/**
+ * Build a synthetic Horizon transaction record.
+ */
+function horizonRecord(overrides = {}) {
+  return {
+    id: overrides.id || "tx-1",
+    hash: overrides.hash || "hash-1",
+    ledger: overrides.ledger ?? 100,
+    created_at: overrides.created_at || "2026-01-01T00:00:00Z",
+    source_account: overrides.source_account || OTHER_ADDRESS,
+    memo: overrides.memo || "",
+    memo_type: overrides.memo_type || "none",
+    successful: overrides.successful ?? true,
+    _embedded: { operations: overrides.operations || [] },
+  };
+}
+
+function horizonResponse(records, links = {}) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ _embedded: { records }, _links: links }),
+  };
+}
+
+describe("Transactions Route Suite (/api/transactions)", () => {
+  const originalFetch = global.fetch;
+  // Restore any env overrides so they never leak into suites sharing this
+  // worker (rate-limit-sensitive suites read these lazily).
+  const originalRateLimitScale = process.env.RATE_LIMIT_SCALE;
+  const originalHorizonUrl = process.env.HORIZON_URL;
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    if (originalRateLimitScale === undefined) {
+      delete process.env.RATE_LIMIT_SCALE;
+    } else {
+      process.env.RATE_LIMIT_SCALE = originalRateLimitScale;
+    }
+    if (originalHorizonUrl === undefined) {
+      delete process.env.HORIZON_URL;
+    } else {
+      process.env.HORIZON_URL = originalHorizonUrl;
+    }
+  });
+
+  beforeEach(() => {
+    pool.reset();
+    jest.clearAllMocks();
+  });
+
+  // =========================================================================
+  // GET /api/transactions/export — happy path
+  // =========================================================================
+  describe("GET /api/transactions/export — happy path", () => {
+    const sentTx = horizonRecord({
+      id: "tx-sent-1",
+      hash: "hash-sent",
+      ledger: 100,
+      created_at: "2026-01-01T00:00:00Z",
+      operations: [
+        {
+          from: USER_ADDRESS,
+          to: OTHER_ADDRESS,
+          amount: "25.0000000",
+          asset_type: "native",
+        },
+      ],
+    });
+    const receivedTx = horizonRecord({
+      id: "tx-received-1",
+      hash: "hash-received",
+      ledger: 101,
+      created_at: "2026-01-02T00:00:00Z",
+      operations: [
+        {
+          from: OTHER_ADDRESS,
+          to: USER_ADDRESS,
+          amount: "10.0000000",
+          asset_type: "native",
+        },
+      ],
+    });
+
+    const SENT_ROW =
+      `"tx-sent-1","hash-sent","100","2026-01-01T00:00:00Z","${USER_ADDRESS}","${OTHER_ADDRESS}",` +
+      `"25.0000000","XLM","","none","true","sent"\n`;
+    const RECEIVED_ROW =
+      `"tx-received-1","hash-received","101","2026-01-02T00:00:00Z","${OTHER_ADDRESS}","${USER_ADDRESS}",` +
+      `"10.0000000","XLM","","none","true","received"\n`;
+
+    it("200 — streams the transaction history as a downloadable CSV", async () => {
+      global.fetch = jest.fn().mockResolvedValue(horizonResponse([sentTx, receivedTx]));
+
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "csv", account: USER_ADDRESS })
+        .set("Authorization", `Bearer ${bearerToken(USER_ADDRESS)}`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/csv");
+      expect(res.headers["cache-control"]).toBe("no-store");
+      expect(res.headers["content-disposition"]).toMatch(
+        /^attachment; filename="transactions-GAAAAAAA-\d{4}-\d{2}-\d{2}\.csv"$/
+      );
+      expect(res.text.startsWith(CSV_HEADER)).toBe(true);
+      expect(res.text).toContain(SENT_ROW);
+      expect(res.text).toContain(RECEIVED_ROW);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch.mock.calls[0][0]).toContain(
+        `/accounts/${encodeURIComponent(USER_ADDRESS)}/transactions`
+      );
+    });
+
+    it("200 — applies the filter query parameter to the exported rows", async () => {
+      global.fetch = jest.fn().mockResolvedValue(horizonResponse([sentTx, receivedTx]));
+
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "csv", account: USER_ADDRESS, filter: "sent" })
+        .set("Authorization", `Bearer ${bearerToken(USER_ADDRESS)}`);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(CSV_HEADER + SENT_ROW);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/transactions/export — authentication / authorisation
+  // =========================================================================
+  describe("GET /api/transactions/export — authentication / authorisation", () => {
+    it("401 — rejects the request when no JWT is presented", async () => {
+      global.fetch = jest.fn();
+
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "csv", account: USER_ADDRESS });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized: Missing or invalid token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("401 — rejects the request when the JWT is invalid", async () => {
+      global.fetch = jest.fn();
+
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "csv", account: USER_ADDRESS })
+        .set("Authorization", "Bearer not-a-real-jwt.token.value");
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized: Invalid or expired token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("403 — rejects exporting another user's transactions", async () => {
+      global.fetch = jest.fn();
+
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "csv", account: USER_ADDRESS })
+        .set("Authorization", `Bearer ${bearerToken(OTHER_ADDRESS)}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe(
+        "Forbidden: you may only export your own transactions"
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // GET /api/transactions/export — validation failures
+  // =========================================================================
+  describe("GET /api/transactions/export — validation failures", () => {
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    it("400 — rejects unsupported export formats", async () => {
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "json", account: USER_ADDRESS })
+        .set("Authorization", `Bearer ${bearerToken(USER_ADDRESS)}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Unsupported format. Use format=csv");
+    });
+
+    it("400 — rejects a missing account parameter", async () => {
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "csv" })
+        .set("Authorization", `Bearer ${bearerToken(USER_ADDRESS)}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Valid Stellar account address required");
+    });
+
+    it("400 — rejects a malformed Stellar account address", async () => {
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "csv", account: "not-a-stellar-address" })
+        .set("Authorization", `Bearer ${bearerToken(USER_ADDRESS)}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Valid Stellar account address required");
+    });
+  });
+
+  // =========================================================================
+  // Not-found paths
+  // =========================================================================
+  describe("Not-found paths", () => {
+    it("404 — unknown sub-route under /api/transactions", async () => {
+      const res = await request(app).get("/api/transactions/does-not-exist");
+
+      expect(res.status).toBe(404);
+    });
+
+    it("200 — Horizon 404 (account has no history) yields a header-only CSV", async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+
+      const res = await request(app)
+        .get("/api/transactions/export")
+        .query({ format: "csv", account: USER_ADDRESS })
+        .set("Authorization", `Bearer ${bearerToken(USER_ADDRESS)}`);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(CSV_HEADER);
+    });
+  });
+});


### PR DESCRIPTION
## Closes #1158

Adds `backend/src/routes/transactions.test.js` — a route-level test suite for the transaction-history export endpoint, which previously had **no test file**. This follows the same conventions as the existing route suites (`escrow.test.js`, `developer.test.js`, `dao.test.js`) and covers every category required by the issue.

---

## The route under test

`src/routes/transactions.js` exposes a single endpoint:

> `GET /api/transactions/export?format=csv&account=G...&filter=all|sent|received|escrow`

It streams an account's transaction history from Horizon straight to the client as a CSV download using Node's `stream.pipeline` (no full buffering), walking every Horizon page via the `next` link, encoding each record as a CSV row on the fly, and applying the requested filter mid-stream. It is guarded by `verifyJWT` and enforces that users may only export **their own** transactions.

Because there is exactly one endpoint and it takes no `:id` path parameter, this suite maps the issue's four coverage categories onto that reality as follows (details per test below):

| Issue scope | How it applies here |
|---|---|
| Happy path with valid payload | Full end-to-end streamed-CSV assertions (status, headers, header row, encoded data rows, Horizon URL) + a filtered-export variant |
| Authentication / authorisation rejection | Missing token → `401`; invalid JWT → `401`; valid JWT for someone else's account → `403` |
| Validation failure (400) | Unsupported `format`, missing `account`, malformed Stellar address |
| Not-found path where the route takes an id | No id exists on this route, so the closest real paths are covered: unknown sub-route → Express `404`, and Horizon returning `404` → documented "no history" behavior of a header-only CSV |

---

## Test inventory (10 tests)

### Happy path
1. **`200 — streams the transaction history as a downloadable CSV`** — mocks a Horizon page containing one *sent* and one *received* payment, then asserts:
   - status `200`
   - `Content-Type: text/csv`, `Cache-Control: no-store`
   - `Content-Disposition: attachment` with the expected `transactions-GAAAAAAA-YYYY-MM-DD.csv` filename pattern
   - response body starts with the exact CSV header line
   - both records appear as **byte-exact** CSV rows (verifying quoting, type resolution via embedded operations, native asset → `XLM`, boolean serialization of `successful`)
   - Horizon was fetched **exactly once**, at `/accounts/<address>/transactions`
2. **`200 — applies the filter query parameter`** — same page with `filter=sent` yields precisely `header + sent row` (the received record is dropped by the transform).

### Authentication / authorisation
3. **`401 — rejects the request when no JWT is presented`** — also asserts `fetch` is never called (proves the guard runs before any Horizon work).
4. **`401 — rejects the request when the JWT is invalid`** — garbage bearer token.
5. **`403 — rejects exporting another user's transactions`** — valid JWT whose `publicKey` differs from the queried `account`.

### Validation failures
6. **`400 — rejects unsupported export formats`** (`format=json`)
7. **`400 — rejects a missing account parameter`**
8. **`400 — rejects a malformed Stellar account address`**

Each asserts the specific error message returned by the handler.

### Not-found paths
9. **`404 — unknown sub-route under /api/transactions`**
10. **`200 — Horizon 404 (account has no history) yields a header-only CSV`** — documents the intentional behavior in the route where a Horizon `404` means "no transactions" and the stream completes with just the CSV header.

---

## Test-infrastructure decisions

1. **Pool mocked with the shared `src/testUtils/pgMock.js` factory**, exactly as the issue notes and as existing service/route tests do (`jest.mock("../db/pool")`). The route itself never touches Postgres, but `../middleware/auth` and `../middleware/rateLimiter` require the pool module transitively, so mocking keeps the whole graph hermetic.
2. **Real `verifyJWT` instead of stubbing auth middleware.** Tokens are minted with `jsonwebtoken` against `process.env.JWT_SECRET` (provided by `backend/jest.setup.js`), so the actual JWT verification path — including its two distinct `401` error messages — is exercised end-to-end rather than assumed.
3. **Horizon is stubbed via `global.fetch`** using the repo's established save/restore pattern (`originalFetch` captured, restored in `afterAll`). Responses mimic Horizon's `{ ok, status, json() }` shape; no network access occurs.
4. **Rate limiter handled explicitly.** The export limiter allows 10 requests/min per IP, which a suite of HTTP calls can legitimately trip. Rather than weakening assertions, the suite sets the repo-supported `RATE_LIMIT_SCALE` env knob *before* the router is first required (the limiter bakes its scaled ceiling at creation time) — and restores the previous value (or deletes it) in `afterAll`. This restoration matters: jest workers are reused across test files, and leaking the override would break rate-limit-sensitive suites elsewhere (`rateLimiter.test.js`, `publicJobBoard.test.js`). Verified: `publicJobBoard.test.js`'s real-429 test still passes when run in the same invocation.
5. **No CSRF token needed** — every request here is a `GET`. The CSRF requirement noted in #1158 (and addressed by the shared-helper work in `193a369`) applies to mutating requests only.
6. **"Not-found path" interpretation.** The issue's fourth bullet presumes routes that take an id; this route has none. Rather than invent an artificial endpoint, the suite covers the two genuinely reachable not-found behaviors: unmatched sub-route → `404`, and upstream Horizon `404` → empty export. If maintainers prefer different semantics here, happy to adjust.

---

## Verification

```
cd backend
npx jest src/routes/transactions.test.js     # 10 passed (10 total)
npx eslint src/routes/transactions.test.js   # clean
```

- Suite passes after rebasing onto current `main` (`193a369`) — re-ran the full suite post-rebase.
- Ran together with `src/middleware/rateLimiter.test.js` and `src/routes/publicJobBoard.test.js` to confirm no env leakage from the `RATE_LIMIT_SCALE` handling: both behave identically with and without this change.

### Pre-existing failures on `main` (unrelated to this PR)

For transparency — these fail identically **without** this change (verified by running those suites in isolation, excluding the new file):

| Suite | Failure |
|---|---|
| `routes/auth.test.js`, `routes/contributors.test.js`, `routes/aiScorer.test.js`, `routes/jobs.boost.test.js` | 4 suites / 11 tests failing on `main` before this PR |
| `middleware/rateLimiter.test.js` | One stale assertion expects `blocked.body.message`, but the limiter handler responds with `{ error }` |

This PR does not touch any of that code and adds exactly **one new file (+297 lines)** — no production code is modified.

---

## Checklist

- [x] Happy path covered with a valid payload (including streamed headers and byte-exact rows)
- [x] Authentication rejection (401 ×2) and authorisation rejection (403) covered
- [x] Validation failure (400) covered for malformed query payloads
- [x] Not-found paths covered to the extent they exist on this route
- [x] Pool mocked via `src/testUtils/pgMock.js`
- [x] Lint clean; suite green locally and after rebase onto latest `main`
