### PR TITLE
test: fix failing suite src/services/jobService.test.js

### DIFF
--- a/backend/src/services/applicationService.js
+++ b/backend/src/services/applicationService.js
@@ -6,12 +6,17 @@
 "use strict";
 
 const crypto = require("crypto");
-const { readPool, writePool } = require("../db/pool");
+const poolModule = require("../db/pool");
+const pool = poolModule.writePool || poolModule;
+const readPool = poolModule.readPool || poolModule;
 const { findApplicationsByJob } = require("../db/queries/applications");
-const pool = writePool; // default to write; SELECTs below use readPool
 const { getJob, assignFreelancer } = require("./jobService");
 const { calculateFreelancerTier, isBlocked } = require("./profileService");
-const { createJobNotification, queueNotification, EVENT_TYPES } = require("./notificationService");
+const {
+  createJobNotification,
+  queueNotification,
+  EVENT_TYPES,
+} = require("./notificationService");
 
 /**
  * Camel-cased application record returned by this service.
@@ -265,8 +270,8 @@ async function submitApplication({
     payload: {
       jobTitle: job.title,
       clientName: job.clientAddress,
-      freelancerName: freelancerAddress
-    }
+      freelancerName: freelancerAddress,
+    },
   });
 
   return rowToApp(appRow);
@@ -305,20 +310,32 @@ function hashBidReveal(bidAmount, nonce) {
     .digest("hex");
 }
 
-async function revealApplicationBid(applicationId, freelancerAddress, bidAmount, nonce) {
+async function revealApplicationBid(
+  applicationId,
+  freelancerAddress,
+  bidAmount,
+  nonce,
+) {
   validatePublicKey(freelancerAddress);
   if (!nonce || typeof nonce !== "string") {
     const e = new Error("Reveal nonce is required");
     e.status = 400;
     throw e;
   }
-  if (!bidAmount || isNaN(parseFloat(bidAmount)) || parseFloat(bidAmount) <= 0) {
+  if (
+    !bidAmount ||
+    isNaN(parseFloat(bidAmount)) ||
+    parseFloat(bidAmount) <= 0
+  ) {
     const e = new Error("Reveal bid amount must be positive");
     e.status = 400;
     throw e;
   }
 
-  const { rows } = await pool.query("SELECT * FROM applications WHERE id = $1", [applicationId]);
+  const { rows } = await pool.query(
+    "SELECT * FROM applications WHERE id = $1",
+    [applicationId],
+  );
   if (!rows.length) {
     const e = new Error("Application not found");
     e.status = 404;
@@ -347,7 +364,8 @@ async function revealApplicationBid(applicationId, freelancerAddress, bidAmount,
     e.status = 400;
     throw e;
   }
-  const revealDeadline = new Date(job.biddingClosedAt).getTime() + 24 * 60 * 60 * 1000;
+  const revealDeadline =
+    new Date(job.biddingClosedAt).getTime() + 24 * 60 * 60 * 1000;
   if (Date.now() > revealDeadline) {
     const e = new Error("Reveal deadline has passed");
     e.status = 400;
@@ -383,7 +401,9 @@ async function getApplicationsForJob(jobId, filters = {}) {
   const rows = await findApplicationsByJob(readPool, { jobId });
   const applications = rows.map(rowToApp);
   if (!filters.tier) return applications;
-  return applications.filter((application) => application.freelancerTier === filters.tier);
+  return applications.filter(
+    (application) => application.freelancerTier === filters.tier,
+  );
 }
 
 /**
@@ -486,8 +506,8 @@ async function acceptApplication(applicationId, clientAddress) {
       jobId: app.job_id,
       payload: {
         jobTitle: job.title,
-        freelancerName: app.freelancer_address
-      }
+        freelancerName: app.freelancer_address,
+      },
     });
 
     for (const rejected of rejectedApplications) {

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -5,12 +5,10 @@
  */
 "use strict";
 
-const { readPool, writePool } = require("../db/pool");
-const {
-  findJobById,
-  listJobs: queryListJobs,
-} = require("../db/queries/jobs");
-const pool = writePool; // default alias — write-safe; read-only paths use readPool
+const poolModule = require("../db/pool");
+const pool = poolModule.writePool || poolModule;
+const readPool = poolModule.readPool || poolModule;
+const { findJobById, listJobs: queryListJobs } = require("../db/queries/jobs");
 const { refreshFreelancerTier } = require("./profileService");
 const { createJobNotification, EVENT_TYPES } = require("./notificationService");
 const { insertAuditLog } = require("./auditLogService");
@@ -196,7 +194,6 @@ function validatePublicKey(key) {
   }
 }
 
-
 /**
  * Convert a snake_case `jobs` row into the camelCase API object.
  *
@@ -227,7 +224,7 @@ function rowToJob(row) {
     timezone: row.timezone,
     screeningQuestions: row.screening_questions || [],
     milestones: normalizeMilestoneRows(row.milestones, row.budget),
-    disputeReason:      row.dispute_reason,
+    disputeReason: row.dispute_reason,
     disputeDescription: row.dispute_description,
     disputedBy: row.disputed_by,
     disputedAt: row.disputed_at,
@@ -275,7 +272,21 @@ function rowToJob(row) {
  *   clientAddress: 'GBX...',
  * });
  */
-let createJob = async function ({ title, description, budget, currency, category, categorySlug, skills, deadline, timezone, clientAddress, screeningQuestions, milestones, visibility = "public" }) {
+let createJob = async function ({
+  title,
+  description,
+  budget,
+  currency,
+  category,
+  categorySlug,
+  skills,
+  deadline,
+  timezone,
+  clientAddress,
+  screeningQuestions,
+  milestones,
+  visibility = "public",
+}) {
   validatePublicKey(clientAddress);
 
   if (!title || title.length < 10) {
@@ -307,7 +318,7 @@ let createJob = async function ({ title, description, budget, currency, category
   if (categoryLookupVal) {
     const { rows: catRows } = await pool.query(
       "SELECT id, name FROM categories WHERE slug = $1 OR LOWER(name) = LOWER($2) LIMIT 1",
-      [categoryLookupVal, categoryLookupVal]
+      [categoryLookupVal, categoryLookupVal],
     );
     if (catRows.length) {
       resolvedCategoryId = catRows[0].id;
@@ -329,7 +340,12 @@ let createJob = async function ({ title, description, budget, currency, category
     throw e;
   }
 
-  const safeSkills = Array.isArray(skills) ? skills.slice(0, 8).map(s => s.trim()).filter(Boolean) : [];
+  const safeSkills = Array.isArray(skills)
+    ? skills
+        .slice(0, 8)
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
   const safeScreeningQuestions = Array.isArray(screeningQuestions)
     ? screeningQuestions.slice(0, 5).filter((q) => q && q.trim().length > 0)
     : [];
@@ -365,7 +381,9 @@ let createJob = async function ({ title, description, budget, currency, category
 
     if (safeSkills.length > 0) {
       // Normalize and insert missing skills
-      const skillValues = safeSkills.map((s) => `(LOWER(TRIM($$${s}$$)), TRIM($$${s}$$))`).join(",");
+      const skillValues = safeSkills
+        .map((s) => `(LOWER(TRIM($$${s}$$)), TRIM($$${s}$$))`)
+        .join(",");
       await client.query(`
         INSERT INTO skills (slug, display_name)
         VALUES ${skillValues}
@@ -376,12 +394,14 @@ let createJob = async function ({ title, description, budget, currency, category
       const slugs = safeSkills.map((s) => s.toLowerCase().trim());
       const { rows: skillRows } = await client.query(
         "SELECT id FROM skills WHERE slug = ANY($1::text[])",
-        [slugs]
+        [slugs],
       );
 
       // Insert into job_skills
       if (skillRows.length > 0) {
-        const jobSkillValues = skillRows.map((r) => `('${job.id}', ${r.id})`).join(",");
+        const jobSkillValues = skillRows
+          .map((r) => `('${job.id}', ${r.id})`)
+          .join(",");
         await client.query(`
           INSERT INTO job_skills (job_id, skill_id)
           VALUES ${jobSkillValues}
@@ -401,9 +421,9 @@ let createJob = async function ({ title, description, budget, currency, category
   if (safeSkills.length > 0) {
     const { rows: updatedSkills } = await pool.query(
       "SELECT s.display_name FROM skills s JOIN job_skills js ON s.id = js.skill_id WHERE js.job_id = $1",
-      [job.id]
+      [job.id],
     );
-    job.skills = updatedSkills.map(s => s.display_name);
+    job.skills = updatedSkills.map((s) => s.display_name);
   } else {
     job.skills = [];
   }
@@ -424,7 +444,11 @@ let createJob = async function ({ title, description, budget, currency, category
       job.id,
     ]);
   } catch (err) {
-    console.error("[tfidf] Failed to compute vector for job", job.id, err.message);
+    console.error(
+      "[tfidf] Failed to compute vector for job",
+      job.id,
+      err.message,
+    );
   }
 
   return rowToJob(job);
@@ -544,7 +568,9 @@ async function listJobs({
         'StartSel=<mark>,StopSel=</mark>,MaxWords=50,MinWords=20') AS headline_title,
       ts_headline(description, websearch_to_tsquery('english', $${searchIdx}),
         'StartSel=<mark>,StopSel=</mark>,MaxWords=80,MinWords=30') AS headline_description`;
-    conditions.push(`search_vector @@ websearch_to_tsquery('english', $${searchIdx})`);
+    conditions.push(
+      `search_vector @@ websearch_to_tsquery('english', $${searchIdx})`,
+    );
     orderClause = `rank DESC, ${orderClause}`;
   }
 
@@ -567,7 +593,6 @@ async function listJobs({
       OR jobs.category = $${params.length}
     )`);
   }
-
 
   const minBudget = parseFloat(min_budget);
   if (!Number.isNaN(minBudget)) {
@@ -677,7 +702,7 @@ async function listJobs({
     nextCursor = encodeCursor(rows[rows.length - 1]);
   }
 
-  return { jobs, nextCursor };
+  return { jobs, nextCursor, hasMore: Boolean(nextCursor) };
 }
 
 /**
@@ -689,7 +714,10 @@ async function listJobs({
  * @returns {Promise<Object[]>} An array of job objects.
  * @throws {Error} If the clientAddress is an invalid Stellar public key.
  */
-async function listJobsByClient(clientAddress, { includeDeleted = false } = {}) {
+async function listJobsByClient(
+  clientAddress,
+  { includeDeleted = false } = {},
+) {
   validatePublicKey(clientAddress);
   const deletedFilter = includeDeleted ? "" : "AND deleted_at IS NULL";
   const { rows } = await pool.query(
@@ -793,7 +821,11 @@ let assignFreelancer = async function (jobId, freelancerAddress) {
  * @returns {Promise<Object>} The updated job object.
  * @throws {Error} If the escrowContractId is invalid or the job is not found.
  */
-let updateJobEscrowId = async function (jobId, escrowContractId, { amount } = {}) {
+let updateJobEscrowId = async function (
+  jobId,
+  escrowContractId,
+  { amount } = {},
+) {
   if (!escrowContractId || typeof escrowContractId !== "string") {
     const e = new Error("Invalid escrow contract ID");
     e.status = 400;
@@ -808,9 +840,8 @@ let updateJobEscrowId = async function (jobId, escrowContractId, { amount } = {}
   if (rows.length) {
     const job = rowToJob(rows[0]);
     // Use explicit amount when provided (e.g. accepted bid amount); fall back to job budget
-    const escrowAmount = amount !== undefined
-      ? parseFloat(amount).toFixed(7)
-      : job.budget;
+    const escrowAmount =
+      amount !== undefined ? parseFloat(amount).toFixed(7) : job.budget;
     await pool.query(
       `INSERT INTO escrows (job_id, contract_id, amount_xlm, milestones, status, created_at, updated_at)
        VALUES ($1, $2, $3, $4, 'funded', NOW(), NOW())
@@ -839,7 +870,7 @@ let updateJobEscrowId = async function (jobId, escrowContractId, { amount } = {}
 async function deleteJob(jobId) {
   const { rowCount } = await pool.query(
     "UPDATE jobs SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1 AND deleted_at IS NULL",
-    [jobId]
+    [jobId],
   );
   if (!rowCount) {
     const e = new Error("Job not found");
@@ -859,7 +890,7 @@ async function purgeDeletedJobs(days = 90) {
     `DELETE FROM jobs
      WHERE deleted_at IS NOT NULL
        AND deleted_at < NOW() - INTERVAL '1 day' * $1`,
-    [days]
+    [days],
   );
   return rowCount || 0;
 }
@@ -878,9 +909,10 @@ async function purgeDeletedJobs(days = 90) {
  */
 async function boostJob(jobId, txHash, boostDays = 7) {
   // Verify job exists
-  const { rows } = await pool.query(`${JOB_SELECT_CLAUSE} WHERE id = $1 AND deleted_at IS NULL`, [
-    jobId,
-  ]);
+  const { rows } = await pool.query(
+    `${JOB_SELECT_CLAUSE} WHERE id = $1 AND deleted_at IS NULL`,
+    [jobId],
+  );
   if (!rows.length) {
     const e = new Error("Job not found");
     e.status = 404;
@@ -958,7 +990,11 @@ async function raiseDispute(jobId, { reason, description, raisedBy }) {
       entityType: "job",
       entityId: jobId,
       oldValue: oldJob ? { status: oldJob.status, disputeReason: null } : null,
-      newValue: { status: job.status, disputeReason: reason, disputedBy: raisedBy },
+      newValue: {
+        status: job.status,
+        disputeReason: reason,
+        disputedBy: raisedBy,
+      },
     });
   } catch {
     // Non-fatal
@@ -1107,7 +1143,10 @@ async function extendJobExpiry(jobId, days = 30, clientAddress) {
     throw e;
   }
 
-  const { rows } = await pool.query(`${JOB_SELECT_CLAUSE} WHERE id = $1 AND deleted_at IS NULL`, [jobId]);
+  const { rows } = await pool.query(
+    `${JOB_SELECT_CLAUSE} WHERE id = $1 AND deleted_at IS NULL`,
+    [jobId],
+  );
   if (!rows.length) {
     const e = new Error("Job not found");
     e.status = 404;
@@ -1130,7 +1169,9 @@ async function extendJobExpiry(jobId, days = 30, clientAddress) {
   const alreadyExtendedDays = alreadyExtendedMs / (1000 * 60 * 60 * 24);
 
   if (alreadyExtendedDays + daysNum > 90) {
-    const e = new Error("Maximum total extension is 90 days from the original expiry");
+    const e = new Error(
+      "Maximum total extension is 90 days from the original expiry",
+    );
     e.status = 400;
     throw e;
   }
@@ -1151,7 +1192,7 @@ async function extendJobExpiry(jobId, days = 30, clientAddress) {
          updated_at = NOW()
      WHERE id = $2
      RETURNING *`,
-    [newExpiry.toISOString(), jobId]
+    [newExpiry.toISOString(), jobId],
   );
 
   const updatedJob = rowToJob(updateRows[0]);
@@ -1169,7 +1210,7 @@ async function incrementViewCount(jobId) {
   const { rows } = await pool.query(
     `UPDATE jobs SET view_count = COALESCE(view_count, 0) + 1, updated_at = NOW()
      WHERE id = $1 RETURNING view_count`,
-    [jobId]
+    [jobId],
   );
   if (!rows.length) {
     const e = new Error("Job not found");
@@ -1187,7 +1228,7 @@ async function incrementViewCount(jobId) {
 async function getJobAnalytics(jobId) {
   const { rows: jobRows } = await pool.query(
     `${JOB_SELECT_CLAUSE} WHERE id = $1 AND deleted_at IS NULL`,
-    [jobId]
+    [jobId],
   );
   if (!jobRows.length) {
     const e = new Error("Job not found");
@@ -1203,14 +1244,14 @@ async function getJobAnalytics(jobId) {
        MIN(bid_amount) AS min_bid,
        MAX(bid_amount) AS max_bid
      FROM applications WHERE job_id = $1`,
-    [jobId]
+    [jobId],
   );
 
   const { rows: viewRows } = await pool.query(
     `SELECT COUNT(*)::int AS total_views,
             COUNT(DISTINCT ip_hash)::int AS unique_views
      FROM job_views WHERE job_id = $1`,
-    [jobId]
+    [jobId],
   );
 
   return {
@@ -1236,7 +1277,7 @@ async function expireOldJobs() {
      WHERE status = 'open'
        AND deleted_at IS NULL
        AND expires_at IS NOT NULL
-       AND expires_at < NOW()`
+       AND expires_at < NOW()`,
   );
   return rowCount || 0;
 }
@@ -1255,7 +1296,7 @@ async function getExpiringJobs(daysFromNow = 3) {
        AND expires_at > NOW()
        AND expires_at <= NOW() + INTERVAL '1 day' * $1
      ORDER BY expires_at ASC`,
-    [daysFromNow]
+    [daysFromNow],
   );
   return rows.map(rowToJob);
 }
@@ -1274,7 +1315,7 @@ async function bulkCancelJobs(jobIds, clientAddress) {
         `UPDATE jobs SET status = 'cancelled', updated_at = NOW()
          WHERE id = $1 AND client_address = $2 AND status = 'open' AND deleted_at IS NULL
          RETURNING id`,
-        [id, clientAddress]
+        [id, clientAddress],
       );
       results.push({ id, success: rows.length > 0 });
     } catch {
@@ -1333,14 +1374,14 @@ async function bulkBoostJobs(jobIds, clientAddress, txHash) {
 async function getRecommendedJobs(publicKey) {
   const { rows: profileRows } = await pool.query(
     "SELECT skills FROM profiles WHERE public_key = $1",
-    [publicKey]
+    [publicKey],
   );
   const skills = profileRows.length ? profileRows[0].skills || [] : [];
 
   if (!skills.length) {
     // No skills, return recent open jobs excluding applied ones
     const { rows } = await pool.query(
-       `SELECT j.*, COALESCE((SELECT array_agg(s.display_name) FROM job_skills js JOIN skills s ON s.id = js.skill_id WHERE js.job_id = j.id), '{}') AS skills FROM jobs j
+      `SELECT j.*, COALESCE((SELECT array_agg(s.display_name) FROM job_skills js JOIN skills s ON s.id = js.skill_id WHERE js.job_id = j.id), '{}') AS skills FROM jobs j
         WHERE j.status = 'open'
           AND j.visibility = 'public'
           AND j.deleted_at IS NULL
@@ -1350,7 +1391,7 @@ async function getRecommendedJobs(publicKey) {
           )
         ORDER BY j.created_at DESC
         LIMIT 5`,
-      [publicKey]
+      [publicKey],
     );
     return rows.map(rowToJob);
   }
@@ -1363,7 +1404,7 @@ async function getRecommendedJobs(publicKey) {
        AND skills && $1
      ORDER BY created_at DESC
      LIMIT 5`,
-    [skills, publicKey]
+    [skills, publicKey],
   );
 
   return rows.map(rowToJob);
@@ -1384,19 +1425,19 @@ async function getSuggestions(query) {
            AND status = 'open'
            AND deleted_at IS NULL
          ORDER BY title LIMIT 5`,
-        [q]
+        [q],
       ),
       pool.query(
         `SELECT DISTINCT skill
          FROM (SELECT unnest(skills) AS skill FROM jobs WHERE status = 'open' AND deleted_at IS NULL) skills
          WHERE skill ILIKE $1
          ORDER BY skill LIMIT 3`,
-        [`%${q}%`]
+        [`%${q}%`],
       ),
     ]);
 
     const categoryMatches = VALID_CATEGORIES.filter((cat) =>
-      cat.toLowerCase().includes(q.toLowerCase())
+      cat.toLowerCase().includes(q.toLowerCase()),
     ).slice(0, 2);
 
     return {
@@ -1503,7 +1544,10 @@ assignFreelancer = async function (jobId, freelancerAddress) {
   try {
     await recordTimelineEvent(jobId, "bid_accepted");
   } catch (err) {
-    console.error("[timeline] Failed to record bid_accepted event:", err.message);
+    console.error(
+      "[timeline] Failed to record bid_accepted event:",
+      err.message,
+    );
   }
   return job;
 };
@@ -1516,7 +1560,10 @@ updateJobStatus = async function (id, status) {
     try {
       await recordTimelineEvent(id, "work_completed");
     } catch (err) {
-      console.error("[timeline] Failed to record work_completed event:", err.message);
+      console.error(
+        "[timeline] Failed to record work_completed event:",
+        err.message,
+      );
     }
   }
   return job;
@@ -1530,7 +1577,10 @@ updateJobEscrowId = async function (jobId, escrowContractId, options = {}) {
   try {
     await recordTimelineEvent(jobId, "escrow_funded", txHash);
   } catch (err) {
-    console.error("[timeline] Failed to record escrow_funded event:", err.message);
+    console.error(
+      "[timeline] Failed to record escrow_funded event:",
+      err.message,
+    );
   }
   return job;
 };

--- a/backend/src/testUtils/pgMock.js
+++ b/backend/src/testUtils/pgMock.js
@@ -11,6 +11,7 @@ function defaultJobRow(overrides = {}) {
     budget: overrides.budget || "500.0000000",
     currency: overrides.currency || "XLM",
     category: overrides.category || "Smart Contracts",
+    category_id: overrides.category_id ?? null,
     skills: overrides.skills || [],
     status: overrides.status || "open",
     client_address: overrides.client_address,
@@ -148,6 +149,19 @@ function findJobIdFromUpdate(text, params) {
   return null;
 }
 
+const DEFAULT_CATEGORIES = [
+  { id: 1, name: "Smart Contracts", slug: "smart-contracts" },
+  { id: 2, name: "Frontend Development", slug: "frontend-development" },
+  { id: 3, name: "Backend Development", slug: "backend-development" },
+  { id: 4, name: "UI/UX Design", slug: "ui-ux-design" },
+  { id: 5, name: "Technical Writing", slug: "technical-writing" },
+  { id: 6, name: "DevOps", slug: "devops" },
+  { id: 7, name: "Security Audit", slug: "security-audit" },
+  { id: 8, name: "Data Analysis", slug: "data-analysis" },
+  { id: 9, name: "Mobile Development", slug: "mobile-development" },
+  { id: 10, name: "Other", slug: "other" },
+];
+
 function createPgMock() {
   const jobs = new Map();
   const applications = new Map();
@@ -161,17 +175,41 @@ function createPgMock() {
   const apiKeys = new Map();
   const escrows = new Map();
   const onboardingProgress = new Map();
+  const timelineEvents = [];
+
+  function formatJobRow(row) {
+    const skillIds = jobSkillsMap.get(row.id) || new Set();
+    const skills = skillIds.size
+      ? [...skillsMap.values()]
+          .filter((s) => skillIds.has(s.id))
+          .map((s) => s.display_name)
+      : row.skills || [];
+    const cat = DEFAULT_CATEGORIES.find(
+      (c) => c.name === row.category || c.id === row.category_id,
+    );
+    return {
+      ...row,
+      skills,
+      category_slug: row.category_slug || cat?.slug || null,
+      category_name: row.category || cat?.name || null,
+      category_id_resolved: row.category_id || cat?.id || 1,
+    };
+  }
 
   const query = jest.fn(async (sql, params = []) => {
     const text = sql.replace(/\s+/g, " ").trim();
 
+    // ─── WebSocket Event Queue ───────────────────────────────────────────
     if (text.startsWith("INSERT INTO ws_event_queue")) {
       const id = wsEvents.size + 1;
       let createdAt = new Date().toISOString();
       if (text.includes("INTERVAL '8 days'")) {
-        createdAt = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+        createdAt = new Date(
+          Date.now() - 8 * 24 * 60 * 60 * 1000,
+        ).toISOString();
       }
-      const eventJson = typeof params[0] === "string" ? JSON.parse(params[0]) : params[0];
+      const eventJson =
+        typeof params[0] === "string" ? JSON.parse(params[0]) : params[0];
       const row = { id, event: eventJson, created_at: createdAt };
       wsEvents.set(id, row);
       return { rows: [row] };
@@ -181,7 +219,7 @@ function createPgMock() {
       const lastId = params[0] || 0;
       const limit = params[1] || 50;
       const rows = [...wsEvents.values()]
-        .filter(r => r.id > lastId)
+        .filter((r) => r.id > lastId)
         .sort((a, b) => a.id - b.id)
         .slice(0, limit);
       return { rows };
@@ -209,11 +247,29 @@ function createPgMock() {
       return { rows: [], rowCount: 0 };
     }
 
+    // ─── Categories ──────────────────────────────────────────────────────
+    if (
+      text.includes(
+        "FROM categories WHERE slug = $1 OR LOWER(name) = LOWER($2)",
+      )
+    ) {
+      const val = (params[0] || "").toLowerCase().trim();
+      const cat = DEFAULT_CATEGORIES.find(
+        (c) => c.slug === val || c.name.toLowerCase() === val,
+      );
+      return { rows: cat ? [cat] : [] };
+    }
+
+    if (text.includes("FROM categories") && !text.includes("FROM jobs")) {
+      return { rows: DEFAULT_CATEGORIES };
+    }
+
+    // ─── Skills ──────────────────────────────────────────────────────────
     if (text.startsWith("INSERT INTO skills")) {
       const matches = text.match(/\$\$(.*?)\$\$/g);
       if (matches) {
-        matches.forEach(m => {
-          const name = m.replace(/\$\$/g, '');
+        matches.forEach((m) => {
+          const name = m.replace(/\$\$/g, "");
           const slug = name.toLowerCase().trim();
           if (!skillsMap.has(slug)) {
             skillsMap.set(slug, { id: skillsMap.size + 1, display_name: name });
@@ -225,17 +281,19 @@ function createPgMock() {
 
     if (text.startsWith("SELECT id FROM skills WHERE slug = ANY")) {
       const slugs = params[0] || [];
-      const rows = slugs.map(s => {
-        const found = skillsMap.get(s);
-        return found ? { id: found.id } : null;
-      }).filter(Boolean);
+      const rows = slugs
+        .map((s) => {
+          const found = skillsMap.get(s);
+          return found ? { id: found.id } : null;
+        })
+        .filter(Boolean);
       return { rows };
     }
 
     if (text.startsWith("INSERT INTO job_skills")) {
       const matches = text.match(/\('([^']+)',\s*(\d+)\)/g);
       if (matches) {
-        matches.forEach(m => {
+        matches.forEach((m) => {
           const parts = m.match(/\('([^']+)',\s*(\d+)\)/);
           if (parts) {
             const jobId = parts[1];
@@ -250,16 +308,45 @@ function createPgMock() {
       return { rows: [] };
     }
 
-    if (text.startsWith("SELECT s.display_name FROM skills s JOIN job_skills js")) {
+    if (
+      text.startsWith("SELECT s.display_name FROM skills s JOIN job_skills js")
+    ) {
       const jobId = params[0];
       const skillIds = jobSkillsMap.get(jobId) || new Set();
       const rows = [...skillsMap.values()]
-        .filter(s => skillIds.has(s.id))
-        .map(s => ({ display_name: s.display_name }));
+        .filter((s) => skillIds.has(s.id))
+        .map((s) => ({ display_name: s.display_name }));
       return { rows };
     }
 
-    // INSERT INTO jobs
+    // ─── Job Timeline ────────────────────────────────────────────────────
+    if (
+      text.includes("FROM job_timeline WHERE job_id = $1 AND event_type = $2")
+    ) {
+      const found = timelineEvents.find(
+        (e) => e.job_id === params[0] && e.event_type === params[1],
+      );
+      return { rows: found ? [found] : [] };
+    }
+
+    if (text.startsWith("INSERT INTO job_timeline")) {
+      const evt = {
+        id: `evt-${timelineEvents.length + 1}`,
+        job_id: params[0],
+        event_type: params[1],
+        tx_hash: params[2] || null,
+        created_at: new Date().toISOString(),
+      };
+      timelineEvents.push(evt);
+      return { rows: [evt] };
+    }
+
+    if (text.includes("FROM job_timeline WHERE job_id = $1")) {
+      const rows = timelineEvents.filter((e) => e.job_id === params[0]);
+      return { rows };
+    }
+
+    // ─── INSERT INTO jobs ────────────────────────────────────────────────
     if (text.startsWith("INSERT INTO jobs")) {
       const row = defaultJobRow({
         id: `job-${jobs.size + 1}`,
@@ -268,57 +355,278 @@ function createPgMock() {
         budget: params[2],
         currency: params[3],
         category: params[4],
+        category_id: params[5],
+        status: "open",
         client_address: params[6],
         deadline: params[7],
         timezone: params[8],
         screening_questions: params[9],
-        milestones: typeof params[10] === "string" ? JSON.parse(params[10]) : params[10],
-        visibility: params[11],
+        milestones:
+          typeof params[10] === "string" ? JSON.parse(params[10]) : params[10],
+        visibility: params[11] || "public",
       });
       jobs.set(row.id, row);
-      return { rows: [row] };
+      return { rows: [formatJobRow(row)] };
     }
 
-    if (text.includes("FROM jobs WHERE id = $1")) {
+    // ─── Single Job SELECT (by ID) ───────────────────────────────────────
+    if (
+      !text.includes("FROM applications") &&
+      text.includes("FROM jobs") &&
+      (text.includes("WHERE id = $1") ||
+        text.includes("WHERE jobs.id = $1") ||
+        text.includes("WHERE j.id = $1"))
+    ) {
       const row = jobs.get(params[0]);
       if (!row) return { rows: [] };
-      if (text.includes("AND deleted_at IS NULL") && row.deleted_at) return { rows: [] };
-      return { rows: [row] };
+      if (text.includes("deleted_at IS NULL") && row.deleted_at)
+        return { rows: [] };
+      return { rows: [formatJobRow(row)] };
     }
 
-    if (text.includes("FROM jobs WHERE client_address = $1")) {
+    // ─── Jobs by client SELECT ───────────────────────────────────────────
+    if (text.includes("FROM jobs") && text.includes("client_address = $1")) {
       let rows = [...jobs.values()].filter(
         (job) => job.client_address === params[0],
       );
-      if (text.includes("AND deleted_at IS NULL")) {
+      if (text.includes("deleted_at IS NULL")) {
         rows = rows.filter((job) => !job.deleted_at);
       }
-      return { rows };
+      return { rows: rows.map(formatJobRow) };
     }
 
-    // escrows queries
+    // ─── INSERT INTO escrows / UPDATE escrows ─────────────────────────────
     if (text.startsWith("INSERT INTO escrows")) {
-      return { rows: [] };
+      const row = defaultEscrowRow({
+        id: `escrow-${escrows.size + 1}`,
+        job_id: params[0],
+        client_address: params[1],
+        freelancer_address: params[2],
+        amount_xlm: params[3],
+      });
+      escrows.set(row.id, row);
+      return { rows: [row], rowCount: 1 };
+    }
+
+    if (text.startsWith("UPDATE escrows")) {
+      return { rows: [], rowCount: 1 };
     }
 
     if (text.includes("FROM escrows") && text.includes("job_id = $1")) {
-      const escrow = [...escrows.values()].find((e) => e.job_id === params[0]) || escrows.get(params[0]);
+      const escrow =
+        [...escrows.values()].find((e) => e.job_id === params[0]) ||
+        escrows.get(params[0]);
       return { rows: escrow ? [escrow] : [] };
     }
 
+    // ─── Specific UPDATE jobs ────────────────────────────────────────────
+
     // UPDATE jobs SET applicant_count
     if (text.includes("UPDATE jobs") && text.includes("applicant_count")) {
-      const idParam = params[0];
-      const job = [...jobs.values()].find(j => j.id === idParam);
-      if (job) {
-        job.applicant_count += 1;
-        jobs.set(job.id, job);
+      const row = jobs.get(params[0]);
+      if (row) {
+        row.applicant_count = (row.applicant_count || 0) + 1;
+        jobs.set(row.id, row);
       }
-      return { rows: [] };
+      return { rows: [], rowCount: row ? 1 : 0 };
     }
 
-    // UPDATE applications SET status = 'accepted'
-    if (text.startsWith("UPDATE applications SET status = 'accepted'")) {
+    // UPDATE jobs SET deleted_at
+    if (text.includes("UPDATE jobs") && text.includes("SET deleted_at")) {
+      const row = jobs.get(params[0]);
+      if (!row || row.deleted_at) return { rows: [], rowCount: 0 };
+      row.deleted_at = new Date().toISOString();
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)], rowCount: 1 };
+    }
+
+    // UPDATE jobs SET status = 'cancelled' (bulkCancelJobs)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("status = 'cancelled'") &&
+      text.includes("client_address = $2")
+    ) {
+      const row = jobs.get(params[0]);
+      if (
+        !row ||
+        row.deleted_at ||
+        row.client_address !== params[1] ||
+        row.status !== "open"
+      ) {
+        return { rows: [], rowCount: 0 };
+      }
+      row.status = "cancelled";
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [{ id: row.id }], rowCount: 1 };
+    }
+
+    // UPDATE jobs SET status = $1 (updateJobStatus)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("SET status = $1") &&
+      text.includes("WHERE id = $2")
+    ) {
+      const row = jobs.get(params[1]);
+      if (!row) return { rows: [] };
+      row.status = params[0];
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)] };
+    }
+
+    // UPDATE jobs SET freelancer_address (assignFreelancer)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("SET freelancer_address = $1")
+    ) {
+      const row = jobs.get(params[1]);
+      if (!row) return { rows: [] };
+      row.freelancer_address = params[0];
+      row.status = "in_progress";
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)] };
+    }
+
+    // UPDATE jobs SET escrow_contract_id (updateJobEscrowId)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("SET escrow_contract_id = $1")
+    ) {
+      const row = jobs.get(params[1]);
+      if (!row) return { rows: [] };
+      row.escrow_contract_id = params[0];
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)] };
+    }
+
+    // UPDATE jobs SET boosted (boostJob)
+    if (text.includes("UPDATE jobs") && text.includes("SET boosted = true")) {
+      const row = jobs.get(params[1]);
+      if (!row) return { rows: [] };
+      row.boosted = true;
+      row.boosted_until = params[0];
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)] };
+    }
+
+    // UPDATE jobs SET share_count (incrementShareCount)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("share_count = COALESCE(share_count, 0) + 1")
+    ) {
+      const row = jobs.get(params[0]);
+      if (!row || row.deleted_at) return { rows: [], rowCount: 0 };
+      row.share_count = (row.share_count || 0) + 1;
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)], rowCount: 1 };
+    }
+
+    // UPDATE jobs SET status = 'disputed' (raiseDispute)
+    if (text.includes("UPDATE jobs") && text.includes("dispute_reason = $1")) {
+      const row = jobs.get(params[3]);
+      if (!row || row.deleted_at || row.status !== "in_progress") {
+        return { rows: [] };
+      }
+      row.status = "disputed";
+      row.dispute_reason = params[0];
+      row.dispute_description = params[1];
+      row.disputed_by = params[2];
+      row.disputed_at = new Date().toISOString();
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)] };
+    }
+
+    // UPDATE jobs SET status = 'in_progress' (resolveDispute)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("dispute_reason = NULL")
+    ) {
+      const row = jobs.get(params[0]);
+      if (!row || row.deleted_at || row.status !== "disputed") {
+        return { rows: [] };
+      }
+      row.status = "in_progress";
+      row.dispute_reason = null;
+      row.dispute_description = null;
+      row.disputed_by = null;
+      row.disputed_at = null;
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)] };
+    }
+
+    // UPDATE jobs SET expires_at (extendJobExpiry)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("extended_count = COALESCE(extended_count, 0) + 1")
+    ) {
+      const row = jobs.get(params[1]);
+      if (!row) return { rows: [] };
+      row.expires_at = params[0];
+      row.extended_until = params[0];
+      row.extended_count = (row.extended_count || 0) + 1;
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [formatJobRow(row)] };
+    }
+
+    // UPDATE jobs SET view_count (incrementViewCount)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("view_count = COALESCE(view_count, 0) + 1")
+    ) {
+      const row = jobs.get(params[0]);
+      if (!row || row.deleted_at) return { rows: [] };
+      row.view_count = (row.view_count || 0) + 1;
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [{ view_count: row.view_count }] };
+    }
+
+    // UPDATE jobs SET bidding_closed_at (closeBiddingForJob)
+    if (
+      text.includes("UPDATE jobs") &&
+      text.includes("bidding_closed_at = NOW()")
+    ) {
+      const row = jobs.get(params[0]);
+      if (!row) return { rows: [] };
+      row.bidding_closed_at = new Date().toISOString();
+      row.updated_at = new Date().toISOString();
+      jobs.set(row.id, row);
+      return { rows: [{ bidding_closed_at: row.bidding_closed_at }] };
+    }
+
+    // UPDATE jobs SET status = 'expired' (expireOldJobs)
+    if (text.startsWith("UPDATE") && text.includes("status = 'expired'")) {
+      return { rowCount: 0 };
+    }
+
+    // DELETE FROM jobs for purgeDeletedJobs
+    if (text.startsWith("DELETE FROM jobs")) {
+      let count = 0;
+      for (const [id, j] of jobs.entries()) {
+        if (j.deleted_at) {
+          jobs.delete(id);
+          count++;
+        }
+      }
+      return { rowCount: count, rows: [] };
+    }
+
+    // ─── Applications Queries ────────────────────────────────────────────
+
+    // UPDATE applications SET accepted
+    if (
+      text.includes("UPDATE applications") &&
+      text.includes("status = 'accepted'")
+    ) {
       const row = applications.get(params[0]);
       if (!row) return { rows: [] };
       row.status = "accepted";
@@ -327,10 +635,16 @@ function createPgMock() {
       return { rows: [row] };
     }
 
-    // UPDATE applications SET status = 'rejected'
-    if (text.includes("UPDATE applications") && text.includes("status = 'rejected'")) {
+    // UPDATE applications SET rejected
+    if (
+      text.includes("UPDATE applications") &&
+      text.includes("status = 'rejected'")
+    ) {
       const jobApps = [...applications.values()].filter(
-        (app) => app.job_id === params[0] && app.id !== params[1] && app.status === "pending",
+        (app) =>
+          app.job_id === params[0] &&
+          app.id !== params[1] &&
+          app.status === "pending",
       );
       jobApps.forEach((app) => {
         app.status = "rejected";
@@ -338,16 +652,10 @@ function createPgMock() {
       });
       return { rows: [] };
     }
-    if (text.startsWith("UPDATE jobs SET deleted_at")) {
-      const row = jobs.get(params[0]);
-      if (!row || row.deleted_at) return { rows: [], rowCount: 0 };
-      row.deleted_at = new Date().toISOString();
-      row.updated_at = new Date().toISOString();
-      jobs.set(row.id, row);
-      return { rows: [row], rowCount: 1 };
-    }
-    if (text.startsWith("UPDATE jobs SET status")) {
-      const row = jobs.get(params[1]);
+
+    // UPDATE applications SET bid_revealed
+    if (text.includes("UPDATE applications") && text.includes("bid_revealed")) {
+      const row = applications.get(params[0]);
       if (!row) return { rows: [] };
       row.bid_revealed = true;
       row.revealed_bid_amount = params[1];
@@ -357,7 +665,7 @@ function createPgMock() {
     }
 
     // UPDATE applications SET withdrawn_at
-    if (text.startsWith("UPDATE applications SET withdrawn_at")) {
+    if (text.includes("UPDATE applications") && text.includes("withdrawn_at")) {
       const row = applications.get(params[0]);
       if (!row) return { rows: [] };
       row.withdrawn_at = new Date().toISOString();
@@ -365,16 +673,48 @@ function createPgMock() {
       return { rows: [row] };
     }
 
+    // SELECT applications for job (findApplicationsByJob)
+    if (
+      text.includes("FROM applications") &&
+      (text.includes("WHERE a.job_id = $1") ||
+        text.includes("WHERE job_id = $1"))
+    ) {
+      const rows = [...applications.values()]
+        .filter((app) => app.job_id === params[0])
+        .map((app) => ({ ...defaultApplicationRow(app), ...app }));
+      return { rows };
+    }
+
+    // SELECT applications for freelancer (getApplicationsForFreelancer)
+    if (
+      text.includes("FROM applications") &&
+      (text.includes("WHERE a.freelancer_address = $1") ||
+        text.includes("WHERE freelancer_address = $1"))
+    ) {
+      const rows = [...applications.values()]
+        .filter((app) => app.freelancer_address === params[0])
+        .map((app) => ({ ...defaultApplicationRow(app), ...app }));
+      return { rows };
+    }
+
     // SELECT * FROM applications WHERE id
-    if (text.startsWith("SELECT * FROM applications WHERE id")) {
+    if (
+      text.includes("FROM applications WHERE id = $1") ||
+      text.includes("FROM applications a WHERE a.id = $1")
+    ) {
       const row = applications.get(params[0]);
-      return { rows: row ? [row] : [] };
+      return { rows: row ? [{ ...defaultApplicationRow(row), ...row }] : [] };
     }
 
     // SELECT 1 FROM applications WHERE job_id AND freelancer_address
-    if (text.includes("SELECT 1 FROM applications WHERE") && text.includes("job_id") && text.includes("freelancer_address")) {
+    if (
+      text.includes("SELECT 1 FROM applications WHERE") &&
+      text.includes("job_id") &&
+      text.includes("freelancer_address")
+    ) {
       const exists = [...applications.values()].some(
-        (app) => app.job_id === params[0] && app.freelancer_address === params[1],
+        (app) =>
+          app.job_id === params[0] && app.freelancer_address === params[1],
       );
       return { rows: exists ? [{ "?column?": 1 }] : [] };
     }
@@ -382,7 +722,8 @@ function createPgMock() {
     // INSERT INTO applications
     if (text.includes("INSERT INTO applications")) {
       const duplicate = [...applications.values()].some(
-        (app) => app.job_id === params[0] && app.freelancer_address === params[1],
+        (app) =>
+          app.job_id === params[0] && app.freelancer_address === params[1],
       );
       if (duplicate) {
         const err = new Error("duplicate");
@@ -403,32 +744,64 @@ function createPgMock() {
       return { rows: [row] };
     }
 
-    // UPDATE ... SET freelancer_address for assignFreelancer
-    if (text.includes("SET freelancer_address = $1, status = 'in_progress'") && text.includes("UPDATE jobs")) {
-      const row = jobs.get(params[1]);
-      if (!row) return { rows: [] };
-      row.freelancer_address = params[0];
-      row.status = "in_progress";
-      jobs.set(row.id, row);
-      return { rows: [row] };
-    }
-
-    // listJobs-style query: FROM jobs ... ORDER BY ... (paginated)
-    if (text.includes("FROM jobs") && text.includes("ORDER BY") && !text.includes("WHERE id = $") && !text.includes("WHERE client_address = $1")) {
-      let rows = [...jobs.values()].filter((job) => job.visibility === "public");
+    // ─── listJobs-style query: FROM jobs ... ORDER BY ... (paginated) ────
+    if (
+      !text.includes("FROM applications") &&
+      text.includes("FROM jobs") &&
+      text.includes("ORDER BY") &&
+      !text.includes("WHERE id = $") &&
+      !text.includes("WHERE client_address = $1") &&
+      !text.includes("FROM job_timeline") &&
+      !text.includes("COUNT(*)") &&
+      !text.includes("GROUP BY")
+    ) {
+      let rows = [...jobs.values()].filter(
+        (job) => job.visibility === "public",
+      );
       if (text.includes("deleted_at IS NULL")) {
         rows = rows.filter((job) => !job.deleted_at);
       }
       if (text.includes("status = $1")) {
         rows = rows.filter((job) => job.status === params[0]);
       }
-      if (text.includes("category = $")) {
-        const categoryIndex = text.indexOf("category = $2") >= 0 ? 1 : 0;
-        const category = params[categoryIndex];
-        if (category) rows = rows.filter((job) => job.category === category);
+      if (
+        text.includes("category = $") ||
+        text.includes("c.slug = $") ||
+        text.includes("jobs.category = $")
+      ) {
+        const catParam = params.find(
+          (p) =>
+            typeof p === "string" &&
+            (DEFAULT_CATEGORIES.some(
+              (c) =>
+                c.name.toLowerCase() === p.toLowerCase() ||
+                c.slug.toLowerCase() === p.toLowerCase(),
+            ) ||
+              [...jobs.values()].some((j) => j.category === p)),
+        );
+        if (catParam) {
+          rows = rows.filter(
+            (job) =>
+              (job.category &&
+                job.category.toLowerCase() === catParam.toLowerCase()) ||
+              (job.category_slug &&
+                job.category_slug.toLowerCase() === catParam.toLowerCase()) ||
+              DEFAULT_CATEGORIES.some(
+                (c) =>
+                  (c.slug === catParam.toLowerCase() ||
+                    c.name.toLowerCase() === catParam.toLowerCase()) &&
+                  job.category &&
+                  job.category.toLowerCase() === c.name.toLowerCase(),
+              ),
+          );
+        }
       }
       const limit = params[params.length - 1] ?? 50;
-      return { rows: rows.slice(0, limit) };
+      return {
+        rows: rows
+          .slice(0, typeof limit === "number" ? limit : 50)
+          .map(formatJobRow),
+      };
     }
 
     // Job invitations check
@@ -464,17 +837,29 @@ function createPgMock() {
     }
 
     // SELECT with COUNT(*) for analytics overview — return mock data
-    if (text.includes("COUNT(*)") && text.includes("FROM jobs")) {
+    if (
+      text.includes("COUNT(*)") &&
+      text.includes("FROM jobs") &&
+      !text.includes("GROUP BY")
+    ) {
       return {
-        rows: [{
-          total_jobs: jobs.size,
-          open_jobs: [...jobs.values()].filter(j => j.status === "open").length,
-          in_progress_jobs: [...jobs.values()].filter(j => j.status === "in_progress").length,
-          completed_jobs: [...jobs.values()].filter(j => j.status === "completed").length,
-          avg_budget_xlm: "250.00",
-          total_filled: [...jobs.values()].filter(j => j.freelancer_address).length,
-          avg_days_to_fill: null,
-        }]
+        rows: [
+          {
+            total_jobs: jobs.size,
+            open_jobs: [...jobs.values()].filter((j) => j.status === "open")
+              .length,
+            in_progress_jobs: [...jobs.values()].filter(
+              (j) => j.status === "in_progress",
+            ).length,
+            completed_jobs: [...jobs.values()].filter(
+              (j) => j.status === "completed",
+            ).length,
+            avg_budget_xlm: "250.00",
+            total_filled: [...jobs.values()].filter((j) => j.freelancer_address)
+              .length,
+            avg_days_to_fill: null,
+          },
+        ],
       };
     }
 
@@ -482,7 +867,9 @@ function createPgMock() {
     if (text.includes("GROUP BY category") && text.includes("FROM jobs")) {
       const cats = {};
       for (const job of jobs.values()) {
-        if (!cats[job.category]) cats[job.category] = { count: 0, budgetSum: 0, filledCount: 0 };
+        if (!cats[job.category]) {
+          cats[job.category] = { count: 0, budgetSum: 0, filledCount: 0 };
+        }
         cats[job.category].count++;
         cats[job.category].budgetSum += parseFloat(job.budget || 0);
         if (job.freelancer_address) cats[job.category].filledCount++;
@@ -494,7 +881,7 @@ function createPgMock() {
           avg_budget_xlm: data.budgetSum / data.count,
           filled_count: data.filledCount,
           avg_days_to_fill: null,
-        }))
+        })),
       };
     }
 
@@ -504,23 +891,22 @@ function createPgMock() {
     }
 
     // SELECT from applications with count for job analytics
-    if (text.includes("FROM applications WHERE job_id = $1") && text.includes("COUNT(*)") && !text.includes("a.job_id")) {
-      return { rows: [{ total_applications: 0, accepted_applications: 0, avg_bid: "0", min_bid: "0", max_bid: "0" }] };
-    }
-
-    // UPDATE jobs SET status = 'expired' (expireOldJobs)
-    if (text.startsWith("UPDATE") && text.includes("status = 'expired'") && text.includes("expires_at < NOW()")) {
-      return { rowCount: 0 };
-    }
-
-    // SELECT with INTERVAL for getExpiringJobs
-    if (text.includes("expires_at > NOW()") && text.includes("expires_at <= NOW() + INTERVAL")) {
-      return { rows: [] };
-    }
-
-    // DELETE FROM jobs for purgeDeletedJobs
-    if (text.startsWith("DELETE FROM jobs")) {
-      return { rowCount: 0, rows: [] };
+    if (
+      text.includes("FROM applications WHERE job_id = $1") &&
+      text.includes("COUNT(*)") &&
+      !text.includes("a.job_id")
+    ) {
+      return {
+        rows: [
+          {
+            total_applications: 0,
+            accepted_applications: 0,
+            avg_bid: "0",
+            min_bid: "0",
+            max_bid: "0",
+          },
+        ],
+      };
     }
 
     // UPDATE profiles (for settings)
@@ -556,7 +942,10 @@ function createPgMock() {
       return { rows: [row] };
     }
 
-    if (text.includes("FROM api_keys k") && text.includes("k.owner_public_key = $1")) {
+    if (
+      text.includes("FROM api_keys k") &&
+      text.includes("k.owner_public_key = $1")
+    ) {
       const rows = [...apiKeys.values()]
         .filter((k) => k.owner_public_key === params[0])
         .map((k) => ({
@@ -573,7 +962,10 @@ function createPgMock() {
       return { rows };
     }
 
-    if (text.startsWith("UPDATE api_keys") && text.includes("SET revoked_at = NOW()")) {
+    if (
+      text.startsWith("UPDATE api_keys") &&
+      text.includes("SET revoked_at = NOW()")
+    ) {
       const key = apiKeys.get(params[0]);
       if (key && key.owner_public_key === params[1] && !key.revoked_at) {
         key.revoked_at = new Date().toISOString();
@@ -585,21 +977,31 @@ function createPgMock() {
       return { rows: [], rowCount: 0 };
     }
 
-    if (text.startsWith("UPDATE api_keys") && text.includes("SET rotating_key_hash")) {
+    if (
+      text.startsWith("UPDATE api_keys") &&
+      text.includes("SET rotating_key_hash")
+    ) {
       const key = apiKeys.get(params[0]);
-      if (key && key.owner_public_key === params[1] && !key.revoked_at && !key.rotating_at) {
+      if (
+        key &&
+        key.owner_public_key === params[1] &&
+        !key.revoked_at &&
+        !key.rotating_at
+      ) {
         key.previous_key_hash = key.key_hash;
         key.rotating_key_hash = params[2];
         key.key_prefix = params[3];
         key.rotating_at = new Date().toISOString();
         apiKeys.set(key.id, key);
         return {
-          rows: [{
-            id: key.id,
-            label: key.label,
-            created_at: key.created_at,
-            rotating_at: key.rotating_at,
-          }],
+          rows: [
+            {
+              id: key.id,
+              label: key.label,
+              created_at: key.created_at,
+              rotating_at: key.rotating_at,
+            },
+          ],
           rowCount: 1,
         };
       }
@@ -615,7 +1017,8 @@ function createPgMock() {
       const row = defaultOnboardingRow({
         public_key: params[0],
         current_step: params[1],
-        completed_steps: typeof params[2] === "string" ? JSON.parse(params[2]) : params[2],
+        completed_steps:
+          typeof params[2] === "string" ? JSON.parse(params[2]) : params[2],
         dismissed: params[3],
         completed: params[4],
       });
@@ -623,7 +1026,10 @@ function createPgMock() {
       return { rows: [row] };
     }
 
-    if (text.includes("FROM onboarding_progress") && text.includes("public_key = $1")) {
+    if (
+      text.includes("FROM onboarding_progress") &&
+      text.includes("public_key = $1")
+    ) {
       const row = onboardingProgress.get(params[0]);
       return { rows: row ? [row] : [] };
     }
@@ -632,10 +1038,9 @@ function createPgMock() {
     if (text.includes("FROM categories")) {
       return { rows: [] };
     }
-
     // Generic UPDATE ... RETURNING
     if (text.startsWith("UPDATE") && text.includes("RETURNING")) {
-      return { rows: [{}] };
+      return { rows: [] };
     }
 
     // Generic SELECT from notification_queue
@@ -799,6 +1204,7 @@ function createPgMock() {
     apiKeys.clear();
     escrows.clear();
     onboardingProgress.clear();
+    timelineEvents.length = 0;
     query.mockClear();
     connect.mockClear();
   }

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # CDN Setup Documentation
 
 ## Environment Variables
@@ -69,4 +68,3 @@ No code changes are required in services; the fallback is handled inside
 
 Leave `DATABASE_READ_URL` unset. Both `readPool` and `writePool` will point
 to the same local Postgres instance defined by `DATABASE_URL`.
->>>>>>> main


### PR DESCRIPTION
closes #1083 

## Description
Fixes failing tests in `src/services/jobService.test.js` (Issue #1083).

### Root Cause Analysis
1. **Mock Query Interception in `pgMock.js`**:
   - `pgMock` contained outdated and mismatched SQL query patterns for `UPDATE jobs` operations (including `escrow_contract_id`, `boosted`, `share_count`, `dispute_reason`, `extended_count`, `view_count`, and `bidding_closed_at`).
   - A corrupt update branch matching `UPDATE jobs SET status` was incorrectly mutating application bid state, causing `raiseDispute`, `resolveDispute`, and `bulkCancelJobs` to fail.
   - The category fallback in `pgMock` was capturing any query matching `FROM categories`, intercepting `listJobs` queries that joined or selected against categories and returning raw category rows instead of job rows.
   - Queries with `JOB_SELECT_CLAUSE` (with lateral joins) were failing to match the simple single-job `WHERE id = $1` matcher and returning 404 for existing records in `boostJob`, `extendJobExpiry`, `getJobAnalytics`, etc.
   - Applications queries like `findApplicationsByJob` were being matched by the single job / list jobs query handlers due to subqueries referencing the `jobs` table.
2. **Missing `hasMore` in `jobService.listJobs`**:
   - `listJobs` previously only returned `{ jobs, nextCursor }`. `hasMore: Boolean(nextCursor)` was added to satisfy the pagination API contract expected by tests.
3. **Defensive DB Pool Resolution**:
   - `jobService.js` and `applicationService.js` now safely resolve `poolModule.writePool || poolModule` and `poolModule.readPool || poolModule` when modules or unit tests mock the default export of `../db/pool`.

---

## Key Changes
- [pgMock.js](file:///home/khaleepha/drips/Stellar-MarketPay-/backend/src/testUtils/pgMock.js):
  - Rewrote mock query handlers to properly route job status transitions, escrow updates, timeline event insertions/queries, dispute handling, expiry extensions, view counts, and category filtering.
  - Ensured `applications` queries and `jobs` queries are cleanly segregated so subqueries on `jobs` or `categories` do not misroute queries.
- [jobService.js](file:///home/khaleepha/drips/Stellar-MarketPay-/backend/src/services/jobService.js):
  - Added `hasMore: Boolean(nextCursor)` to `listJobs` return object.
  - Safely resolved `readPool` and `writePool` from `../db/pool`.
- [applicationService.js](file:///home/khaleepha/drips/Stellar-MarketPay-/backend/src/services/applicationService.js):
  - Safely resolved `readPool` and `writePool` from `../db/pool`.

---

## Verification & Test Results

### 1. `jobService.test.js` Unit Tests
```bash
cd backend && npx jest src/services/jobService.test.js
