### PR TITLE
docs: regenerate architecture/contract-API/troubleshooting docs; ci: re-enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,163 @@
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------
+  # Frontend (Next.js app) — npm
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    assignees:
+      - "Emmy123222"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      # Major bumps are reviewed manually, one at a time, so they don't
+      # get silently bundled into an automated PR.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ---------------------------------------------------------------------
+  # Backend (API service) — npm
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+    assignees:
+      - "Emmy123222"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ---------------------------------------------------------------------
+  # Repo-root tooling (husky, lint-staged, eslint, prettier) — npm
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "tooling"
+    assignees:
+      - "Emmy123222"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ---------------------------------------------------------------------
+  # Soroban escrow contract — cargo
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "cargo"
+    directory: "/contracts/marketpay-contract"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "contracts"
+    assignees:
+      - "Emmy123222"
+    groups:
+      cargo-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ---------------------------------------------------------------------
+  # Arbitrator registry contract — cargo
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "cargo"
+    directory: "/contracts/arbitrator-registry"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "contracts"
+    assignees:
+      - "Emmy123222"
+    groups:
+      cargo-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ---------------------------------------------------------------------
+  # GitHub Actions workflows
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    assignees:
+      - "Emmy123222"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,94 +1,224 @@
 # Architecture — Stellar MarketPay
 
+This document describes the system as it actually exists in this repository: a Next.js frontend that signs and submits Soroban transactions directly through Freighter, an Express/PostgreSQL backend that serves as the REST/GraphQL API and an on-chain indexer/cache (not a funds custodian), and two independent Soroban contracts (`marketpay-contract` for escrow and `arbitrator-registry` for staked arbitrators).
+
+## Table of Contents
+
+- [System Overview](#system-overview)
+- [Component Breakdown](#component-breakdown)
+- [Job & Escrow Data Flow](#job--escrow-data-flow)
+- [Escrow Contract Surface](#escrow-contract-surface)
+- [Job Lifecycle](#job-lifecycle)
+- [Infrastructure & Deployment](#infrastructure--deployment)
+- [Security Model](#security-model)
+
+---
+
 ## System Overview
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                          User's Browser                             │
-│  ┌────────────────────────────┐   ┌────────────────────────────┐   │
-│  │  Next.js Frontend          │   │  Freighter Extension       │   │
-│  │  (React + Tailwind)        │◄─►│  (Stellar Wallet)          │   │
-│  └──────────┬─────────────────┘   └────────────────────────────┘   │
-└─────────────┼───────────────────────────────────────────────────────┘
-              │ REST API
-              ▼
-┌─────────────────────────────┐
-│  Node.js Backend (Express)  │
-│                             │
-│  • Job CRUD                 │
-│  • Application management   │
-│  • Profile storage          │
-│  • Escrow record keeping    │
-└──────────────┬──────────────┘
-               │ Horizon REST
-               ▼
-┌─────────────────────────────┐     ┌──────────────────────────────┐
-│  Stellar Horizon API        │◄───►│  Stellar Network             │
-│  (horizon-testnet           │     │  (Validators)                │
-│   .stellar.org)             │     │                              │
-└─────────────────────────────┘     └──────────────────────────────┘
-                                               ▲
-                                               │ Soroban
-                                  ┌────────────────────────────────┐
-                                  │  MarketPay Escrow Contract     │
-                                  │  (Rust/WASM)                   │
-                                  │                                │
-                                  │  create_escrow()               │
-                                  │  start_work()                  │
-                                  │  release_escrow()              │
-                                  │  refund_escrow()               │
-                                  └────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────────┐
+│                              User's Browser                                │
+│  ┌───────────────────────────────┐        ┌──────────────────────────┐    │
+│  │  Next.js Frontend (Pages       │◄──────►│  Freighter Extension    │    │
+│  │  Router, React 18 + Tailwind)  │  sign   │  (Stellar Wallet)       │    │
+│  └───────────┬─────────────────┬─┘        └──────────────────────────┘    │
+│              │                 │                                            │
+│      REST/GraphQL      Signed XDR — submitted directly, no backend hop      │
+│    + WebSocket (JWT)                │                                       │
+└──────────────┼──────────────────────┼───────────────────────────────────────┘
+               ▼                      ▼
+┌──────────────────────────────┐   ┌──────────────────────────────────────┐
+│   Express Backend (API)      │   │  Stellar Horizon / Soroban RPC        │
+│                               │   │                                        │
+│  • Job/application/profile   │   │  (horizon-testnet / soroban-testnet   │
+│    CRUD (source of truth     │   │   .stellar.org, or mainnet equiv.)    │
+│    for non-financial data)   │◄─►└───────────────┬────────────────────────┘
+│  • SEP-10 auth + JWT/CSRF    │   Horizon polling/streaming              │
+│  • WebSocket (/ws/realtime,  │   (indexerService)                       ▼
+│    /ws/scope/:sessionId)     │                              ┌────────────────────────────┐
+│  • Horizon indexer — mirrors │                              │  marketpay-contract (Rust/  │
+│    on-chain escrow state     │                              │  WASM) — escrow, milestones,│
+│    into Postgres             │                              │  sealed-bid auctions,        │
+│  • Referral/audit bookkeeping│                              │  disputes & bonds,            │
+│  • Service-keypair signer    │─────signs & submits──────────►  arbitration, DAO governance,  │
+│    for automated timeout     │   (STELLAR_SERVICE_SECRET,   │  certificates, ratings         │
+│    refunds & recurring       │    narrow, admin-scoped path)│                                  │
+│    escrow ticks only         │                              └────────────────────────────┘
+└──────────────┬────────────────┘                              ┌────────────────────────────┐
+               │                                                 │  arbitrator-registry        │
+      ┌────────┴─────────┐                                       │  (Rust/WASM) — staked        │
+      ▼                  ▼                                       │  arbitrator pool, separate    │
+┌───────────┐     ┌────────────┐                                 │  from marketpay-contract       │
+│ PostgreSQL │     │   Redis    │                                └────────────────────────────┘
+│ (pg, hand- │     │ (ioredis,  │
+│  written   │     │  cache +   │
+│  SQL, no   │     │  Bull job  │
+│  ORM)      │     │  queue)    │
+└───────────┘     └────────────┘
 ```
+
+**Key correction from earlier versions of this document:** escrow funds do **not** flow through the backend. The frontend builds the Soroban contract call, Freighter signs it locally, and the signed transaction is submitted straight to Soroban RPC / Horizon from the browser. The backend's role for the funds path is to *read back* what happened (via its Horizon indexer) and keep Postgres in sync — it is a REST/GraphQL API and indexer/cache layer, not a payment intermediary. The one exception is a small set of backend-initiated, service-keypair-signed calls used for automation (timeout refunds, recurring escrow ticks) — see [Job & Escrow Data Flow](#job--escrow-data-flow).
+
+---
+
+## Component Breakdown
+
+### Frontend (`frontend/`)
+
+- **Framework**: Next.js 14 (Pages Router — `frontend/pages/`), React 18, TypeScript, Tailwind CSS.
+- **API client**: a shared Axios instance (`frontend/lib/api/client.ts`, `withCredentials: true` so the JWT/CSRF cookies ride along) wrapped by per-domain modules — `lib/api/jobs.ts`, `applications.ts`, `escrow.ts`, `profiles.ts`, `messages.ts`, `disputes.ts`, `dao.ts`, `admin.ts`, `auth.ts`, `certificates.ts`, `assessments.ts`, `nft.ts`, and more. Data fetching in components goes through `hooks/useApi.ts` (SWR-based).
+- **Wallet integration**: `frontend/lib/wallet.ts` uses `@stellar/freighter-api` (with a `window.freighter` fallback) for connecting, requesting access, and signing transactions.
+- **Chain interaction**: `frontend/lib/stellar.ts` uses `@stellar/stellar-sdk` (`Horizon.Server`, `SorobanRpc.Server`, `Contract`, `TransactionBuilder`) to build Soroban contract invocations (e.g. `create_escrow`, `release_escrow`), gets a fee-tier estimate from `lib/sorobanFees.ts` (backed by the backend's `/api/gas-estimate`), hands the built XDR to Freighter to sign, then submits directly to Soroban RPC/Horizon. `lib/contractMock.ts` provides a mock-contract mode (`NEXT_PUBLIC_USE_CONTRACT_MOCK=true`) for local frontend work without a deployed contract.
+- **Realtime**: `hooks/useRealtimeBids.ts` and other consumers connect to the backend's `/ws/realtime` WebSocket for live notifications, bid updates, and job-expiry warnings.
+- **Other notable pieces**: PWA/service worker (`@ducanh2912/next-pwa`, `public/sw.src.js`) with background sync and push notifications; i18n (`next-i18next`); WebAuthn/passkey support (`@simplewebauthn/browser`, `lib/api/passkeys.ts`); end-to-end message encryption (`tweetnacl`, `lib/crypto.ts`); Storybook, Jest, and Playwright for component/unit/e2e testing.
+
+### Backend (`backend/`)
+
+- **Framework**: Express 5, entry point `backend/src/server.js` — a plain `http.createServer(app)` so the same server also hosts the raw `ws` WebSocket server via the HTTP `upgrade` event. Not a framework-managed server process.
+- **Routes** (`backend/src/routes/`, ~35 files) cover jobs, applications, profiles, onboarding, escrow, auth (SEP-10), ratings, messaging, disputes, admin (+2FA), time entries, notifications, developer/public API keys, referrals, events, invitations, stats, contributors, gas estimation, transactions, DAO, proposal templates, price alerts, AI job-description scoring, and NFTs — plus a GraphQL endpoint at `/api/graphql`.
+- **Services** (`backend/src/services/`, ~45 files) hold the business logic: `jobService`, `applicationService`, `profileService`, `escrowService`, `recurringEscrowService`, `disputeService`, `indexerService` (the Horizon indexer), `sorobanClient` / `sorobanArbitratorRegistry` / `sorobanEvidence` (read-only Soroban RPC calls), `notificationService`, `messageService`, `encryptionService`, `stellarServiceKey` (the narrow backend-signing path), `ipfsService`, `nftCertificateService`, `ratingService`, `referralService`, `daoService`, `cacheService` (Redis), `authTokens` (JWT/refresh tokens), `auditLogService`, and more.
+- **Database**: **PostgreSQL** via a raw `pg.Pool` (`backend/src/db/pool.js`) — no ORM. Schema evolves through hand-written SQL migrations (`backend/src/db/migrations/V<N>__name.{up,down}.sql`) applied by a custom runner (`backend/src/db/migrate.js`) that validates the applied version against the highest version found on disk at boot. See [Troubleshooting: Migration Version Collisions](./troubleshooting.md#migration-version-collisions) for a known pitfall in this scheme.
+- **Auth**: SEP-10 Stellar Web Authentication (`routes/auth.js`, matches `docs/auth-flow.md` / ADR-004) — the backend issues a challenge transaction, the client signs it with Freighter, and the backend verifies it and issues a JWT (httpOnly cookie) plus a CSRF token (`middleware/csrf.js`, double-submit cookie pattern via `csrf-csrf`). `middleware/auth.js` verifies the JWT on protected routes and gates admin routes behind role + optional TOTP 2FA. WebAuthn/passkeys (`routes/webauthn.js`) provide a secondary auth factor.
+- **Caching & queues**: Redis via `ioredis` (`services/cacheService.js`) backs both response caching and a **Bull** job queue (`workers/emailWorker.js`) for email sending.
+- **WebSocket server**: a raw `ws` server on the same HTTP server, with two paths — `/ws/realtime` (notifications, bid updates, job-expiry warnings, JWT passed as a query param, 5-connection-per-user cap, missed-notification replay) and `/ws/scope/:sessionId` (a collaborative scope-document editor with live sync, persisted with a 24h TTL).
+- **Background workers**: interval-based (no external cron) — job-expiry checks, an escrow-timeout checker, notification processing, idempotency-key cleanup, WS event cleanup, weekly digest/report emails, soft-deleted-record purging, a recurring-escrow ticker, saved-search alerts, and API-key rotation finalization — all started from `bootstrap()` in `server.js`.
+- **Talking to Stellar**: `services/indexerService.js` polls/streams Horizon for payments touching the platform wallet/contract, parses job IDs out of memos, classifies escrow events, and writes the result back into Postgres (an `indexer_state` table tracks the sync checkpoint) — this is how the backend's view of escrow state stays consistent with the chain. `services/stellarServiceKey.js` holds a backend-owned Stellar keypair used **only** for a small set of automated, admin-scoped contract calls (timeout refunds, recurring escrow ticks) — not for regular user-initiated escrow operations.
+
+### Smart Contracts (`contracts/`)
+
+- **`marketpay-contract`** (`contracts/marketpay-contract/src/lib.rs`, Soroban SDK 22, `#![no_std]`) — the core escrow contract. 71 public entrypoints covering: escrow create/start/release/refund/timeout, milestone-based partial release, sealed-bid budget commitment and freelancer bid auctions, disputes with configurable bonds, (partially implemented) multi-arbitrator arbitration cases, DAO governance proposals/voting, job boosts, on-chain message CID notarization, deliverable-hash oracle verification, completion certificates, ratings, and multi-sig admin/freeze controls. See [`docs/contract-api-reference.md`](./contract-api-reference.md) for the full function-by-function reference.
+- **`arbitrator-registry`** (`contracts/arbitrator-registry/src/lib.rs`) — a separate, independently deployed contract that manages a staking-gated pool of arbitrators (register/deregister with a minimum XLM/token stake, DAO-driven registration/removal). It is **not currently wired into `marketpay-contract`'s dispute resolution on-chain** — `resolve_dispute` is gated by a single `arbitrator` address set via `set_arbitrator`, independently of this registry. The two are connected administratively today, not contractually.
+- **`contracts/certora/`** — a Certora formal-verification specification (`escrow.spec`) for the escrow contract; not a deployable crate (see `docs/formal-verification.md`).
+
+---
+
+## Job & Escrow Data Flow
+
+1. **Auth**: The frontend requests a SEP-10 challenge (`GET /api/auth`), signs it with Freighter, and posts it back. The backend verifies the signature and sets a JWT (httpOnly cookie) plus issues a CSRF token.
+2. **Job posting**: `POST /api/jobs` writes the job directly into PostgreSQL via `jobService`. No blockchain interaction happens at this step — pure backend CRUD.
+3. **Application / hiring**: similarly REST CRUD through `applicationService` into Postgres, with realtime updates pushed over `/ws/realtime`.
+4. **Escrow creation (funds path)**: once a client hires a freelancer, the **frontend** — not the backend — builds the `create_escrow` Soroban invocation (`frontend/lib/stellar.ts`), gets it signed by Freighter, and submits it directly to Soroban RPC/Horizon. The funds are locked **inside the Soroban contract**, never touching the backend.
+5. **Indexing**: `indexerService` observes the resulting Horizon transaction, updates the `escrows`/`jobs` tables in Postgres, advances its sync checkpoint, and broadcasts a realtime WebSocket event so connected clients see the new state without polling.
+6. **Release / refund**: The client-initiated release/refund follows the same frontend-signs-directly pattern as creation. The frontend also calls back to the backend (`POST /api/escrow/:jobId/release`) with the resulting `contractTxHash` so it can update status, process referral bookkeeping (`referralService`), and write an audit log — the backend explicitly does not move funds on this path. The one exception: **automated** timeout refunds and recurring-escrow ticks are signed and submitted by the backend itself using its own service keypair (`stellarServiceKey`), a narrow and explicitly scoped automation path distinct from normal user-initiated calls.
+7. **Disputes / arbitration**: `disputeService` manages dispute records and IPFS-hosted evidence (`ipfsService`), reading arbitrator membership from the `arbitrator-registry` contract via `sorobanArbitratorRegistry`.
+
+---
+
+## Escrow Contract Surface
+
+The escrow contract now exposes far more than the four core functions historically documented here. Grouped by category (see [`docs/contract-api-reference.md`](./contract-api-reference.md) for full signatures):
+
+| Category | Representative functions |
+|---|---|
+| Escrow lifecycle | `create_escrow`, `create_escrow_with_deliverable`, `create_escrow_with_milestones`, `start_work`, `release_escrow`, `release_with_conversion`, `refund_escrow`, `timeout_refund` |
+| Milestones | `release_milestone`, `reject_milestone`, `get_milestone` |
+| Sealed-bid auctions | `commit_budget`, `reveal_budget`, `submit_bid_commitment`, `close_bidding`, `reveal_bid`, `get_revealed_bids` |
+| Disputes & bonds | `raise_dispute`, `resolve_dispute`, `set_dispute_bond`, `get_dispute_bond`, `get_dispute_bond_config` |
+| Arbitration cases | `resolve_arbitration` (case creation / vote submission are not yet exposed as public entrypoints — see the API reference for this gap) |
+| Deliverable oracle | `submit_deliverable_hash`, `submit_deliverable`, `verify_deliverable_hash`, `check_deliverable_match` |
+| Certificates & ratings | `mint_certificate`, `get_certificate`, `submit_client_rating`, `submit_freelancer_rating` |
+| Governance (DAO) | `create_proposal`, `cast_vote`, `resolve_proposal`, `list_active_proposals` |
+| Job boost | `boost_job` |
+| Messaging | `publish_message`, `get_message_cids` |
+| Extensions | `request_extension`, `approve_extension` |
+| Admin / multi-sig / freeze | `freeze_contract`, `unfreeze_contract`, `add_admin`, `set_unfreeze_threshold`, `set_treasury_address`, `set_platform_fee_bps`, `set_default_timeout_seconds`, `set_max_referrer_bonus_xlm`, `upgrade` |
+
+### Escrow state machine
+
+```
+        create_escrow() / create_escrow_with_deliverable()
+        create_escrow_with_milestones()
+              │
+              ▼
+         ┌──────────┐
+         │  Locked  │
+         └──────────┘
+        /            \
+  start_work()    refund_escrow()
+      /               or timeout_refund()
+     ▼                       ▼
+┌────────────┐        ┌──────────┐
+│ InProgress │        │ Refunded │  (terminal)
+└────────────┘        └──────────┘
+     │  \
+     │   raise_dispute()
+     │         ▼
+     │    ┌──────────┐
+     │    │ Disputed │ ← release_milestone()/reject_milestone() still work here
+     │    └──────────┘
+     │         │
+release_escrow() / submit_deliverable() (hash match) / release_milestone() (last one) / resolve_dispute()
+     ▼
+┌──────────┐
+│ Released │  (terminal)
+└──────────┘
+```
+
+---
 
 ## Job Lifecycle
 
 ```
-Client posts job ──► Budget locked in Soroban escrow
+Client posts job ──► (backend CRUD only — no chain interaction yet)
          │
          ▼
-Freelancers submit proposals
+Freelancers submit proposals / sealed bids
          │
          ▼
-Client reviews & accepts proposal
+Client reviews & accepts a proposal
          │
          ▼
-Job status → in_progress
-Freelancer notified
+Client's browser signs create_escrow() via Freighter ──► budget locked in Soroban contract
+Job status → in_progress; freelancer notified (WebSocket)
          │
          ▼
-Freelancer delivers work
+Freelancer delivers work (optionally hashed via the deliverable oracle)
          │
          ▼
 Client reviews deliverables
          │
     ┌────┴────┐
     │         │
-Approve    Dispute
+ Approve    Dispute
     │         │
     ▼         ▼
-Escrow    Admin
-released  resolves (v2.1)
-to
-freelancer
+Escrow    Dispute bond (if configured) locked;
+released  arbitrator resolves via resolve_dispute()
+to            (multi-arbitrator arbitration cases are
+freelancer     only partially wired — see contract API reference)
 ```
 
-## Escrow Flow (Soroban Contract)
+---
 
-```
-create_escrow()          start_work()         release_escrow()
-[Client locks XLM]  →  [Work begins]    →   [Funds sent to freelancer]
-      │                                              OR
-      └──────────── refund_escrow() ────────── [Refund to client]
-                   [Before work starts]
-```
+## Infrastructure & Deployment
+
+- **Local dev** (`docker-compose.yml`): `frontend` (Next.js dev server, port 3000), `backend` (Express dev server, port 4000), `redis` (`redis:7-alpine`), `postgres` (`postgres:16-alpine`), and an opt-in `logging` profile running Elasticsearch + Kibana + Filebeat for local ELK log inspection.
+- **Production** (`docker-compose.prod.yml`): `nginx` reverse proxy/TLS termination + `certbot` for renewal, **blue/green** `frontend-blue`/`frontend-green` and `backend-blue`/`backend-green` services (image-tag driven, gated by `blue`/`green` Compose profiles), a metrics stack (`node-exporter`, `prometheus`, `grafana`), and an optional `watchtower` for auto-updates. `deploy/scripts/` (`deploy.sh`, `health-check.sh`, `rollback.sh`, `switch-traffic.sh`) implement the blue/green cutover.
+- **Kubernetes**: `deploy/helm/marketpay/` is a Helm chart with templates for `backend`, `frontend`, `postgres`, and `redis`, as an alternative to the Compose-based deployment.
+- **Edge/WAF**: `infra/cloudflare/main.tf` (Terraform) configures Cloudflare-level WAF/DNS/edge rules.
+- **Monitoring**: `monitoring/prometheus/` (scrape config + alert rules) and `monitoring/grafana/` (dashboards + provisioning) back the Prometheus/Grafana stack referenced above; `monitoring/filebeat/` + `monitoring/setup-elk.sh` support the optional ELK logging profile.
+- **Load testing**: `k6/` holds k6 scripts (`get-jobs.js`, `get-profiles.js`, `post-applications.js`, `seed-data.js`) exercised via `docker-compose.loadtest.yml`.
+
+**Note on `packages/`**: `packages/backend` and `packages/client` contain a small, self-contained prototype (a TypeORM-style messaging service and one React component) that is **not wired into the real `frontend/`/`backend/` build** — the root `package.json` has no `workspaces` field referencing it, and git history shows only two isolated experimental commits ever touched it. Treat it as legacy/dead code, not part of the live architecture.
+
+---
 
 ## Security Model
 
 | Concern | Mitigation |
 |---------|-----------|
-| Payment disputes | Soroban contract enforces rules — no human intermediary |
-| Key exposure | Freighter signs locally — private key never leaves browser |
-| Fake job postings | Wallet signature required to post (v1.1) |
-| Double spending | Stellar sequence numbers prevent replay |
-| Sybil freelancers | Reputation system planned (v1.4) |
-| Backend trust | Backend is stateless helper — all payments are on-chain |
+| Payment disputes | Soroban contract enforces escrow rules; disputes go through a bonded `raise_dispute()`/`resolve_dispute()` flow, with multi-arbitrator arbitration cases only partially implemented today (see the contract API reference) |
+| Key exposure | Freighter signs locally — the client's private key never leaves the browser extension |
+| Backend-signed transactions | Limited to a narrow, explicitly-scoped service keypair (`STELLAR_SERVICE_SECRET`) used only for automated timeout refunds and recurring-escrow ticks — never for user-initiated fund movement |
+| Session/API security | SEP-10 wallet-signature authentication, JWT + CSRF double-submit cookie protection, optional WebAuthn/passkey second factor, admin TOTP 2FA |
+| Fake job postings | Wallet-authenticated session required to post (SEP-10) |
+| Double spending | Stellar sequence numbers prevent transaction replay |
+| Cross-site request forgery | `csrf-csrf` double-submit cookie on all state-mutating REST endpoints not otherwise exempted (see [Troubleshooting](./troubleshooting.md#csrf-403-errors-when-calling-the-api-from-a-script)) |
+| Backend trust | Backend is a REST/GraphQL API + on-chain indexer/cache — it does not custody escrowed funds for the normal client-initiated flow |
+| Dispute evidence integrity | Evidence CIDs anchored on-chain (`submit_evidence_cid`) alongside IPFS-hosted content |
+| Contract upgrades | Admin-gated `upgrade()` entrypoint preserves storage across WASM redeploys; multi-sig `freeze_contract`/`unfreeze_contract` (M-of-N admin signatures) provides an emergency stop |
+
+---
+
+**Last Updated**: 2026-08-24

--- a/docs/contract-api-reference.md
+++ b/docs/contract-api-reference.md
@@ -1,11 +1,16 @@
 # Smart Contract API Reference
 
-MarketPay is powered by a single Soroban smart contract (`MarketPayContract`) deployed on Stellar.
-This is the authoritative reference for every public function, data type, storage key, and event.
+MarketPay is powered by two Soroban smart contracts deployed on Stellar:
 
-> **Source:** `contracts/marketpay-contract/src/lib.rs`
+- **`MarketPayContract`** (`contracts/marketpay-contract/src/lib.rs`) — escrow, milestones, sealed-bid auctions, disputes/bonds, arbitration, governance, certificates, ratings, messaging.
+- **`ArbitratorRegistry`** (`contracts/arbitrator-registry/src/lib.rs`) — staking-gated arbitrator registration used to source arbitrators for disputes.
+
+This is the authoritative reference for every public entrypoint, data type, storage key, and event **currently implemented** in those two contracts.
+
+> **Source:** `contracts/marketpay-contract/src/lib.rs`, `contracts/arbitrator-registry/src/lib.rs`
 > **Soroban SDK:** 22.0.0
 > **Build target:** `wasm32-unknown-unknown` (release)
+> **Function count:** `MarketPayContract` exposes **71** public entrypoints; `ArbitratorRegistry` exposes **13**.
 
 ---
 
@@ -14,18 +19,26 @@ This is the authoritative reference for every public function, data type, storag
 - [Data Types](#data-types)
 - [Storage Keys](#storage-keys)
 - [Events Reference](#events-reference)
-- [Initialization](#initialization)
+- [Initialization & Versioning](#initialization--versioning)
 - [Escrow Lifecycle](#escrow-lifecycle)
-- [Getters](#getters)
-- [Governance (DAO)](#governance-dao)
-- [Sealed-Bid Auction](#sealed-bid-auction)
-- [Deliverable Oracle](#deliverable-oracle)
-- [Job Certificates & Ratings](#job-certificates--ratings)
-- [Dispute Arbitration](#dispute-arbitration)
-- [Messaging — On-chain CID Notarization](#messaging--on-chain-cid-notarization)
+- [Escrow Getters](#escrow-getters)
+- [Single Arbitrator (Legacy)](#single-arbitrator-legacy)
+- [Admin, Treasury & Fee Configuration](#admin-treasury--fee-configuration)
+- [Multi-Sig Admin & Freeze Governance](#multi-sig-admin--freeze-governance)
+- [Escrow Timeout Extension](#escrow-timeout-extension)
+- [On-Chain Message Notarization](#on-chain-message-notarization)
+- [Governance (DAO Proposals)](#governance-dao-proposals)
+- [Disputes & Dispute Bonds](#disputes--dispute-bonds)
+- [Arbitration Cases](#arbitration-cases)
+- [Milestones](#milestones)
 - [Job Boost](#job-boost)
-- [Admin & Versioning](#admin--versioning)
+- [Sealed-Bid Budget Commitment](#sealed-bid-budget-commitment)
+- [Sealed-Bid Freelancer Auctions](#sealed-bid-freelancer-auctions)
+- [Deliverable Oracle](#deliverable-oracle)
+- [Job Certificates & Dispute Evidence](#job-certificates--dispute-evidence)
+- [Ratings](#ratings)
 - [Error Reference](#error-reference)
+- [Arbitrator Registry Contract](#arbitrator-registry-contract)
 
 ---
 
@@ -40,7 +53,9 @@ enum EscrowStatus {
     Released,    // Client approved; funds sent to freelancer
     Refunded,    // Client cancelled before start; funds returned
     Disputed,    // A participant raised a dispute
-    Frozen,      // Admin-frozen — no operations allowed until unfrozen
+    Frozen,      // Reserved state value; the contract-wide freeze is a
+                 // separate `Frozen` storage flag, not an EscrowStatus a
+                 // given escrow transitions into via any public function.
 }
 ```
 
@@ -52,239 +67,303 @@ enum EscrowStatus {
 |--------------------|----------------------|-------------------------------------------------------|
 | `job_id`           | `String`             | Backend job UUID                                      |
 | `client`           | `Address`            | Stellar address that locked the funds                 |
-| `freelancer`       | `Address`            | Stellar address that will receive payment             |
-| `token`            | `Address`            | SAC address for XLM or USDC payment token             |
+| `freelancer`       | `Address`            | Stellar address that will receive payment              |
+| `token`            | `Address`            | SAC address for XLM or USDC payment token              |
 | `amount`           | `i128`               | Total payment in smallest token units (stroops for XLM)|
-| `status`           | `EscrowStatus`       | Current lifecycle state                               |
-| `created_at`       | `u32`                | Ledger sequence number at creation                    |
-| `timeout_ledger`   | `u32`                | Ledger sequence after which `timeout_refund()` opens  |
-| `milestones`       | `Vec<Milestone>`     | Milestone list for partial releases (empty if none)   |
-| `referrer`         | `Option<Address>`    | Referrer receives 2% of released amount               |
-| `deliverable_hash` | `Option<BytesN<32>>` | Expected SHA-256 hash of deliverable (oracle path)    |
+| `status`           | `EscrowStatus`       | Current lifecycle state                                |
+| `created_at`       | `u32`                | Ledger sequence number at creation                     |
+| `timeout_ledger`   | `u32`                | Ledger sequence after which `timeout_refund()` opens (legacy path) |
+| `milestones`       | `Vec<Milestone>`     | Milestone list for partial releases (empty if none)     |
+| `referrer`         | `Option<Address>`    | Referrer receives a bonus share of the released amount  |
+| `deliverable_hash` | `Option<BytesN<32>>` | Expected SHA-256 hash of the deliverable (oracle path)   |
 
 ---
 
 ### `Milestone`
 
-| Field          | Type      | Description                                  |
-|----------------|-----------|----------------------------------------------|
-| `id`           | `u32`     | Zero-based milestone identifier              |
-| `description`  | `String`  | Human-readable milestone name                |
-| `percentage`   | `u32`     | Share of total escrow (0–100); all must sum to 100 |
-| `released`     | `bool`    | Whether this milestone has been paid out     |
-| `rejected`     | `bool`    | Whether this milestone was rejected & refunded|
+| Field          | Type      | Description                                          |
+|----------------|-----------|-------------------------------------------------------|
+| `id`           | `u32`     | Zero-based milestone identifier                       |
+| `description`  | `String`  | Human-readable milestone name                         |
+| `percentage`   | `u32`     | Share of total escrow (0–100); all must sum to 100    |
+| `released`     | `bool`    | Whether this milestone has been paid out               |
+| `rejected`     | `bool`    | Whether this milestone was rejected & refunded         |
 
 ### `MilestoneInput`
 
-| Field          | Type     | Description                                     |
-|----------------|----------|-------------------------------------------------|
-| `description`  | `String` | Human-readable milestone name                   |
-| `percentage`   | `u32`    | Share of total escrow (0–100); all must sum to 100 |
+| Field          | Type     | Description                                        |
+|----------------|----------|-----------------------------------------------------|
+| `description`  | `String` | Human-readable milestone name                        |
+| `percentage`   | `u32`    | Share of total escrow (0–100); all must sum to 100    |
 
 ---
 
 ### `CreateEscrowParams`
 
-| Field             | Type                | Required | Description                               |
-|-------------------|---------------------|----------|-------------------------------------------|
-| `freelancer`      | `Address`           | Yes      | Recipient of released funds               |
-| `token`           | `Address`           | Yes      | Payment token SAC address                 |
-| `amount`          | `i128`              | Yes      | Total escrow amount (stroops)             |
-| `milestones`      | `Option<Vec<MilestoneInput>>` | No | Per-milestone descriptions & percentages; must sum to 100 |
-| `timeout_ledgers` | `Option<u32>`       | No       | Ledger timeout (default: 120,960 ≈ 7 days)|
-| `referrer`        | `Option<Address>`   | No       | Referral bonus recipient (not client/freelancer) |
+| Field             | Type                          | Required | Description                               |
+|-------------------|-------------------------------|----------|--------------------------------------------|
+| `freelancer`      | `Address`                     | Yes      | Recipient of released funds                |
+| `token`           | `Address`                     | Yes      | Payment token SAC address                  |
+| `amount`          | `i128`                        | Yes      | Total escrow amount (stroops)              |
+| `milestones`      | `Option<Vec<MilestoneInput>>` | No       | Per-milestone descriptions & percentages; must sum to 100, max 5 |
+| `timeout_ledgers` | `Option<u32>`                 | No       | Ledger timeout (default: 120,960 ≈ 7 days) |
+| `referrer`        | `Option<Address>`             | No       | Referral bonus recipient (not client/freelancer) |
+
+---
+
+### `ExtensionRequest`
+
+| Field                 | Type      | Description                                        |
+|-----------------------|-----------|-----------------------------------------------------|
+| `requested_by`        | `Address` | Which participant (client or freelancer) requested it |
+| `new_timeout_ledger`  | `u32`     | The proposed later timeout ledger                    |
+| `created_at`          | `u32`     | Ledger sequence when the request was made             |
+
+---
+
+### `DisputeBondConfig`
+
+Global configuration set by the admin; when unset, `raise_dispute` runs in legacy zero-cost mode.
+
+| Field    | Type      | Description                                  |
+|----------|-----------|-----------------------------------------------|
+| `token`  | `Address` | SAC token used for the dispute bond           |
+| `amount` | `i128`    | Bond amount required to raise a dispute       |
+
+### `DisputeBond`
+
+Per-job snapshot of a locked bond, created when `raise_dispute` is called while a `DisputeBondConfig` is set.
+
+| Field              | Type      | Description                                     |
+|--------------------|-----------|---------------------------------------------------|
+| `caller`           | `Address` | The participant who raised the dispute and posted the bond |
+| `token`            | `Address` | Bond token (copied from `DisputeBondConfig` at raise-time) |
+| `amount`           | `i128`    | Bond amount locked                                |
+| `raised_at_ledger` | `u32`     | Ledger sequence when the bond was locked           |
+
+### `ArbitrationCase`
+
+| Field         | Type           | Description                                              |
+|---------------|----------------|------------------------------------------------------------|
+| `job_id`      | `String`       | Disputed job                                                |
+| `arbitrators` | `Vec<Address>` | Selected arbitrators (expected: 3)                          |
+| `votes`       | `Vec<u32>`     | Each arbitrator's `client_percent` vote (0–100)              |
+| `resolution`  | `u32`          | Median of the 3 votes = client's share of funds              |
+| `status`      | `u32`          | `0` = open, `1` = resolved                                   |
+
+> **Note:** `resolve_arbitration(env, case_id)` is the only public entrypoint that operates on `ArbitrationCase` records in the current contract. There is **no public function that creates an `ArbitrationCase`, registers the 3 arbitrators against it, or lets them submit votes** — the corresponding error codes (`OnlyAdminRegisterArbitrators = 7007`, `Need3Arbitrators = 7008`, `OnlyAdminOpenArbitration = 7009`, `ArbitrationCaseNotOpen = 7011`, `OnlySelectedArbitrators = 7012`, `AllVotesSubmitted = 7013`) exist in `errors.rs` but are not wired to any `pub fn` yet. A case record must currently be written directly to contract storage (e.g. by a future admin-only entrypoint, or off-chain tooling during development) before `resolve_arbitration` can be called against it. Treat this as a known gap between the error surface and the implemented API — see also the separate [`ArbitratorRegistry`](#arbitrator-registry-contract) contract, which independently manages staked arbitrator membership but is not yet linked to `ArbitrationCase` creation.
+
+### `DisputeCase`
+
+Declared in `lib.rs` but **not referenced by any public or private function** — dead/reserved code as of this writing.
+
+| Field         | Type           |
+|---------------|----------------|
+| `job_id`      | `String`       |
+| `arbitrators` | `Vec<Address>` |
+| `votes`       | `Vec<u32>`     |
+| `voters`      | `Vec<Address>` |
+| `resolution`  | `u32`          |
+| `status`      | `u32`          |
+
+### `RecurringEscrow`
+
+Declared in `lib.rs` (retainer-style recurring payments) but **no public entrypoints operate on it yet** — reserved for a future feature.
+
+| Field                  | Type            |
+|------------------------|-----------------|
+| `job_id`               | `String`        |
+| `client`                | `Address`       |
+| `freelancer`            | `Address`       |
+| `token`                 | `Address`       |
+| `amount_per_release`    | `i128`          |
+| `interval_ledgers`      | `u32`           |
+| `releases_remaining`    | `u32`           |
+| `last_release_ledger`   | `u32`           |
+| `status`                | `EscrowStatus`  |
 
 ---
 
 ### `BidCommitment`
 
 | Field                 | Type         | Description                                |
-|-----------------------|--------------|--------------------------------------------|
-| `job_id`              | `String`     | Associated job                             |
-| `freelancer`          | `Address`    | Bidding freelancer                         |
-| `commitment`          | `BytesN<32>` | `SHA-256(amount_bytes ∥ nonce)`            |
-| `submitted_at_ledger` | `u32`        | Ledger when commitment was stored          |
-| `bid_revealed`        | `bool`       | Whether the bid has been revealed          |
-
----
+|-----------------------|--------------|----------------------------------------------|
+| `job_id`              | `String`     | Associated job                                |
+| `freelancer`          | `Address`    | Bidding freelancer                            |
+| `commitment`          | `BytesN<32>` | `SHA-256(amount_be_bytes ∥ nonce)`             |
+| `submitted_at_ledger` | `u32`        | Ledger when commitment was stored              |
+| `bid_revealed`        | `bool`       | Whether the bid has been revealed              |
 
 ### `RevealedBid`
 
 | Field                | Type      | Description                           |
-|----------------------|-----------|---------------------------------------|
-| `freelancer`         | `Address` | Bidder                                |
-| `amount`             | `i128`    | Revealed bid amount in stroops        |
-| `revealed_at_ledger` | `u32`     | Ledger sequence of reveal             |
-
----
+|----------------------|-----------|-----------------------------------------|
+| `freelancer`         | `Address` | Bidder                                  |
+| `amount`             | `i128`    | Revealed bid amount in stroops          |
+| `revealed_at_ledger` | `u32`     | Ledger sequence of reveal               |
 
 ### `BiddingState`
 
-| Field                    | Type      | Description                                  |
-|--------------------------|-----------|----------------------------------------------|
-| `job_id`                 | `String`  | Associated job                               |
-| `client`                 | `Address` | Job owner                                    |
-| `is_closed`              | `bool`    | Whether the commit phase is over             |
-| `closed_at_ledger`       | `u32`     | Ledger when `close_bidding` was called       |
-| `reveal_deadline_ledger` | `u32`     | `closed_at_ledger + 1000` (~24h reveal window)|
-
----
+| Field                    | Type      | Description                                          |
+|--------------------------|-----------|---------------------------------------------------------|
+| `job_id`                 | `String`  | Associated job                                           |
+| `client`                 | `Address` | Job owner                                                |
+| `is_closed`              | `bool`    | Whether the commit phase is over                         |
+| `closed_at_ledger`       | `u32`     | Ledger when `close_bidding` was called                    |
+| `reveal_deadline_ledger` | `u32`     | `closed_at_ledger + REVEAL_WINDOW_LEDGERS` (17,280 ≈ 24h)  |
 
 ### `BudgetCommitment`
 
 | Field           | Type      | Description                              |
-|-----------------|-----------|------------------------------------------|
-| `job_id`        | `String`  | Associated job                           |
-| `client`        | `Address` | Job owner                                |
-| `budget_amount` | `i128`    | Client's committed budget in stroops     |
-| `is_revealed`   | `bool`    | Whether the budget has been revealed     |
-
----
+|-----------------|-----------|---------------------------------------------|
+| `job_id`        | `String`  | Associated job                               |
+| `client`        | `Address` | Job owner                                    |
+| `budget_amount` | `i128`    | Client's committed budget in stroops          |
+| `is_revealed`   | `bool`    | Whether the budget has been revealed          |
 
 ### `DeliverableSubmission`
 
 | Field                       | Type     | Description                            |
-|-----------------------------|----------|----------------------------------------|
-| `job_id`                    | `String` | Associated job                         |
-| `client_hash_submitted`     | `bool`   | Client has submitted their hash        |
-| `freelancer_hash_submitted` | `bool`   | Freelancer has submitted their hash    |
-| `hashes_match`              | `bool`   | Both hashes verified to match          |
-
----
+|-----------------------------|----------|-------------------------------------------|
+| `job_id`                    | `String` | Associated job                             |
+| `client_hash_submitted`     | `bool`   | Client has submitted their hash             |
+| `freelancer_hash_submitted` | `bool`   | Freelancer has submitted their hash          |
+| `hashes_match`              | `bool`   | Both hashes verified to match                |
 
 ### `Certificate`
 
-Proof-of-work NFT minted to the freelancer once the escrow is released.
+Proof-of-work record minted to the freelancer once the escrow is released.
 
 | Field        | Type      | Description                             |
-|--------------|-----------|-----------------------------------------|
-| `job_id`     | `String`  | Associated job                          |
-| `title`      | `String`  | Job title (NFT metadata)                |
-| `client`     | `Address` | Client who released the escrow          |
-| `freelancer` | `Address` | Certificate recipient                   |
-| `amount`     | `i128`    | Escrow amount at time of minting (XLM)  |
-| `created_at` | `u32`     | Ledger sequence at mint time            |
-
----
+|--------------|-----------|--------------------------------------------|
+| `job_id`     | `String`  | Associated job                              |
+| `title`      | `String`  | Job title (metadata)                         |
+| `client`     | `Address` | Client who released the escrow               |
+| `freelancer` | `Address` | Certificate recipient                         |
+| `amount`     | `i128`    | Escrow amount at time of minting               |
+| `created_at` | `u32`     | Ledger sequence at mint time                   |
 
 ### `Rating`
 
-| Field                | Type      | Description                              |
-|----------------------|-----------|------------------------------------------|
-| `job_id`             | `String`  | Associated job                           |
-| `rater`              | `Address` | Who submitted the rating                 |
-| `rated`              | `Address` | Who was rated                            |
-| `score_out_of_5`     | `u32`     | Score 1–5                                |
-| `submitted_at_ledger`| `u32`     | Ledger when rating was stored            |
+| Field                 | Type      | Description                              |
+|-----------------------|-----------|----------------------------------------------|
+| `job_id`              | `String`  | Associated job                                |
+| `rater`               | `Address` | Who submitted the rating                       |
+| `rated`               | `Address` | Who was rated                                  |
+| `score_out_of_5`      | `u32`     | Score 1–5                                       |
+| `submitted_at_ledger` | `u32`     | Ledger when rating was stored                    |
 
----
+### `FreelancerRatingStats`
+
+| Field         | Type  | Description                                     |
+|---------------|-------|---------------------------------------------------|
+| `total_score` | `u32` | Sum of all `score_out_of_5` values received         |
+| `count`       | `u32` | Number of ratings received (average = total/count)  |
 
 ### `Proposal` (Governance)
 
 | Field             | Type      | Description                                  |
-|-------------------|-----------|----------------------------------------------|
-| `id`              | `u32`     | Sequential proposal ID (starts at 1)         |
-| `title`           | `String`  | Short proposal title                         |
-| `description`     | `String`  | Full proposal text                           |
-| `votes_for`       | `u32`     | Count of approving votes                     |
-| `votes_against`   | `u32`     | Count of rejecting votes                     |
-| `deadline_ledger` | `u32`     | Voting closes at this ledger sequence        |
-| `resolved`        | `bool`    | Whether the vote has been finalized          |
-| `result`          | `bool`    | `true` = passed (`votes_for > votes_against`)|
-
----
-
-### `ArbitrationCase`
-
-| Field         | Type           | Description                              |
-|---------------|----------------|------------------------------------------|
-| `job_id`      | `String`       | Disputed job                             |
-| `arbitrators` | `Vec<Address>` | 3 selected arbitrators                   |
-| `votes`       | `Vec<u32>`     | Each arbitrator's `client_percent` (0–100)|
-| `resolution`  | `u32`          | Median vote = client's share of funds    |
-| `status`      | `u32`          | `0` = open, `1` = resolved               |
+|-------------------|-----------|-------------------------------------------------|
+| `id`              | `u32`     | Sequential proposal ID (starts at 1)              |
+| `title`           | `String`  | Short proposal title                               |
+| `description`     | `String`  | Full proposal text                                  |
+| `votes_for`       | `u32`     | Count of approving votes                             |
+| `votes_against`   | `u32`     | Count of rejecting votes                              |
+| `deadline_ledger` | `u32`     | Voting closes at this ledger sequence                  |
+| `resolved`        | `bool`    | Whether the vote has been finalized                     |
+| `result`          | `bool`    | `true` = passed (`votes_for > votes_against`)             |
 
 ---
 
 ## Storage Keys
 
-| Key                               | Value Type               | Description                               |
-|-----------------------------------|--------------------------|-------------------------------------------|
-| `Admin`                           | `Address`                | Contract administrator                    |
-| `EscrowCount`                     | `u32`                    | Total escrows ever created                |
-| `Escrow(job_id)`                  | `Escrow`                 | Escrow record per job                     |
-| `TimeoutTimestamp(job_id)`        | `u32`                    | Unix timestamp for timeout eligibility    |
-| `BudgetCommitment(job_id)`        | `BudgetCommitment`       | Sealed budget per job                     |
-| `BidCommitment(job_id, address)`  | `BidCommitment`          | Sealed bid per freelancer per job         |
-| `BiddingState(job_id)`            | `BiddingState`           | Bidding session state                     |
-| `RevealedBids(job_id)`            | `Vec<RevealedBid>`       | All revealed bids for a job               |
-| `DeliverableSubmission(job_id)`   | `DeliverableSubmission`  | Deliverable match state                   |
-| `Certificate(job_id)`             | `Certificate`            | Completion certificate per job            |
-| `FreelancerCertificates(address)` | `Vec<String>`            | All job IDs a freelancer has certs for    |
-| `ClientRating(job_id)`            | `Rating`                 | Client-to-freelancer rating               |
-| `FreelancerRating(job_id)`        | `Rating`                 | Freelancer-to-client rating               |
-| `FreelancerRatingStats(address)`  | `FreelancerRatingStats`  | Rolling total_score + count               |
-| `Proposal(id)`                    | `Proposal`               | Governance proposal by ID                 |
-| `ProposalCount`                   | `u32`                    | Total proposals created                   |
-| `HasVoted(address, proposal_id)`  | `bool`                   | Prevents double-voting                    |
-| `CompletedJobs(address)`          | `u32`                    | Completed job count per address           |
-| `DefaultTimeoutSeconds`           | `u32`                    | Global default escrow timeout in seconds  |
-| `TreasuryAddress`                 | `Address`                | Address receiving platform fees           |
-| `PlatformFeeBps`                  | `u32`                    | Platform fee in basis points (default 100)|
-| `Admins`                          | `Vec<Address>`           | Multi-sig admin list                      |
-| `Frozen`                          | `bool`                   | Global freeze flag                        |
-| `UnfreezeThreshold`               | `u32`                    | Required M-of-N admin signatures to unfreeze |
-| `MaxReferrerBonusXlm`          | `i128`                   | Admin-set cap on referrer bonus payouts   |
-| `ExtensionRequest(job_id)`     | `ExtensionRequest`       | Pending timeout extension request         |
-| `DisputeBondConfig`            | `DisputeBondConfig`      | Global dispute bond configuration         |
-| `DisputeBond(job_id)`          | `DisputeBond`            | Per-job locked dispute bond record        |
-| `FreelancerDeliverableHash(job_id)` | `BytesN<32>`          | Freelancer-submitted deliverable SHA-256  |
-| `EvidenceCids(job_id)`         | `Vec<Bytes>`             | Dispute-evidence IPFS CID audit trail     |
-| `Arbitrator(address)`             | `bool`                   | Whether address is a registered arbitrator|
-| `ArbitratorPool`                  | `Vec<Address>`           | All registered arbitrators                |
-| `ArbitrationCase(case_id)`        | `ArbitrationCase`        | Arbitration case by ID                    |
-| `ArbitrationCaseCount`            | `u32`                    | Total arbitration cases                   |
-| `MessageCid(job_id)`              | `Vec<String>`            | IPFS CIDs for job thread messages         |
-| `Version`                         | `u32`                    | Contract version (starts at 1)            |
+`DataKey` enum variants used as instance-storage keys in `MarketPayContract`:
+
+| Key                                 | Value Type               | Description                                  |
+|--------------------------------------|---------------------------|-------------------------------------------------|
+| `Admin`                              | `Address`                 | Legacy single-admin field                        |
+| `Admins`                             | `Vec<Address>`             | Multi-sig admin list                              |
+| `UnfreezeThreshold`                  | `u32`                      | M-of-N admin signatures required to unfreeze        |
+| `Frozen`                             | `bool`                     | Global freeze flag                                   |
+| `EscrowCount`                        | `u32`                      | Total escrows ever created                            |
+| `Escrow(job_id)`                     | `Escrow`                   | Escrow record per job                                  |
+| `TimeoutTimestamp(job_id)`           | `u32`                      | Unix timestamp for timeout eligibility                  |
+| `DefaultTimeoutSeconds`              | `u32`                      | Global default escrow timeout in seconds                 |
+| `ExtensionRequest(job_id)`           | `ExtensionRequest`         | Pending timeout extension request                          |
+| `TreasuryAddress`                    | `Address`                  | Address receiving platform fees                              |
+| `PlatformFeeBps`                     | `u32`                      | Platform fee in basis points (default 100 = 1%)                |
+| `MaxReferrerBonusXlm`                | `Option<i128>`             | Admin-set cap on referrer bonus payouts (`None` = uncapped)      |
+| `BudgetCommitment(job_id)`           | `BudgetCommitment`         | Sealed budget per job                                              |
+| `BidCommitment(job_id, address)`     | `BidCommitment`            | Sealed bid per freelancer per job                                   |
+| `BiddingState(job_id)`               | `BiddingState`             | Bidding session state                                                |
+| `RevealedBids(job_id)`               | `Vec<RevealedBid>`         | All revealed bids for a job                                           |
+| `DeliverableSubmission(job_id)`      | `DeliverableSubmission`    | Deliverable match state (client/freelancer hash submission flags)      |
+| `FreelancerDeliverableHash(job_id)`  | `BytesN<32>`               | Freelancer-submitted deliverable SHA-256                                 |
+| `EvidenceCids(job_id)`               | `Vec<Bytes>`               | Dispute-evidence IPFS CID audit trail                                     |
+| `Certificate(job_id)`                | `Certificate`              | Completion certificate per job                                             |
+| `FreelancerCertificates(address)`    | `Vec<String>`              | All job IDs a freelancer holds certificates for                             |
+| `ClientRating(job_id)`               | `Rating`                   | Client-to-freelancer rating                                                  |
+| `FreelancerRating(job_id)`           | `Rating`                   | Freelancer-to-client rating                                                   |
+| `FreelancerRatingStats(address)`     | `FreelancerRatingStats`    | Rolling total_score + count                                                     |
+| `Proposal(id)`                       | `Proposal`                 | Governance proposal by ID                                                        |
+| `ProposalCount`                      | `u32`                      | Total proposals created                                                           |
+| `HasVoted(address, proposal_id)`     | `bool`                     | Prevents double-voting                                                             |
+| `CompletedJobs(address)`             | `u32`                      | Completed job count per address (voting eligibility gate)                           |
+| `DisputeBondConfig`                  | `DisputeBondConfig`        | Global dispute bond configuration                                                     |
+| `DisputeBond(job_id)`                | `DisputeBond`              | Per-job locked dispute bond record                                                      |
+| `Arbitrator(address)`                | `bool`                     | Whether `address` was ever set via `set_arbitrator` (legacy single-arbitrator model)      |
+| `ArbitratorPool`                     | `Vec<Address>`             | Declared but not populated by any public entrypoint as of this writing                      |
+| `ArbitratorAddress`                  | `Address`                  | The single arbitrator set by `set_arbitrator` / read by `get_arbitrator`                       |
+| `ArbitrationCase(case_id)`           | `ArbitrationCase`          | Arbitration case by ID                                                                            |
+| `ArbitrationCaseCount`               | `u32`                      | Declared; not incremented by any public entrypoint as of this writing (no case-creation fn)         |
+| `DisputeCase(job_id)`                | `DisputeCase`              | Declared; unused (see `DisputeCase` in Data Types)                                                    |
+| `MessageCid(job_id)`                 | `Vec<String>`              | IPFS CIDs for job thread messages                                                                       |
+| `Version`                            | `u32`                      | Contract version, bumped by `upgrade()` (starts at 1)                                                     |
 
 ---
 
 ## Events Reference
 
-Events are emitted as `env.events().publish((topic_symbol, subtopic), data)`.
+Events are emitted as `env.events().publish((topic_symbol, subtopic), data)`. Only events actually present in `lib.rs` are listed — several administrative functions (`upgrade`, `set_arbitrator`, `set_default_timeout_seconds`, `add_admin`, `set_unfreeze_threshold`, `set_dispute_bond`) currently emit **no** event and are marked as such below.
 
-| Symbol      | Topic                        | Data                                                    | Emitted By                          |
-|-------------|------------------------------|---------------------------------------------------------|-------------------------------------|
-| `escrow_cr` | `(escrow_cr, job_id)`        | `(client, freelancer, amount)`                          | `create_escrow`                     |
-| `work_strt` | `(work_strt, job_id)`        | `(client, freelancer)`                                  | `start_work`                        |
-| `escrow_rl` | `(escrow_rl, job_id)`        | `(client, freelancer, freelancer_amount, referral_amount, fee_amount)` | `release_escrow`, `release_with_conversion` |
-| `ref_bon`   | `(ref_bon, referrer)`        | `(job_id, bonus_amount)`                                | `release_escrow` with referrer      |
-| `escrow_rf` | `(escrow_rf, job_id)`        | `(client, freelancer, amount)`                          | `refund_escrow`, `timeout_refund`   |
-| `escrow_ds` | `(escrow_ds, job_id)`        | `(client, freelancer, caller)`                          | `raise_dispute`                     |
-| `milestone_released` | `(milestone_released, job_id)` | `(client, freelancer, milestone_id, amount)`     | `release_milestone`                   |
-| `milestone_rejected` | `(milestone_rejected, job_id)` | `(client, freelancer, milestone_index, refund)`  | `reject_milestone`                   |
-| `boosted`   | `(boosted, client)`          | `(job_id, expiry_ledger, amount)`                       | `boost_job`                         |
-| `budgtcmt`  | `(budgtcmt, client)`         | `job_id`                                                | `commit_budget`                     |
-| `budgrvld`  | `(budgrvld, client)`         | `budget_amount`                                         | `reveal_budget`                     |
-| `bid_cmt`   | `(bid_cmt, job_id)`          | `freelancer`                                            | `submit_bid_commitment`             |
-| `bid_cls`   | `(bid_cls, job_id)`          | `reveal_deadline_ledger`                                | `close_bidding`                     |
-| `bid_rvl`   | `(bid_rvl, job_id)`          | `(freelancer, amount)`                                  | `reveal_bid`                        |
-| `clthash`   | `(clthash, client)`          | `job_id`                                                | `submit_client_deliverable`         |
-| `frelhash`  | `(frelhash, freelancer)`     | `job_id`                                                | `submit_freelancer_deliverable`     |
-| `dlv_ok`    | `(dlv_ok, job_id)`           | `(caller, actual_hash)`                                 | `submit_deliverable` (hash match)   |
-| `dlv_bad`   | `(dlv_bad, job_id)`          | `(caller, actual_hash)`                                 | `submit_deliverable` (hash mismatch)|
-| `certmnt`   | `(certmnt, client)`          | `(job_id, amount)`                                      | `mint_certificate`                  |
-| `msg_sent`  | `(msg_sent, job_id)`         | `(sender, recipient, ipfs_cid, ledger_seq)`             | `publish_message`                   |
-| `proposed`  | `(proposed, proposer)`       | `(proposal_id, title, deadline_ledger)`                 | `create_proposal`                   |
-| `voted`     | `(voted, voter)`             | `(proposal_id, approve)`                                | `cast_vote`                         |
-| `resolved`  | `(resolved, proposal_id)`    | `(result, votes_for, votes_against)`                    | `resolve_proposal`                  |
-| `arb_res`   | `(arb_res, case_id)`         | `resolution` (client_percent)                           | `resolve_arbitration`               |
-| `upgraded`  | `(upgraded, admin)`          | `new_version`                                           | `upgrade`                           |
-| `timeout`   | `(timeout, admin)`           | `timeout_seconds`                                       | `set_default_timeout_seconds`       |
+| Symbol         | Topic                          | Data                                                                    | Emitted By                                    |
+|----------------|----------------------------------|----------------------------------------------------------------------------|--------------------------------------------------|
+| `escrow_cr`    | `(escrow_cr, job_id)`             | `(client, freelancer, amount)`                                              | `create_escrow`, `create_escrow_with_deliverable`, `create_escrow_with_milestones` |
+| `work_strt`    | `(work_strt, job_id)`             | `(client, freelancer)`                                                       | `start_work`                                       |
+| `plat_fee`     | `(plat_fee, job_id)`              | `(treasury, fee_amount)`                                                      | `release_escrow`, `release_with_conversion`, `release_milestone` (when fee > 0) |
+| `ref_bon`      | `(ref_bon, referrer)`             | `(job_id, bonus_amount)`                                                       | `release_escrow` (when a referrer bonus is paid)     |
+| `escrow_rl`    | `(escrow_rl, job_id)`             | `(client, freelancer, freelancer_amount, referral_amount, fee_amount)`          | `release_escrow`, `release_with_conversion`, `submit_deliverable` (on hash match) |
+| `escrow_rf`    | `(escrow_rf, job_id)`             | `(client, freelancer, amount)`                                                    | `refund_escrow`, `timeout_refund`                     |
+| `set_fee`      | `(set_fee, admin)`                | `bps`                                                                              | `set_platform_fee_bps`                                 |
+| `ref_cap`      | `(ref_cap, admin)`                | `cap`                                                                              | `set_max_referrer_bonus_xlm`                            |
+| `frozen`       | `(frozen, admin)`                 | `true`                                                                             | `freeze_contract`                                        |
+| `ext_req`      | `(ext_req, job_id)`               | `(caller, new_timeout_ledger)`                                                     | `request_extension`                                       |
+| `ext_app`      | `(ext_app, job_id)`               | `(caller, requested_by, new_timeout_ledger)`                                        | `approve_extension`                                         |
+| `msg_sent`     | `(msg_sent, job_id)`              | `(sender, recipient, ipfs_cid, ledger_seq)`                                          | `publish_message`                                            |
+| `proposed`     | `(proposed, proposer)`            | `(proposal_id, title, deadline_ledger)`                                               | `create_proposal`                                              |
+| `voted`        | `(voted, voter)`                  | `(proposal_id, approve)`                                                               | `cast_vote`                                                      |
+| `resolved`     | `(resolved, proposal_id)`         | `(result, votes_for, votes_against)`                                                     | `resolve_proposal`                                                 |
+| `bond_lck`     | `(bond_lck, job_id)`              | `(caller, token, amount)`                                                                 | `raise_dispute` (when a `DisputeBondConfig` is set)                   |
+| `escrow_ds`    | `(escrow_ds, job_id)`             | `(client, freelancer, caller)`                                                              | `raise_dispute` (both bonded and legacy zero-cost paths)                 |
+| `bond_rtn`     | `(bond_rtn, job_id)`              | `(caller, amount)`                                                                            | `resolve_dispute` (when the bond-poster wins)                              |
+| `bond_slsh`    | `(bond_slsh, job_id)`             | `(winner, amount)`                                                                              | `resolve_dispute` (when the bond-poster loses)                               |
+| `dsp_res`      | `(dsp_res, job_id)`               | `(arbitrator, winner, split_percentage, ...)`                                                     | `resolve_dispute`                                                               |
+| `arb_rsl`      | `(arb_rsl, case_id)`              | `resolution`                                                                                        | `resolve_arbitration`                                                             |
+| `milestone_released` | `(milestone_released, job_id)` | `(client, freelancer, milestone_id, amount)`                                                   | `release_milestone`                                                                  |
+| `milestone_rejected` | `(milestone_rejected, job_id)` | `(client, freelancer, milestone_index, refund)`                                                | `reject_milestone`                                                                     |
+| `boosted`      | `(boosted, client)`               | `(job_id, expiry_ledger, amount)`                                                                    | `boost_job`                                                                              |
+| `budgtcmt`     | `(budgtcmt, client)`              | `job_id`                                                                                               | `commit_budget`                                                                            |
+| `budgrvld`     | `(budgrvld, client)`              | `budget_amount`                                                                                        | `reveal_budget`                                                                              |
+| `bid_cmt`      | `(bid_cmt, job_id)`               | `freelancer`                                                                                             | `submit_bid_commitment`                                                                        |
+| `bid_cls`      | `(bid_cls, job_id)`               | `reveal_deadline_ledger`                                                                                  | `close_bidding`                                                                                  |
+| `bid_rvl`      | `(bid_rvl, job_id)`               | `(freelancer, amount)`                                                                                    | `reveal_bid`                                                                                       |
+| `evd_add`      | `(evd_add, job_id)`               | `(caller, ledger_seq)`                                                                                     | `submit_evidence_cid`                                                                                |
+
+**No event emitted** by: `initialize`, `upgrade`, `get_version` (getter), `set_arbitrator`, `get_arbitrator` (getter), `set_treasury_address`, `set_default_timeout_seconds`, `unfreeze_contract`, `add_admin`, `set_unfreeze_threshold`, `set_dispute_bond`, `mint_certificate`, `submit_client_deliverable`, `submit_freelancer_deliverable`, `submit_deliverable_hash`, `submit_client_rating`, `submit_freelancer_rating`, and all read-only getters.
 
 ---
 
-## Initialization
+## Initialization & Versioning
 
 ### `initialize`
 
@@ -292,10 +371,29 @@ Events are emitted as `env.events().publish((topic_symbol, subtopic), data)`.
 pub fn initialize(env: Env, admin: Address, treasury_address: Address)
 ```
 
-Must be called **once** immediately after deployment. Stores the admin address and treasury address, sets the platform fee to 100 bps (1 %), escrow counter to 0, default timeout to 7 days (604,800 seconds), freeze threshold to 2, admin list to `[admin]`, and `Version` to 1.
+Must be called **once** immediately after deployment. Stores the admin address and treasury address, sets the platform fee to 100 bps (1%), escrow counter to 0, default timeout to 7 days (604,800 seconds), unfreeze threshold to 2, admin list to `[admin]`, and `Version` to 1.
 
-**Auth required:** None (open — call immediately to claim admin).
+**Auth required:** None (open — call immediately after deploy to claim admin).
 **Panics:** `"Already initialized"` if called again.
+
+### `upgrade`
+
+```rust
+pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>)
+```
+
+Admin-only. Deploys a new WASM implementation via `env.deployer().update_current_contract_wasm(new_wasm_hash)` and increments the stored `Version`. All existing contract storage (escrows, proposals, etc.) is preserved across the upgrade.
+
+**Auth required:** admin (via `require_auth` on the stored admin address).
+**Emits:** nothing.
+
+### `get_version`
+
+```rust
+pub fn get_version(env: Env) -> u32
+```
+
+Returns the current contract version (starts at 1, incremented once per `upgrade()` call).
 
 ---
 
@@ -304,19 +402,20 @@ Must be called **once** immediately after deployment. Stores the admin address a
 ### State Machine
 
 ```
-              create_escrow() / create_escrow_with_milestones()
+              create_escrow() / create_escrow_with_deliverable()
+              create_escrow_with_milestones()
                     │
                     ▼
-               ┌─────────┐
+               ┌──────────┐
                │  Locked  │
-               └─────────┘
-              /           \
+               └──────────┘
+              /            \
         start_work()    refund_escrow()
-            /             or timeout_refund()
-           ▼                    ▼
-    ┌────────────┐       ┌──────────┐
-    │ InProgress │       │ Refunded │  (terminal)
-    └────────────┘       └──────────┘
+            /               or timeout_refund()
+           ▼                       ▼
+    ┌────────────┐          ┌──────────┐
+    │ InProgress │          │ Refunded │  (terminal)
+    └────────────┘          └──────────┘
          │  \
          │   raise_dispute()
          │         ▼
@@ -324,16 +423,18 @@ Must be called **once** immediately after deployment. Stores the admin address a
          │    │ Disputed │ ← release_milestone() / reject_milestone() still work here
          │    └──────────┘
          │         │
-    release_escrow()
+    release_escrow() / release_with_conversion()
     — or —
-    release_milestone() on last remaining milestone
+    submit_deliverable() on hash match
+    — or —
+    release_milestone() on the last remaining milestone
+    — or —
+    resolve_dispute() (arbitrator-only, from Disputed)
          ▼
     ┌──────────┐
     │ Released │  (terminal)
     └──────────┘
 ```
-
----
 
 ### `create_escrow`
 
@@ -341,20 +442,18 @@ Must be called **once** immediately after deployment. Stores the admin address a
 pub fn create_escrow(env: Env, job_id: String, client: Address, params: CreateEscrowParams)
 ```
 
-Transfers `params.amount` tokens from `client` into the contract and stores the escrow record. Status starts as `Locked`. Emits `escrow_cr`.
+Transfers `params.amount` tokens from `client` into the contract and stores a new `Escrow` with status `Locked`. Emits `escrow_cr`.
 
 **Auth required:** `client`
 
-| Panic message | Condition |
+| Panic condition | Error |
 |---|---|
-| `"Amount must be positive"` | `amount ≤ 0` |
-| `"Referrer cannot be the client or freelancer"` | referrer == client or freelancer |
-| `"Maximum 5 milestones allowed"` | more than 5 milestones provided |
-| `"Milestone amount must be positive"` | any milestone ≤ 0 |
-| `"Milestone amounts must sum to total escrow amount"` | sum of milestones ≠ `amount` |
-| `"Escrow already exists for this job"` | duplicate `job_id` |
-
----
+| `amount ≤ 0` | `AmountMustBePositive (2001)` |
+| `referrer == client` or `referrer == freelancer` | `InvalidReferrer (2002)` |
+| duplicate `job_id` | `EscrowAlreadyExists (2003)` |
+| more than 5 milestones | `MaxMilestones (3001)` |
+| any milestone percentage ≤ 0 | `MilestonePercentagePositive (3002)` |
+| milestone percentages don't sum to 100 | `MilestonePercentagesSum (3003)` |
 
 ### `create_escrow_with_deliverable`
 
@@ -368,9 +467,19 @@ pub fn create_escrow_with_deliverable(
 )
 ```
 
-Same as `create_escrow` but stores a SHA-256 expected deliverable hash. Calling `submit_deliverable()` with a matching hash later auto-releases the escrow.
+Same as `create_escrow`, but also stores an expected SHA-256 `deliverable_hash` on the escrow. `release_escrow` will require a matching freelancer-submitted hash (via `submit_deliverable_hash`) before it will pay out. Emits `escrow_cr`.
 
----
+**Auth required:** `client`
+
+### `create_escrow_with_milestones`
+
+```rust
+pub fn create_escrow_with_milestones(env: Env, job_id: String, client: Address, params: CreateEscrowParams)
+```
+
+Identical code path to `create_escrow` — the distinct name documents intent for callers that are populating `params.milestones`. Milestone percentages must sum to 100 (max 5 milestones). Emits `escrow_cr`.
+
+**Auth required:** `client`
 
 ### `start_work`
 
@@ -378,12 +487,10 @@ Same as `create_escrow` but stores a SHA-256 expected deliverable hash. Calling 
 pub fn start_work(env: Env, job_id: String, freelancer: Address)
 ```
 
-Transitions `Locked` → `InProgress`. Emits `work_strt`.
+Transitions the escrow from `Locked` to `InProgress`. Emits `work_strt`.
 
-**Auth required:** `freelancer`
-**Panics:** `"Only the freelancer can start work"`, `"Escrow is not in Locked state"`
-
----
+**Auth required:** `freelancer` (must match `escrow.freelancer`)
+**Panics:** `OnlyFreelancerCanStartWork (2005)`, `EscrowNotLocked (2006)`
 
 ### `release_escrow`
 
@@ -391,21 +498,10 @@ Transitions `Locked` → `InProgress`. Emits `work_strt`.
 pub fn release_escrow(env: Env, job_id: String, client: Address)
 ```
 
-Releases all remaining (unreleased) funds to the freelancer. For milestone escrows, only unreleased milestone amounts are paid out — not the full escrow total. Marks all milestones as completed. Transitions to `Released`. Increments `CompletedJobs` for both parties. Emits `escrow_rl` and optionally `ref_bon`.
-
-If a `deliverable_hash` was set during creation, the freelancer must have submitted a matching hash before release.
+Client-only release. If the escrow has an expected `deliverable_hash`, it must match the freelancer-submitted hash first (`DeliverableHashMismatch (2009)`). Pays the platform fee (`plat_fee` event) to the treasury, then a referrer bonus (`ref_bon` event) if a referrer is set — capped by `MaxReferrerBonusXlm` when configured, otherwise a flat 2% — then the remainder to the freelancer. Sets status `Released` and increments `CompletedJobs` for both client and freelancer (governance voting eligibility). Emits `escrow_rl`.
 
 **Auth required:** `client`
-**Precondition:** Status must be `InProgress` or `Locked`.
-
-**Platform fee:** A configurable percentage (default 100 bps = 1 %) is deducted and sent to the treasury address before the remaining funds are distributed.
-
-**Referral split (when `referrer` is set):**
-- Platform fee: `amount × fee_bps / 10_000`
-- Referrer: `(amount − fee) × 200 / 10_000` (2%)
-- Freelancer: `(amount − fee) − referral_amount`
-
----
+**Panics:** `OnlyClientCanRelease (2007)`, `CannotReleaseStatus (2008)`, `DeliverableHashMismatch (2009)`
 
 ### `release_with_conversion`
 
@@ -419,11 +515,9 @@ pub fn release_with_conversion(
 )
 ```
 
-Intended to route released funds through an on-chain DEX before delivery. Currently transfers the source token directly — DEX swap integration is planned (Issue #104). Emits `escrow_rl`.
+Client-only release variant intended to support paying the freelancer out in a different asset via a DEX swap. **As currently implemented, the DEX swap is not wired up** — it transfers the escrow's original token directly, applying the platform fee but **not** the referrer bonus. The `_target_token` and `_min_amount_out` parameters are accepted but unused. Treat this entrypoint as a placeholder pending real cross-asset conversion support. Emits `escrow_rl`.
 
 **Auth required:** `client`
-
----
 
 ### `refund_escrow`
 
@@ -431,12 +525,10 @@ Intended to route released funds through an on-chain DEX before delivery. Curren
 pub fn refund_escrow(env: Env, job_id: String, client: Address)
 ```
 
-Returns all funds to the client. Only available before work has started (`Locked`). Emits `escrow_rf`.
+Client-only. Only allowed while status is `Locked` (before `start_work`). Refunds the full amount to the client and sets status `Refunded`. Emits `escrow_rf`.
 
 **Auth required:** `client`
-**Panics:** `"Can only refund before work has started"`
-
----
+**Panics:** `OnlyClientCanRefund (2010)`, `CanOnlyRefundLocked (2011)`
 
 ### `timeout_refund`
 
@@ -444,68 +536,104 @@ Returns all funds to the client. Only available before work has started (`Locked
 pub fn timeout_refund(env: Env, job_id: String, client: Address)
 ```
 
-Client claims a refund if the freelancer never started work before the timeout expired. Checks the Unix timestamp stored at creation; falls back to ledger-sequence comparison for escrows created without a timestamp. Emits `escrow_rf`.
+Client-only. Refunds the escrow if the timeout has elapsed while status is still `Locked`. Uses the Unix-timestamp timeout when set (current path), falling back to the legacy ledger-sequence timeout for older escrows. Emits `escrow_rf`.
 
 **Auth required:** `client`
-**Panics:** `"Escrow is not in Locked state"`, `"Timeout period has not expired yet"`
+**Panics:** `OnlyClientCanTimeoutRefund (2012)`, `TimeoutNotExpired (2013)`
 
 ---
 
-### `create_escrow_with_milestones`
+## Escrow Getters
 
-```rust
-pub fn create_escrow_with_milestones(env: Env, job_id: String, client: Address, params: CreateEscrowParams)
-```
+All read-only, no auth required, no events emitted.
 
-Convenience wrapper around `create_escrow` for percentage-based milestones. Milestone percentages must sum to exactly 100. Maximum 5 milestones allowed. Each milestone receives its percentage share of the total escrow amount.
-
-**Auth required:** `client`
-**Panics:** same as `create_escrow` plus `"Milestone percentage must be positive"`, `"Milestone percentages must sum to 100"`
-
----
-
-### `release_milestone`
-
-```rust
-pub fn release_milestone(env: Env, job_id: String, milestone_id: u32, client: Address)
-```
-
-Releases a single milestone's funds to the freelancer. The milestone is identified by its `id` field (assigned at creation). Transfers the milestone's percentage share of the total escrow (minus platform fee) to the freelancer. If this is the final unresolved milestone (all are now released or rejected), the escrow transitions to `Released` and `CompletedJobs` is incremented for both parties. The platform fee is applied to each milestone release independently.
-
-Works even when the escrow is `Disputed` — clients can still release completed milestone work while a dispute is in progress. Emits `milestone_released`.
-
-**Auth required:** `client`
-**Precondition:** Status must be `InProgress`, `Locked`, or `Disputed`.
-**Panics:** `"Only the client can release a milestone"`, `"Cannot release milestone in current status"`, `"Invalid milestone id"`, `"Milestone already released"`, `"Milestone already rejected"`
+| Function | Signature | Returns | Description |
+|---|---|---|---|
+| `get_escrow` | `(env, job_id: String)` | `Escrow` | Full escrow record |
+| `get_status` | `(env, job_id: String)` | `EscrowStatus` | Current status enum |
+| `get_timeout_ledger` | `(env, job_id: String)` | `u32` | Legacy ledger-sequence timeout |
+| `get_timeout_timestamp` | `(env, job_id: String)` | `u32` | Unix-timestamp timeout (0 if unset) |
+| `get_milestone` | `(env, job_id: String, index: u32)` | `Milestone` | Single milestone by index; panics `InvalidMilestoneIndex (3006)` out of bounds |
+| `is_frozen` | `(env)` | `bool` | Global freeze flag |
+| `get_referrer` | `(env, job_id: String)` | `Option<Address>` | Referrer for a job's escrow, if any |
+| `get_escrow_count` | `(env)` | `u32` | Total escrows ever created |
+| `get_admin` | `(env)` | `Address` | The legacy single-admin field (distinct from the `Admins` multisig list) |
+| `get_treasury_address` | `(env)` | `Address` | Platform fee recipient |
+| `get_platform_fee_bps` | `(env)` | `u32` | Current platform fee in basis points |
 
 ---
 
-### `reject_milestone`
+## Single Arbitrator (Legacy)
 
-```rust
-pub fn reject_milestone(env: Env, job_id: String, milestone_index: u32, client: Address)
-```
+A single-address arbitrator field used by `resolve_dispute`. Distinct from the separate [`ArbitratorRegistry`](#arbitrator-registry-contract) contract, which manages a staked pool of arbitrators but is not currently wired into dispute resolution.
 
-Client rejects a single milestone and its percentage share of the escrow is refunded back to the client. Remaining milestones stay locked in the contract. If all milestones become resolved, the escrow transitions to `Released`. Emits `milestone_rejected`.
-
-**Auth required:** `client`
-**Precondition:** Status must be `InProgress`, `Locked`, or `Disputed`.
-**Panics:** `"Only the client can reject a milestone"`, `"Cannot reject milestone in current status"`, `"Invalid milestone id"`, `"Milestone already released"`, `"Milestone already rejected"`
+| Function | Signature | Returns | Description |
+|---|---|---|---|
+| `set_arbitrator` | `(env, admin: Address, arbitrator: Address)` | `()` | Admin-only; sets the sole address allowed to call `resolve_dispute`. No event emitted. |
+| `get_arbitrator` | `(env)` | `Option<Address>` | Currently configured arbitrator, if any |
 
 ---
 
-### `get_milestone`
+## Admin, Treasury & Fee Configuration
 
-```rust
-pub fn get_milestone(env: Env, job_id: String, index: u32) -> Milestone
-```
-
-Returns a single `Milestone` by its array index (0-based position in the milestones list).
-
-**Auth required:** None
-**Panics:** `"Escrow not found"`, `"Milestone index out of bounds"`
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `set_treasury_address` | `(env, admin: Address, treasury_address: Address)` | `()` | admin | `OnlyAdminSetTreasury (1010)`. No event. |
+| `set_platform_fee_bps` | `(env, admin: Address, bps: u32)` | `()` | admin | `bps` must be ≤ 1000 (10%) — `PlatformFeeExceedsMax (1012)`. Emits `set_fee`. |
+| `get_default_timeout_seconds` | `(env)` | `u32` | — | Current global default escrow timeout |
+| `set_default_timeout_seconds` | `(env, admin: Address, timeout_seconds: u32)` | `()` | admin | Must be > 0 — `TimeoutMustBePositive (1024)`. No event. |
+| `get_max_referrer_bonus_xlm` | `(env)` | `Option<i128>` | — | `None` = uncapped legacy 2% behavior |
+| `set_max_referrer_bonus_xlm` | `(env, admin: Address, cap: i128)` | `()` | admin | `cap ≥ 0` (0 disables referrer program) — `ReferrerCapNegative (1022)`. Emits `ref_cap`. |
 
 ---
+
+## Multi-Sig Admin & Freeze Governance
+
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `freeze_contract` | `(env, admin: Address)` | `()` | any address in `Admins` | Blocks all state-mutating calls guarded by the internal `check_not_frozen` gate. Emits `frozen`. |
+| `unfreeze_contract` | `(env, admins: Vec<Address>)` | `()` | ≥ `UnfreezeThreshold` distinct admins, each via `require_auth` | `InsufficientSignatures (1014)`, `NotAnAdmin (1015)`, `DuplicateAdminSignature (1016)`. No event. |
+| `add_admin` | `(env, admin: Address, new_admin: Address)` | `()` | existing admin | `OnlyAdminCanAddAdmin (1017)`, `AlreadyAdmin (1018)`. No event. |
+| `set_unfreeze_threshold` | `(env, admin: Address, threshold: u32)` | `()` | existing admin | Threshold must be between 1 and `admins.len()` — `InvalidThreshold (1020)`. No event. |
+| `get_admins` | `(env)` | `Vec<Address>` | — | Full multisig admin list |
+| `get_unfreeze_threshold` | `(env)` | `u32` | — | Current M-of-N threshold (default 2) |
+
+---
+
+## Escrow Timeout Extension
+
+Mutual-consent extension of an escrow's timeout, requested by either participant and approved by the other.
+
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `request_extension` | `(env, job_id: String, caller: Address, new_timeout_ledger: u32)` | `()` | client or freelancer | Only while `Locked`/`InProgress`; one pending request per job — `ExtensionAlreadyPending (9006)`, `NewTimeoutMustBeLater (9005)`. Emits `ext_req`. |
+| `approve_extension` | `(env, job_id: String, caller: Address)` | `()` | the *other* participant | `CannotApproveOwnExtension (9008)`, `NoPendingExtension (9007)`. Updates `timeout_ledger` and recalculates the Unix-timestamp timeout (~5s/ledger). Emits `ext_app`. |
+| `get_extension_request` | `(env, job_id: String)` | `Option<ExtensionRequest>` | — | Pending extension request for a job, if any |
+
+---
+
+## On-Chain Message Notarization
+
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `publish_message` | `(env, job_id: String, sender: Address, recipient: Address, ipfs_cid: String)` | `()` | `sender` | Records an off-chain (IPFS-stored) message's CID on-chain, appended to a per-job list. Emits `msg_sent`. |
+| `get_message_cids` | `(env, job_id: String)` | `Vec<String>` | — | All message CIDs recorded for a job |
+
+---
+
+## Governance (DAO Proposals)
+
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `create_proposal` | `(env, proposer: Address, title: String, description: String, duration_ledgers: u32)` | `u32` (proposal id) | `proposer` | `DurationPositive (6001)`. Emits `proposed`. |
+| `cast_vote` | `(env, voter: Address, proposal_id: u32, approve: bool)` | `()` | `voter`, requires ≥ 1 completed job | `OnlyCompletedJobsCanVote (6005)`, `AlreadyVoted (6006)`, `VotingPeriodEnded (6004)`. Emits `voted`. |
+| `resolve_proposal` | `(env, proposal_id: u32)` | `()` | anyone, after the deadline | `VotingNotOver (6007)`. Sets `resolved = true`, `result = votes_for > votes_against`. Emits `resolved`. |
+| `get_proposal` | `(env, id: u32)` | `Proposal` | — | Full proposal record; `ProposalNotFound (6002)` |
+| `list_active_proposals` | `(env)` | `Vec<Proposal>` | — | All proposals with `resolved == false` |
+
+---
+
+## Disputes & Dispute Bonds
 
 ### `raise_dispute`
 
@@ -513,671 +641,341 @@ Returns a single `Milestone` by its array index (0-based position in the milesto
 pub fn raise_dispute(env: Env, job_id: String, caller: Address)
 ```
 
-Either participant can raise a dispute. Transitions escrow to `Disputed`. Emits `escrow_ds`.
+Client or freelancer only. Not allowed on `Released`/`Refunded`/`Frozen`/already-`Disputed` escrows (`CannotDisputeResolved (7002)`). If an admin has set a `DisputeBondConfig`, this call locks the configured bond amount from `caller` into the contract (transferred via the bond token's SAC), stores a `DisputeBond` snapshot, and emits `bond_lck`. Otherwise it runs in legacy zero-cost mode. Either path sets status `Disputed` and emits `escrow_ds`.
 
-**Auth required:** `caller` (must be client or freelancer)
-**Panics:** `"Only participants can raise a dispute"`, `"Cannot dispute a resolved escrow"`
+**Auth required:** `caller` (must be the escrow's client or freelancer) — `OnlyParticipantsCanDispute (7001)`
 
----
-
-## Getters
-
-### `get_escrow`
+### `resolve_dispute`
 
 ```rust
-pub fn get_escrow(env: Env, job_id: String) -> Escrow
+pub fn resolve_dispute(env: Env, job_id: String, arbitrator: Address, winner: Address, split_percentage: u32)
 ```
 
-Returns the full `Escrow` struct. Panics `"Escrow not found"` if none exists.
+**Arbitrator-only** — `arbitrator` must equal the address previously set via `set_arbitrator` (`OnlyAdminCanResolveDispute (7003)`). Escrow must be `Disputed` (`EscrowNotDisputed (7004)`). `split_percentage` (0–100) of the escrow amount goes to `winner`, the remainder to the other participant. If a `DisputeBond` was locked for this job: it's returned to the bond-poster (`bond_rtn`) if they are the `winner`, or slashed entirely to `winner` (`bond_slsh`) if the bond-poster lost — either way the bond record is consumed so a second call to `resolve_dispute` cannot re-settle it. Sets status `Released`. Emits `dsp_res` (plus `bond_rtn`/`bond_slsh` if a bond existed).
 
----
+**Auth required:** `arbitrator`
 
-### `get_status`
+### `set_dispute_bond`
 
 ```rust
-pub fn get_status(env: Env, job_id: String) -> EscrowStatus
+pub fn set_dispute_bond(env: Env, admin: Address, token: Address, amount: i128)
 ```
 
-Returns the current `EscrowStatus` for the job.
+Admin-only. Configures the global bond token/amount required to raise future disputes. `amount` must be > 0 (`BondAmountPositive (7006)`). No event.
+
+**Auth required:** admin
+
+### Getters
+
+| Function | Signature | Returns | Description |
+|---|---|---|---|
+| `get_dispute_bond_config` | `(env)` | `(Option<Address>, i128)` | `(None, 0)` if unset (legacy zero-cost mode), else `(Some(token), amount)` |
+| `get_dispute_bond` | `(env, job_id: String)` | `Option<DisputeBond>` | Per-job locked bond record, if any |
 
 ---
 
-### `get_timeout_ledger`
-
-```rust
-pub fn get_timeout_ledger(env: Env, job_id: String) -> u32
-```
-
-Returns the ledger sequence used by the legacy timeout path.
-
----
-
-### `get_timeout_timestamp`
-
-```rust
-pub fn get_timeout_timestamp(env: Env, job_id: String) -> u32
-```
-
-Returns the Unix timestamp after which `timeout_refund()` becomes available. Returns `0` for escrows created without a stored timestamp.
-
----
-
-### `get_referrer`
-
-```rust
-pub fn get_referrer(env: Env, job_id: String) -> Option<Address>
-```
-
-Returns the referrer address, or `None` if no referrer was set.
-
----
-
-### `get_escrow_count`
-
-```rust
-pub fn get_escrow_count(env: Env) -> u32
-```
-
-Returns the total number of escrows ever created.
-
----
-
-### `get_admin`
-
-```rust
-pub fn get_admin(env: Env) -> Address
-```
-
-Returns the current admin address.
-
----
-
-### `get_default_timeout_seconds`
-
-```rust
-pub fn get_default_timeout_seconds(env: Env) -> u32
-```
-
-Returns the global default escrow timeout in seconds. Default is 604,800 (7 days).
-
----
-
-### `set_default_timeout_seconds`
-
-```rust
-pub fn set_default_timeout_seconds(env: Env, admin: Address, timeout_seconds: u32)
-```
-
-Updates the global timeout applied to new escrows. Does not affect existing escrows. Emits `timeout`.
-
-**Auth required:** `admin`
-**Panics:** `"Timeout must be positive"` if `timeout_seconds == 0`
-
----
-
-## Governance (DAO)
-
-Users with at least one completed job may vote on governance proposals.
-
-### `create_proposal`
-
-```rust
-pub fn create_proposal(
-    env: Env,
-    proposer: Address,
-    title: String,
-    description: String,
-    duration_ledgers: u32,
-) -> u32
-```
-
-Creates a new proposal. Returns the sequential proposal ID (starts at 1). Emits `proposed`.
-
-**Auth required:** `proposer`
-**Panics:** `"Duration must be positive"` if `duration_ledgers == 0`
-
----
-
-### `cast_vote`
-
-```rust
-pub fn cast_vote(env: Env, voter: Address, proposal_id: u32, approve: bool)
-```
-
-Casts a for/against vote. Voter must have ≥ 1 completed job. One vote per address per proposal. Emits `voted`.
-
-**Auth required:** `voter`
-
-| Panic | Condition |
-|---|---|
-| `"Proposal already resolved"` | Vote after finalization |
-| `"Voting period has ended"` | Ledger past `deadline_ledger` |
-| `"Only users with completed jobs can vote"` | `CompletedJobs(voter) == 0` |
-| `"Voter has already cast a vote"` | Duplicate vote |
-
----
-
-### `resolve_proposal`
-
-```rust
-pub fn resolve_proposal(env: Env, proposal_id: u32)
-```
-
-Finalizes the proposal after the deadline. `result = votes_for > votes_against`. Emits `resolved`. Callable by anyone.
-
-**Auth required:** None
-**Panics:** `"Proposal already resolved"`, `"Voting period is not over yet"`
-
----
-
-### `get_proposal`
-
-```rust
-pub fn get_proposal(env: Env, id: u32) -> Proposal
-```
-
-Returns a `Proposal` by ID.
-
----
-
-### `list_active_proposals`
-
-```rust
-pub fn list_active_proposals(env: Env) -> Vec<Proposal>
-```
-
-Returns all proposals where `resolved == false`.
-
----
-
-## Sealed-Bid Auction
-
-Prevents anchoring bias by keeping bid amounts hidden until a reveal phase.
-
-### Flow Overview
-
-```
-1. client → commit_budget(job_id, budget)
-2. freelancers → submit_bid_commitment(job_id, SHA256(amount ∥ nonce))
-3. client → close_bidding(job_id)             [opens 1000-ledger reveal window]
-4. freelancers → reveal_bid(job_id, amount, nonce)
-5. client selects winner off-chain, then → create_escrow()
-```
-
----
-
-### `commit_budget`
-
-```rust
-pub fn commit_budget(env: Env, job_id: String, budget_amount: i128, client: Address)
-```
-
-Client seals their budget on-chain. Hidden until `reveal_budget()`. Emits `budgtcmt`.
-
-**Auth required:** `client`
-**Panics:** `"Budget must be positive"` if `budget_amount ≤ 0`
-
----
-
-### `reveal_budget`
-
-```rust
-pub fn reveal_budget(env: Env, job_id: String, client: Address)
-```
-
-Marks the budget as publicly visible. Emits `budgrvld` with `budget_amount`.
-
-**Auth required:** `client`
-**Panics:** `"Only the client can reveal the budget"`, `"Budget already revealed"`
-
----
-
-### `submit_bid_commitment`
-
-```rust
-pub fn submit_bid_commitment(
-    env: Env,
-    job_id: String,
-    freelancer: Address,
-    commitment: BytesN<32>,
-)
-```
-
-Freelancer submits `SHA-256(amount_bytes ∥ nonce)` as a sealed commitment. The nonce must be kept secret until reveal. Emits `bid_cmt`.
-
-**Auth required:** `freelancer`
-**Panics:** `"Budget commitment not found"`, `"Bidding is closed"`, `"Bid commitment already submitted"`
-
----
-
-### `close_bidding`
-
-```rust
-pub fn close_bidding(env: Env, job_id: String, client: Address)
-```
-
-Client closes the commit phase and opens a ~24-hour reveal window (`REVEAL_WINDOW_LEDGERS = 1000`). Emits `bid_cls` with `reveal_deadline_ledger`.
-
-**Auth required:** `client`
-
----
-
-### `reveal_bid`
-
-```rust
-pub fn reveal_bid(
-    env: Env,
-    job_id: String,
-    freelancer: Address,
-    amount: i128,
-    nonce: BytesN<32>,
-)
-```
-
-Freelancer reveals their bid. The contract recomputes `SHA-256(amount ∥ nonce)` and verifies it against the stored commitment. On success, appends to `RevealedBids`. Emits `bid_rvl`.
-
-**Commitment formula:**
-```
-commitment = SHA-256(amount.to_be_bytes() ∥ nonce_bytes)
-```
-
-**Auth required:** `freelancer`
-**Panics:** `"Reveal window has closed"`, `"Bid already revealed"`, `"Commitment verification failed"`
-
----
-
-### `get_bid_commitment`
-
-```rust
-pub fn get_bid_commitment(env: Env, job_id: String, freelancer: Address) -> BidCommitment
-```
-
-Returns a freelancer's sealed bid record.
-
----
-
-### `get_revealed_bids`
-
-```rust
-pub fn get_revealed_bids(env: Env, job_id: String) -> Vec<RevealedBid>
-```
-
-Returns all bids successfully revealed during the reveal window.
-
----
-
-## Deliverable Oracle
-
-Allows a pre-agreed SHA-256 hash to gate automatic escrow release.
-
----
-
-### `submit_deliverable`
-
-```rust
-pub fn submit_deliverable(
-    env: Env,
-    job_id: String,
-    actual_hash: BytesN<32>,
-    caller: Address,
-)
-```
-
-The freelancer or admin submits the actual deliverable hash. If it matches `deliverable_hash` stored in the escrow, `release_escrow_core()` is called automatically and `dlv_ok` is emitted. On mismatch, escrow enters `Disputed` and `dlv_bad` is emitted.
-
-**Auth required:** `caller` (must be `freelancer` or `admin`)
-
----
-
-### `submit_client_deliverable` / `submit_freelancer_deliverable`
-
-```rust
-pub fn submit_client_deliverable(env: Env, job_id: String, client: Address)
-pub fn submit_freelancer_deliverable(env: Env, job_id: String, freelancer: Address)
-```
-
-Independent confirmation from each party that their deliverable hash has been submitted. Used as a two-of-two flow (alternative to the oracle path). Emits `clthash` / `frelhash`.
-
-**Auth required:** `client` / `freelancer`
-
----
-
-### `check_deliverable_match`
-
-```rust
-pub fn check_deliverable_match(env: Env, job_id: String) -> bool
-```
-
-Returns `true` if both parties have submitted their hashes and sets `hashes_match = true` in storage.
-
----
-
-### `get_deliverable_submission`
-
-```rust
-pub fn get_deliverable_submission(env: Env, job_id: String) -> DeliverableSubmission
-```
-
-Returns the current deliverable submission status.
-
----
-
-## Job Certificates & Ratings
-
-### `mint_certificate`
-
-```rust
-pub fn mint_certificate(env: Env, job_id: String, title: String, client: Address)
-```
-
-Mints an on-chain proof-of-work certificate (NFT) for the freelancer. Only available once the escrow is released; one certificate per job. `title` is stored on-chain as NFT metadata alongside the client address, freelancer address, escrow amount and mint ledger. Emits `certmnt`.
-
-**Auth required:** `client` (must equal the escrow client)
-**Panics:** `"Only the escrow client can mint the certificate"`, `"Certificate title cannot be empty"`, `"Escrow must be released to mint certificate"`, `"Certificate already minted"`
-
----
-
-### `get_certificate`
-
-```rust
-pub fn get_certificate(env: Env, job_id: String) -> Certificate
-```
-
-Returns the completion certificate for a job.
-
----
-
-### `get_freelancer_certificates`
-
-```rust
-pub fn get_freelancer_certificates(env: Env, freelancer: Address) -> Vec<String>
-```
-
-Returns all job IDs for which the freelancer has received certificates.
-
----
-
-### `submit_client_rating`
-
-```rust
-pub fn submit_client_rating(env: Env, job_id: String, client: Address, score: u32)
-```
-
-Client rates the freelancer 1–5 after escrow release. One rating per job. Updates the freelancer's rolling rating average.
-
-**Auth required:** `client`
-**Panics:** `"Score must be between 1 and 5"`, `"Ratings are allowed only after escrow release"`, `"Client rating already submitted for this job"`
-
----
-
-### `submit_freelancer_rating`
-
-```rust
-pub fn submit_freelancer_rating(env: Env, job_id: String, freelancer: Address, score: u32)
-```
-
-Freelancer rates the client 1–5 after escrow release. One rating per job.
-
-**Auth required:** `freelancer`
-
----
-
-### `get_freelancer_rating_avg`
-
-```rust
-pub fn get_freelancer_rating_avg(env: Env, freelancer: Address) -> u32
-```
-
-Returns the integer floor average of all ratings the freelancer has received. Returns `0` if no ratings exist.
-
----
-
-## Dispute Arbitration
-
-Formal dispute resolution with a randomly selected 3-arbitrator panel.
-
-### `register_arbitrator`
-
-```rust
-pub fn register_arbitrator(env: Env, admin: Address, arbitrator: Address)
-```
-
-Admin adds a trusted address to the arbitrator pool.
-
-**Auth required:** `admin`
-
----
-
-### `open_arbitration`
-
-```rust
-pub fn open_arbitration(env: Env, job_id: String, admin: Address) -> u32
-```
-
-Admin opens a formal arbitration case. Selects 3 arbitrators from the pool using `ledger_sequence % pool_size` as a deterministic (non-cryptographic) seed. Returns the `case_id`.
-
-**Auth required:** `admin`
-**Panics:** `"Need at least 3 registered arbitrators"`
-
----
-
-### `cast_arbitration_vote`
-
-```rust
-pub fn cast_arbitration_vote(env: Env, case_id: u32, arbitrator: Address, client_percent: u32)
-```
-
-Each of the 3 selected arbitrators votes on what share (0–100%) of the escrowed funds should go to the client. The remainder goes to the freelancer.
-
-**Auth required:** `arbitrator` (must be one of the 3 selected)
-**Panics:** `"Client percent must be 0-100"`, `"Arbitration case is not open"`, `"Only selected arbitrators can vote"`, `"All votes already submitted"`
-
----
-
-### `resolve_arbitration`
+## Arbitration Cases
 
 ```rust
 pub fn resolve_arbitration(env: Env, case_id: u32)
 ```
 
-Finalizes the case once all 3 votes are in. The resolution is the **median** vote (drops the highest and lowest). Emits `arb_res`. Callable by anyone.
+Resolves an `ArbitrationCase` by taking the **median of exactly 3 stored votes** (`case.votes`, each a `client_percent` 0–100) — computed as `sum - min - max`, so it's a true median rather than an average. Requires exactly 3 votes already present (`Exactly3VotesRequired (7014)`; case not found panics with `"Arbitration case not found"`). Sets `case.status = 1` and `case.resolution` to the median. Emits `arb_rsl`.
 
-**Auth required:** None
-**Panics:** `"Exactly 3 votes required"`
+> As noted under [`ArbitrationCase`](#data-types) above, there is currently **no public entrypoint to create a case or submit the 3 votes** — this function only resolves a case whose `votes: Vec<u32>` already has exactly 3 entries via some other means. Docs and integrations should treat multi-arbitrator arbitration as **not yet fully wired up end-to-end** in this contract, distinct from the single-arbitrator `resolve_dispute` flow above, which is fully implemented.
 
----
-
-### `get_arbitration_case`
-
-```rust
-pub fn get_arbitration_case(env: Env, case_id: u32) -> ArbitrationCase
-```
-
-Returns the full arbitration case record.
+**Auth required:** none enforced in code (any caller can trigger resolution once 3 votes exist) — contrast with `resolve_dispute`, which is arbitrator-gated.
 
 ---
 
-## Messaging — On-chain CID Notarization
+## Milestones
 
-Messages are stored off-chain on IPFS. Only the content identifier (CID) is published on-chain for censorship resistance and verifiability.
-
-### `publish_message`
+### `release_milestone`
 
 ```rust
-pub fn publish_message(
-    env: Env,
-    job_id: String,
-    sender: Address,
-    recipient: Address,
-    ipfs_cid: String,
-)
+pub fn release_milestone(env: Env, job_id: String, milestone_id: u32, client: Address)
 ```
 
-Appends the IPFS CID to `MessageCid(job_id)` and emits `msg_sent`. Message content remains off-chain.
+Client-only. Callable while escrow status is `InProgress`/`Locked`/`Disputed`. Finds the milestone by `id`, marks it released, pays out its percentage share of the escrow (minus platform fee — emits `plat_fee` when fee > 0) to the freelancer. If **all** milestones are now released or rejected, the escrow itself transitions to `Released` and `CompletedJobs` is incremented for both parties. Emits `milestone_released`.
 
-**Auth required:** `sender`
-**Panics:** `"IPFS CID cannot be empty"`
+**Auth required:** `client` — `OnlyClientCanReleaseMilestone (3004)`
+**Panics:** `CannotReleaseMilestoneStatus (3005)`, `MilestoneAlreadyCompleted (3007)`, invalid id → `"Invalid milestone id"` (not in `errors.rs`'s canonical `error_code_from_panic` mapping — see [Error Reference](#error-reference) caveat)
 
----
-
-### `get_message_cids`
+### `reject_milestone`
 
 ```rust
-pub fn get_message_cids(env: Env, job_id: String) -> Vec<String>
+pub fn reject_milestone(env: Env, job_id: String, milestone_index: u32, client: Address)
 ```
 
-Returns all IPFS CIDs recorded on-chain for a job thread.
+Client-only. Marks the milestone (by **index**, not `id`) rejected and refunds its percentage share to the client. If all milestones are resolved (released or rejected), the escrow transitions to `Released`. Emits `milestone_rejected`.
+
+**Auth required:** `client`
 
 ---
 
 ## Job Boost
 
-### `boost_job`
-
 ```rust
-pub fn boost_job(
-    env: Env,
-    job_id: String,
-    client: Address,
-    treasury: Address,
-    token: Address,
-    amount: i128,
-)
+pub fn boost_job(env: Env, job_id: String, client: Address, treasury: Address, token: Address, amount: i128)
 ```
 
-Client pays XLM to `treasury` to promote a job listing in search results. Emits `boosted` with the expiry ledger.
+Client pays `amount` directly to `treasury` to boost a job listing's visibility (this is a direct payment, not related to the job's escrow). Minimum 5 XLM (50,000,000 stroops) buys a 7-day boost (120,960 ledgers); ≥ 15 XLM (150,000,000 stroops) buys a 30-day boost (518,400 ledgers). Emits `boosted` with the resulting expiry ledger.
 
 **Auth required:** `client`
-
-**Boost tiers** (1 XLM = 10,000,000 stroops):
-
-| Minimum Payment | Ledger Duration | Approximate Duration |
-|-----------------|-----------------|----------------------|
-| 5 XLM (50,000,000 stroops) | 120,960 | 7 days |
-| 15 XLM (150,000,000 stroops) | 518,400 | 30 days |
-
-**Panics:** `"Boost amount must be positive"`, `"Minimum boost is 5 XLM"`
+**Panics:** `MinimumBoost5Xlm (9001)`, `BoostAmountPositive (9002)`
 
 ---
 
-## Admin & Versioning
+## Sealed-Bid Budget Commitment
 
-### `upgrade`
+Lets a client commit to a job budget without immediately publishing it (Issue #108). This is a **procedural** seal (a flag), not a cryptographic commitment scheme — contrast with the freelancer bid commitments below, which are hash-based.
 
-```rust
-pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>)
-```
-
-Replaces the contract WASM with a new version. All on-chain storage (escrows, proposals, ratings, etc.) is preserved — Soroban upgrades only replace the executable. Increments `Version`. Emits `upgraded`.
-
-**Auth required:** `admin`
-**Precondition:** The new WASM must be pre-uploaded via `stellar contract install`.
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `commit_budget` | `(env, job_id: String, budget_amount: i128, client: Address)` | `()` | `client` | `BudgetPositive (4001)`. Emits `budgtcmt`. |
+| `reveal_budget` | `(env, job_id: String, client: Address)` | `()` | `client` | `BudgetCommitmentNotFound (4002)`, `OnlyClientCanRevealBudget (4003)`, `BudgetAlreadyRevealed (4004)`. Emits `budgrvld`. |
+| `get_budget_commitment` | `(env, job_id: String)` | `BudgetCommitment` | — | Full commitment record |
 
 ---
 
-### `get_version`
+## Sealed-Bid Freelancer Auctions
 
-```rust
-pub fn get_version(env: Env) -> u32
-```
+Cryptographic commit-reveal scheme for freelancer bids (Issue #338). A freelancer first submits `SHA-256(amount_be_bytes ∥ nonce)`, then reveals `amount` and `nonce` after bidding closes; the contract recomputes the hash and rejects mismatches.
 
-Returns the current contract version (starts at 1, incremented on each `upgrade`).
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `submit_bid_commitment` | `(env, job_id: String, freelancer: Address, commitment: BytesN<32>)` | `()` | `freelancer` | Requires a prior `commit_budget` for the job. `BiddingClosed (4005)`, `BidCommitmentAlreadySubmitted (4006)`. Emits `bid_cmt`. |
+| `close_bidding` | `(env, job_id: String, client: Address)` | `()` | `client` | Opens the reveal window: `REVEAL_WINDOW_LEDGERS` = 17,280 ledgers (~24h). Emits `bid_cls`. |
+| `reveal_bid` | `(env, job_id: String, freelancer: Address, amount: i128, nonce: BytesN<32>)` | `()` | `freelancer` | Verifies `sha256(amount_be_bytes ‖ nonce) == commitment`. `BiddingNotClosed (4007)`, `RevealWindowClosed (4008)`, `BidAlreadyRevealed (4009)`, `CommitmentVerificationFailed (4010)`. Emits `bid_rvl`. |
+| `get_bid_commitment` | `(env, job_id: String, freelancer: Address)` | `BidCommitment` | — | A freelancer's sealed commitment record |
+| `get_revealed_bids` | `(env, job_id: String)` | `Vec<RevealedBid>` | — | All bids revealed for a job |
+
+---
+
+## Deliverable Oracle
+
+Hash-based verification that client and freelancer agree the delivered work matches (Issue #105 and related).
+
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `submit_client_deliverable` | `(env, job_id: String)` | `()` | client (implicit — see source for exact auth) | Flags the client's side of a `DeliverableSubmission` as submitted. No event. |
+| `submit_freelancer_deliverable` | `(env, job_id: String)` | `()` | freelancer (implicit) | Flags the freelancer's side of a `DeliverableSubmission` as submitted. No event. |
+| `check_deliverable_match` | `(env, job_id: String)` | `bool` | — | If both hash-submitted flags are true, sets `hashes_match = true` and returns `true`, else `false` |
+| `get_deliverable_submission` | `(env, job_id: String)` | `DeliverableSubmission` | — | Full submission-status record |
+| `submit_deliverable_hash` | `(env, job_id: String, freelancer: Address, hash: BytesN<32>)` | `()` | `freelancer` | Stores the SHA-256 hash of completed work for later `release_escrow` verification; requires the escrow to have an expected `deliverable_hash` and be `Locked`/`InProgress`. `NoDeliverableHash (8002)`. No event. |
+| `get_freelancer_deliverable_hash` | `(env, job_id: String)` | `Option<BytesN<32>>` | — | The freelancer-submitted hash, if any |
+| `verify_deliverable_hash` | `(env, job_id: String)` | `bool` | — | `true` iff both the expected and submitted hashes exist and are equal |
+| `submit_deliverable` | `(env, job_id: String, actual_hash: BytesN<32>, caller: Address)` | `()` | freelancer or admin (acting as oracle) — `OnlyFreelancerOrOracle (8001)` | Compares `actual_hash` to `escrow.deliverable_hash`. On match: auto-releases the escrow via the same internal path as `release_escrow` (emits `escrow_rl`). On mismatch: sets status `Disputed` (no dispute bond is locked via this path). |
+
+---
+
+## Job Certificates & Dispute Evidence
+
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `mint_certificate` | `(env, job_id: String, title: String, client: Address)` | `()` | client (must be the escrow's client) | Escrow must be `Released` — `EscrowMustBeReleased (5005)`. One per job — `CertificateAlreadyMinted (5006)`. Non-empty title required. Mints a `Certificate` to the freelancer. No event. |
+| `get_certificate` | `(env, job_id: String)` | `Certificate` | — | Certificate record for a job |
+| `get_freelancer_certificates` | `(env, freelancer: Address)` | `Vec<String>` | — | List of job IDs for which a freelancer holds certificates |
+| `submit_evidence_cid` | `(env, job_id: String, cid: Bytes, caller: Address)` | `()` | client or freelancer | Not allowed on a `Refunded` escrow. Appends `cid` (raw IPFS CID bytes) to the job's append-only evidence audit trail. Emits `evd_add`. |
+| `get_evidence_cids` | `(env, job_id: String)` | `Vec<Bytes>` | — | All evidence CIDs for a job, insertion order |
+
+---
+
+## Ratings
+
+| Function | Signature | Returns | Auth | Notes |
+|---|---|---|---|---|
+| `submit_client_rating` | `(env, job_id: String, client: Address, score: u32)` | `()` | client | `score` 1–5 — `InvalidScore (5001)`. Updates the freelancer's aggregate `FreelancerRatingStats`. No event. |
+| `submit_freelancer_rating` | `(env, job_id: String, freelancer: Address, score: u32)` | `()` | freelancer | `score` 1–5. Only after escrow `Released` — `RatingsOnlyAfterRelease (5002)`. One rating per job — `FreelancerRatingAlreadySubmitted (5004)`. Stores a `Rating` of the client by the freelancer. No event. |
+
+> **Note:** `submit_client_rating`'s duplicate-submission protection (`RatingAlreadySubmitted (5003)`) and exact auth/status checks should be confirmed against the current `lib.rs` source before relying on them in a client integration — the two rating functions are not perfectly symmetric in the current implementation.
 
 ---
 
 ## Error Reference
 
-All errors are Soroban contract panics that revert the transaction with no state changes.
+`ContractError` (`contracts/marketpay-contract/src/errors.rs`), `#[repr(u32)]`, grouped by numeric prefix.
 
-| Panic Message | Function(s) | Cause |
+### 1xxx — Initialization & Admin
+
+| Code | Name | Message |
 |---|---|---|
-| `"Already initialized"` | `initialize` | Called more than once |
-| `"Not initialized"` | most getters | `initialize` not called |
-| `"Amount must be positive"` | `create_escrow` | `amount ≤ 0` |
-| `"Referrer cannot be the client or freelancer"` | `create_escrow` | Invalid referrer address |
-| `"Maximum 5 milestones allowed"` | `create_escrow` | More than 5 milestones |
-| `"Milestone amounts must sum to total escrow amount"` | `create_escrow` | Milestone totals mismatch |
-| `"Milestone percentage must be positive"` | `create_escrow` | Milestone percentage ≤ 0 |
-| `"Milestone percentages must sum to 100"` | `create_escrow` | Milestone percentages don't sum to 100 |
-| `"Escrow already exists for this job"` | `create_escrow` | Duplicate `job_id` |
-| `"Escrow not found"` | multiple | No escrow for the given `job_id` |
-| `"Only the freelancer can start work"` | `start_work` | Wrong auth address |
-| `"Escrow is not in Locked state"` | `start_work`, `timeout_refund` | Wrong status |
-| `"Only the client can release escrow"` | `release_escrow`, `release_with_conversion` | Wrong auth address |
-| `"Cannot release escrow in current status"` | `release_escrow`, `release_with_conversion` | Not `InProgress` or `Locked` |
-| `"Only the client can request a refund"` | `refund_escrow` | Wrong auth address |
-| `"Can only refund before work has started"` | `refund_escrow` | Not in `Locked` state |
-| `"Only the client can request a timeout refund"` | `timeout_refund` | Wrong auth address |
-| `"Timeout period has not expired yet"` | `timeout_refund` | Called before timeout |
-| `"Only the client can release a milestone"` | `release_milestone` | Wrong auth address |
-| `"Cannot release milestone in current status"` | `release_milestone` | Wrong status |
-| `"Invalid milestone id"` | `release_milestone`, `reject_milestone` | Milestone id not found |
-| `"Milestone already released"` | `release_milestone`, `reject_milestone` | Duplicate release |
-| `"Milestone already rejected"` | `release_milestone`, `reject_milestone` | Already rejected |
-| `"Only the client can reject a milestone"` | `reject_milestone` | Wrong auth address |
-| `"Cannot reject milestone in current status"` | `reject_milestone` | Wrong status |
-| `"Milestone index out of bounds"` | `get_milestone` | Index ≥ milestone count |
-| `"Milestone percentages must sum to 100"` | `create_escrow` | Percentages don't sum to 100 |
-| `"Milestone percentage must be positive"` | `create_escrow` | Zero or negative percentage |
-| `"Only participants can raise a dispute"` | `raise_dispute` | Not client or freelancer |
-| `"Cannot dispute a resolved, frozen, or already-disputed escrow"` | `raise_dispute` | Already `Released`, `Refunded`, `Frozen`, or `Disputed` |
-| `"Caller must have a non-zero dispute bond"` | `raise_dispute` | Bond not configured or zero |
-| `"Only admin can resolve a dispute"` | `resolve_dispute` | Wrong auth |
-| `"Escrow is not in Disputed state"` | `resolve_dispute` | Wrong status |
-| `"Score must be between 1 and 5"` | `submit_*_rating` | Invalid score |
-| `"Ratings are allowed only after escrow release"` | `submit_*_rating` | Not `Released` |
-| `"Client rating already submitted for this job"` | `submit_client_rating` | Duplicate rating |
-| `"Freelancer rating already submitted for this job"` | `submit_freelancer_rating` | Duplicate rating |
-| `"Budget must be positive"` | `commit_budget` | `budget_amount ≤ 0` |
-| `"Budget commitment not found"` | multiple | `commit_budget` not called first |
-| `"Only the client can reveal the budget"` | `reveal_budget` | Wrong auth address |
-| `"Budget already revealed"` | `reveal_budget` | Called twice |
-| `"Bidding is closed"` | `submit_bid_commitment` | After `close_bidding` was called |
-| `"Bid commitment already submitted"` | `submit_bid_commitment` | Duplicate per freelancer |
-| `"Bidding not closed"` | `reveal_bid` | `close_bidding` not called yet |
-| `"Reveal window has closed"` | `reveal_bid` | Ledger past `reveal_deadline_ledger` |
-| `"Bid already revealed"` | `reveal_bid` | Duplicate reveal |
-| `"Commitment verification failed"` | `reveal_bid` | Hash mismatch |
-| `"Only the escrow client can mint the certificate"` | `mint_certificate` | Caller ≠ escrow client |
-| `"Certificate title cannot be empty"` | `mint_certificate` | Empty `title` param |
-| `"Escrow must be released to mint certificate"` | `mint_certificate` | Not in `Released` state |
-| `"Certificate already minted"` | `mint_certificate` | Duplicate mint |
-| `"Only freelancer or oracle can submit deliverable"` | `submit_deliverable` | Wrong auth |
-| `"Escrow has no deliverable hash"` | `submit_deliverable` | Used wrong `create_escrow` variant |
-| `"Duration must be positive"` | `create_proposal` | `duration_ledgers == 0` |
-| `"Proposal not found"` | proposal getters | Invalid proposal ID |
-| `"Proposal already resolved"` | `cast_vote`, `resolve_proposal` | Already finalized |
-| `"Voting period has ended"` | `cast_vote` | Past `deadline_ledger` |
-| `"Only users with completed jobs can vote"` | `cast_vote` | No job history |
-| `"Voter has already cast a vote"` | `cast_vote` | Double-vote |
-| `"Voting period is not over yet"` | `resolve_proposal` | Before `deadline_ledger` |
-| `"Only admin can update the timeout"` | `set_default_timeout_seconds` | Wrong auth |
-| `"Timeout must be positive"` | `set_default_timeout_seconds` | Zero timeout |
-| `"Only admin can register arbitrators"` | `register_arbitrator` | Wrong auth |
-| `"Need at least 3 registered arbitrators"` | `open_arbitration` | Pool too small |
-| `"Only admin can open arbitration"` | `open_arbitration` | Wrong auth |
-| `"Arbitration case not found"` | arbitration getters | Invalid `case_id` |
-| `"Arbitration case is not open"` | `cast_arbitration_vote` | Case already resolved |
-| `"Only selected arbitrators can vote"` | `cast_arbitration_vote` | Not in the 3-person panel |
-| `"All votes already submitted"` | `cast_arbitration_vote` | Panel already voted |
-| `"Exactly 3 votes required"` | `resolve_arbitration` | Incomplete votes |
-| `"Minimum boost is 5 XLM"` | `boost_job` | Payment below minimum |
-| `"Boost amount must be positive"` | `boost_job` | `amount ≤ 0` |
-| `"IPFS CID cannot be empty"` | `publish_message` | Empty CID string |
-| `"Contract is frozen"` | all mutating functions | Global freeze is active |
-| `"Arithmetic overflow"` | multiple | Internal overflow in amount calculations |
-| `"Arithmetic underflow"` | `approve_extension` | New timeout ≤ current timeout |
-| `"Only admin can set the referrer bonus cap"` | `set_max_referrer_bonus_xlm` | Wrong auth |
-| `"Only admin can update the dispute bond"` | `set_dispute_bond` | Wrong auth |
-| `"Bond amount must be positive"` | `set_dispute_bond` | `amount ≤ 0` |
-| `"Only admin can set treasury address"` | `set_treasury_address` | Wrong auth |
-| `"Only admin can set platform fee"` | `set_platform_fee_bps` | Wrong auth |
-| `"Platform fee cannot exceed 10% (1000 bps)"` | `set_platform_fee_bps` | Fee > 1000 |
-| `"Treasury not set"` | `release_escrow`, `release_milestone` | Treasury not configured |
-| `"Freelancer deliverable hash does not match or not submitted"` | `release_escrow` | Hash mismatch |
-| `"Referrer bonus cap must be non-negative"` | `set_max_referrer_bonus_xlm` | Negative cap |
+| 1001 | `AlreadyInitialized` | Already initialized |
+| 1002 | `NotInitialized` | Not initialized |
+| 1003 | `ContractFrozen` | Contract is frozen |
+| 1004 | `ContractNotFrozen` | Contract is not frozen |
+| 1010 | `OnlyAdminSetTreasury` | Only admin can set treasury address |
+| 1011 | `OnlyAdminSetFee` | Only admin can set platform fee |
+| 1012 | `PlatformFeeExceedsMax` | Platform fee cannot exceed 10% (1000 bps) |
+| 1013 | `OnlyAdminCanFreeze` | Only an admin can freeze the contract |
+| 1014 | `InsufficientSignatures` | Insufficient admin signatures to unfreeze |
+| 1015 | `NotAnAdmin` | One of the provided addresses is not an admin |
+| 1016 | `DuplicateAdminSignature` | Duplicate admin in unfreeze signatures |
+| 1017 | `OnlyAdminCanAddAdmin` | Only an admin can add new admins |
+| 1018 | `AlreadyAdmin` | Address is already an admin |
+| 1019 | `OnlyAdminUpdateThreshold` | Only an admin can update the threshold |
+| 1020 | `InvalidThreshold` | Threshold must be between 1 and the number of admins |
+| 1021 | `OnlyAdminSetReferrerCap` | Only admin can set the referrer bonus cap |
+| 1022 | `ReferrerCapNegative` | Referrer bonus cap must be non-negative |
+| 1023 | `OnlyAdminUpdateTimeout` | Only admin can update the timeout |
+| 1024 | `TimeoutMustBePositive` | Timeout must be positive |
+
+### 2xxx — Escrow Lifecycle
+
+| Code | Name | Message |
+|---|---|---|
+| 2001 | `AmountMustBePositive` | Amount must be positive |
+| 2002 | `InvalidReferrer` | Referrer cannot be the client or freelancer |
+| 2003 | `EscrowAlreadyExists` | Escrow already exists for this job |
+| 2004 | `EscrowNotFound` | Escrow not found |
+| 2005 | `OnlyFreelancerCanStartWork` | Only the freelancer can start work |
+| 2006 | `EscrowNotLocked` | Escrow is not in Locked state |
+| 2007 | `OnlyClientCanRelease` | Only the client can release escrow |
+| 2008 | `CannotReleaseStatus` | Cannot release escrow in current status |
+| 2009 | `DeliverableHashMismatch` | Freelancer deliverable hash does not match or not submitted |
+| 2010 | `OnlyClientCanRefund` | Only the client can refund |
+| 2011 | `CanOnlyRefundLocked` | Can only refund before work has started |
+| 2012 | `OnlyClientCanTimeoutRefund` | Only the client can request a timeout refund |
+| 2013 | `TimeoutNotExpired` | Timeout period has not expired yet |
+
+### 3xxx — Milestones
+
+| Code | Name | Message |
+|---|---|---|
+| 3001 | `MaxMilestones` | Maximum 5 milestones allowed |
+| 3002 | `MilestonePercentagePositive` | Milestone percentage must be positive |
+| 3003 | `MilestonePercentagesSum` | Milestone percentages must sum to 100 |
+| 3004 | `OnlyClientCanReleaseMilestone` | Only the client can release a milestone |
+| 3005 | `CannotReleaseMilestoneStatus` | Cannot release milestone in current escrow status |
+| 3006 | `InvalidMilestoneIndex` | Invalid milestone index / Milestone index out of bounds |
+| 3007 | `MilestoneAlreadyCompleted` | Milestone already completed |
+
+### 4xxx — Bidding & Sealed-Bid Auction
+
+| Code | Name | Message |
+|---|---|---|
+| 4001 | `BudgetPositive` | Budget amount must be positive |
+| 4002 | `BudgetCommitmentNotFound` | Budget commitment not found |
+| 4003 | `OnlyClientCanRevealBudget` | Only the client can reveal the budget |
+| 4004 | `BudgetAlreadyRevealed` | Budget already revealed |
+| 4005 | `BiddingClosed` | Bidding is closed |
+| 4006 | `BidCommitmentAlreadySubmitted` | Bid commitment already submitted |
+| 4007 | `BiddingNotClosed` | Bidding is not closed |
+| 4008 | `RevealWindowClosed` | Reveal window has closed |
+| 4009 | `BidAlreadyRevealed` | Bid already revealed |
+| 4010 | `CommitmentVerificationFailed` | Commitment verification failed |
+
+### 5xxx — Ratings & Certificates
+
+| Code | Name | Message |
+|---|---|---|
+| 5001 | `InvalidScore` | Score must be between 1 and 5 |
+| 5002 | `RatingsOnlyAfterRelease` | Ratings can only be submitted after escrow release |
+| 5003 | `RatingAlreadySubmitted` | Client rating already submitted for this job |
+| 5004 | `FreelancerRatingAlreadySubmitted` | Freelancer rating already submitted for this job |
+| 5005 | `EscrowMustBeReleased` | Escrow must be released to mint certificate |
+| 5006 | `CertificateAlreadyMinted` | Certificate already minted for this job |
+
+### 6xxx — Governance (DAO)
+
+| Code | Name | Message |
+|---|---|---|
+| 6001 | `DurationPositive` | Voting duration must be positive |
+| 6002 | `ProposalNotFound` | Proposal not found |
+| 6003 | `ProposalAlreadyResolved` | Proposal already resolved |
+| 6004 | `VotingPeriodEnded` | Voting period has ended |
+| 6005 | `OnlyCompletedJobsCanVote` | Only addresses with completed jobs can vote |
+| 6006 | `AlreadyVoted` | Already voted on this proposal |
+| 6007 | `VotingNotOver` | Voting period is not over yet |
+
+### 7xxx — Disputes & Arbitration
+
+| Code | Name | Message | Wired to a public fn? |
+|---|---|---|---|
+| 7001 | `OnlyParticipantsCanDispute` | Only escrow participants can raise a dispute | Yes — `raise_dispute` |
+| 7002 | `CannotDisputeResolved` | Cannot dispute a resolved, frozen, or already-disputed escrow | Yes — `raise_dispute` |
+| 7003 | `OnlyAdminCanResolveDispute` | Only the arbitrator can resolve a dispute | Yes — `resolve_dispute` |
+| 7004 | `EscrowNotDisputed` | Escrow is not in Disputed state | Yes — `resolve_dispute` |
+| 7005 | `OnlyAdminUpdateDisputeBond` | Only admin can update the dispute bond | Yes — `set_dispute_bond` |
+| 7006 | `BondAmountPositive` | Bond amount must be positive | Yes — `set_dispute_bond` |
+| 7007 | `OnlyAdminRegisterArbitrators` | Only admin can register arbitrators | **No** — no matching entrypoint exists yet |
+| 7008 | `Need3Arbitrators` | Need at least 3 registered arbitrators | **No** |
+| 7009 | `OnlyAdminOpenArbitration` | Only admin can open an arbitration case | **No** |
+| 7010 | `ArbitrationCaseNotFound` | Arbitration case not found | Yes — `resolve_arbitration` |
+| 7011 | `ArbitrationCaseNotOpen` | Arbitration case is not open | **No** |
+| 7012 | `OnlySelectedArbitrators` | Only a selected arbitrator can vote | **No** |
+| 7013 | `AllVotesSubmitted` | All votes already submitted | **No** |
+| 7014 | `Exactly3VotesRequired` | Exactly 3 arbitrator votes are required | Yes — `resolve_arbitration` |
+
+### 8xxx — Deliverable Oracle & Messaging
+
+| Code | Name | Message |
+|---|---|---|
+| 8001 | `OnlyFreelancerOrOracle` | Only the freelancer or an oracle-authorized admin can submit the deliverable |
+| 8002 | `NoDeliverableHash` | Escrow has no deliverable hash |
+| 8003 | `IpfsCidEmpty` | IPFS CID cannot be empty |
+
+### 9xxx — Job Boost & Extensions
+
+| Code | Name | Message |
+|---|---|---|
+| 9001 | `MinimumBoost5Xlm` | Minimum boost is 5 XLM |
+| 9002 | `BoostAmountPositive` | Boost amount must be positive |
+| 9003 | `OnlyParticipantsCanExtend` | Only escrow participants can request an extension |
+| 9004 | `CannotExtendStatus` | Cannot extend timeout in current status |
+| 9005 | `NewTimeoutMustBeLater` | New timeout must be later than the current one |
+| 9006 | `ExtensionAlreadyPending` | An extension request is already pending |
+| 9007 | `NoPendingExtension` | No pending extension request |
+| 9008 | `CannotApproveOwnExtension` | Cannot approve your own extension request |
+| 9009 | `OnlyParticipantsCanApprove` | Only escrow participants can approve an extension |
+
+### 99xx — Arithmetic & System
+
+| Code | Name | Message |
+|---|---|---|
+| 9901 | `ArithmeticOverflow` | Arithmetic overflow |
+| 9902 | `CounterOverflow` | Counter overflow |
+| 9903 | `TimeoutLedgerOverflow` | Timeout ledger overflow |
+| 9904 | `TimeoutTimestampOverflow` | Timeout timestamp overflow |
+
+### Reverse mapping caveat
+
+`errors.rs` exposes `ContractError::panic_message()`, `ContractError::code()`, and a free function `error_code_from_panic(msg: &str) -> Option<u32>` that maps Soroban panic/`HostError` strings (including `Error(Contract, #N)` and `Error(Contract, #N): <msg>` formats) back to numeric codes for frontend error handling. **This mapping is not fully synchronized with every `panic!()` call site in `lib.rs`.** Several panic strings used in the wild do not appear in `error_code_from_panic`'s match arms, including (non-exhaustive): `resolve_dispute`'s `"Only the arbitrator can resolve a dispute"` and `"Winner must be the client or the freelancer"`; `mint_certificate`'s `"Only the escrow client can mint the certificate"` and `"Certificate title cannot be empty"`; and assorted milestone/rating/evidence panics such as `"Invalid milestone id"`, `"Milestone already released"`, `"Milestone already rejected"`, `"Only participants can record evidence"`, `"Cannot record evidence on a refunded escrow"`. Frontend code that relies on `error_code_from_panic` to classify a failed transaction should fall back to matching on the raw panic string for these cases until the mapping is completed.
 
 ---
 
-*For deployment instructions see [contract-deployment.md](./contract-deployment.md).*
-*For the escrow database schema see [ADR-003-database-schema-escrow.md](./ADR-003-database-schema-escrow.md).*
+## Arbitrator Registry Contract
+
+`contracts/arbitrator-registry/src/lib.rs` — `ArbitratorRegistry`. A **separate, independently deployed** contract that manages a staking-gated pool of arbitrators. It is not currently invoked by `MarketPayContract`'s dispute/arbitration flow (see the [Arbitration Cases](#arbitration-cases) caveat above) — as of this writing the two contracts are not linked on-chain; any connection between "is a registered arbitrator here" and "is allowed to call `resolve_dispute` on the escrow contract" is enforced off-chain/administratively via `set_arbitrator`.
+
+| Function | Signature | Returns | Auth | Description |
+|---|---|---|---|---|
+| `initialize` | `(env, admin: Address, token: Address, min_stake: i128)` | `()` | none (one-time) | `token` is the SAC used for staking. If `min_stake ≤ 0`, defaults to 100,000,000 stroops (10 XLM). |
+| `set_minimum_stake` | `(env, admin: Address, min_stake: i128)` | `()` | admin | `min_stake` must be > 0 |
+| `register` | `(env, caller: Address, metadata_uri: String)` | `()` | `caller` | Stakes `min_stake` tokens (transferred from caller to contract), added to the active arbitrator list with `metadata_uri` (e.g. an IPFS profile URI). Panics if already registered. |
+| `deregister` | `(env, caller: Address)` | `()` | `caller` | Refunds the caller's staked amount, marks inactive, removes from the active list |
+| `remove_arbitrator` | `(env, admin: Address, arbitrator: Address)` | `()` | admin | Force-removal; refunds stake to the arbitrator, marks inactive |
+| `dao_register_arbitrator` | `(env, admin: Address, arbitrator: Address, metadata_uri: String)` | `()` | admin (DAO-multisig) | Registers `arbitrator` with stake transferred **from `admin`** (i.e. DAO treasury) rather than the arbitrator — bridges an off-chain DAO vote to on-chain registration |
+| `dao_remove_arbitrator` | `(env, admin: Address, arbitrator: Address)` | `()` | admin | DAO-triggered removal; stake is returned **to `admin`** (DAO treasury) as a penalty, not to the arbitrator |
+| `get_arbitrators` | `(env)` | `Vec<Address>` | — | All currently active arbitrator addresses |
+| `get_arbitrator_count` | `(env)` | `u32` | — | Count of active arbitrators |
+| `get_arbitrator` | `(env, address: Address)` | `ArbitratorInfo` | — | Detailed info for one arbitrator; panics "Not registered" if absent |
+| `is_arbitrator` | `(env, address: Address)` | `bool` | — | Whether `address` is currently active |
+| `get_minimum_stake` | `(env)` | `i128` | — | Current minimum stake required to register |
+| `get_token` | `(env)` | `Address` | — | The SAC token address used for staking |
+| `get_admin` | `(env)` | `Address` | — | Contract admin address |
+
+### `ArbitratorInfo`
+
+| Field            | Type      | Description                                  |
+|-------------------|-----------|-------------------------------------------------|
+| `active`          | `bool`    | Whether the arbitrator is currently active        |
+| `staked_amount`   | `i128`    | Amount currently staked                             |
+| `metadata_uri`    | `String`  | Off-chain profile URI (e.g. IPFS)                     |
+| `registered_at`   | `u32`     | Ledger sequence at registration                        |
+
+Constant: `DEFAULT_MIN_STAKE: i128 = 100_000_000` (10 XLM in stroops).
+
+---
+
+**Last Updated**: 2026-08-24

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,8 @@ This guide covers common issues you may encounter when developing, deploying, or
 
 ## Table of Contents
 
+- [Local Setup Issues](#local-setup-issues)
+  - [npm ci Peer-Dependency Errors](#npm-ci-peer-dependency-errors)
 - [Frontend Issues](#frontend-issues)
   - [Freighter Not Detected](#freighter-not-detected)
   - [NEXT_PUBLIC_CONTRACT_ID Not Set](#next_public_contract_id-not-set)
@@ -11,14 +13,83 @@ This guide covers common issues you may encounter when developing, deploying, or
   - [WebSocket Disconnects](#websocket-disconnects)
 - [Backend Issues](#backend-issues)
   - [PostgreSQL Migration Failure](#postgresql-migration-failure)
+  - [Migration Version Collisions](#migration-version-collisions)
   - [Redis Connection Refused](#redis-connection-refused)
   - [Soroban RPC Timeout](#soroban-rpc-timeout)
   - [IPFS Upload Failure](#ipfs-upload-failure)
+  - [CSRF 403 Errors When Calling the API From a Script](#csrf-403-errors-when-calling-the-api-from-a-script)
 - [CI/CD Issues](#cicd-issues)
   - [Workflow Failures (Missing Secrets)](#workflow-failures-missing-secrets)
 - [Network Issues](#network-issues)
   - [Wrong Stellar Network](#wrong-stellar-network)
   - [Transaction Submission Failed](#transaction-submission-failed)
+
+---
+
+## Local Setup Issues
+
+### npm ci Peer-Dependency Errors
+
+**Symptom**:
+```
+npm error code ERESOLVE
+npm error ERESOLVE could not resolve
+npm error While resolving: frontend@1.0.0
+npm error Found: react@18.3.1
+npm error Could not resolve dependency:
+npm error peer react@">=19.0.0" from some-package@x.y.z
+```
+
+**Cause**:
+
+This repo is a set of independent npm workspaces (root, `frontend/`, `backend/`) that are **not** locked together by a single top-level `package-lock.json` with workspace resolution — each directory has its own lockfile. `npm ci` (used in `.github/workflows/ci.yml` and `.github/workflows/security.yml`) installs strictly from the lockfile and fails hard on any peer-dependency mismatch, unlike `npm install`, which will sometimes paper over it.
+
+The most common source of this is a partial dependency bump: `frontend/package.json` pins `react`/`react-dom` at `^18.3.1` and the whole Storybook toolchain (`storybook`, `@storybook/react`, `@storybook/react-vite`, `@storybook/nextjs`, `@storybook/addon-*`) at `^8.6.18`. If any one of those packages gets bumped independently (e.g. `react-dom` to `19.x`, or a single `@storybook/*` package to `10.x` while the rest stay on `8.x`), `npm ci` fails because the peer ranges no longer line up.
+
+**Fix**:
+
+#### 1. Reproduce with a clean install
+
+```bash
+cd frontend   # or backend, or repo root
+rm -rf node_modules
+npm ci
+```
+
+#### 2. Identify the mismatched pair
+
+Read the `npm error` block — it names the package that declared the peer requirement and the version that's actually installed. Cross-check `frontend/package.json` for `react`, `react-dom`, `storybook`, and every `@storybook/*` entry: they should all share the same major version.
+
+#### 3. Align the versions
+
+```bash
+cd frontend
+npm install react@18.3.1 react-dom@18.3.1
+npm install --save-dev storybook@8.6.18 @storybook/react@8.6.18 \
+  @storybook/react-vite@8.6.18 @storybook/nextjs@8.6.18 \
+  @storybook/addon-essentials@8.6.18 @storybook/addon-interactions@8.6.18 \
+  @storybook/addon-links@8.6.18
+npm install
+```
+
+#### 4. Do not reach for `--legacy-peer-deps` as a permanent fix
+
+`npm install --legacy-peer-deps` will unblock a local install, but CI runs plain `npm ci`, which does **not** accept that flag mid-lockfile — you'd have to change the workflow too, and that just hides the real version drift instead of fixing it. Prefer aligning versions (step 3) so the committed lockfile is consistent for everyone, including CI.
+
+#### 5. Regenerate the lockfile if it's out of sync
+
+```bash
+cd frontend
+rm -f package-lock.json
+npm install
+git diff package-lock.json   # review before committing
+```
+
+**Related Files**:
+- `frontend/package.json`
+- `backend/package.json`
+- `.github/workflows/ci.yml`
+- `.github/dependabot.yml` (groups minor/patch updates per ecosystem to reduce the chance of a lone package drifting ahead of its peers)
 
 ---
 
@@ -458,6 +529,56 @@ npm run migrate:rollback
 
 ---
 
+### Migration Version Collisions
+
+**Symptom**:
+```
+error: relation "some_table" already exists
+error: column "some_column" of relation "some_table" already exists
+Migration version mismatch: expected 22, got 22   (but the wrong V22__* files are applied)
+```
+
+**Cause**:
+
+`backend/src/db/migrate.js` parses each file's version from its `V<N>__name.up.sql` prefix (`parseVersion()`), then sorts migrations with `sort((a, b) => a.version - b.version || a.name.localeCompare(b.name))` — ties on the numeric version are broken **alphabetically by filename**, not by intent or dependency order.
+
+This repo's migration history has accumulated many files that share the same version number, e.g. `backend/src/db/migrations/` currently has **ten** different `V22__*.up.sql` files (`V22__add_github_username`, `V22__admin_user_moderation`, `V22__app_level_encryption`, `V22__audit_log_table`, `V22__contract_audit_log_enrichment`, `V22__escrow_webhooks`, `V22__price_alerts`, `V22__project_assessments`, `V22__soft_delete_jobs`, `V22__time_entry_milestone_index`), plus smaller collisions at V3, V5, V6, V10, V12, V13, V17, V19, V20, and V21. This happens when two feature branches are cut from the same base around the same time and each contributor picks "the next number" independently — both land with the same `V<N>` prefix.
+
+Because ordering within a tied version number is alphabetical rather than dependency-aware, a newly added migration that happens to sort before another already-applied `V<N>` migration can run against a database that doesn't yet have the schema it depends on, producing "relation/column already exists" or "does not exist" errors depending on which side of the collision you hit. `validateMigrationVersion()` (also in `migrate.js`) only compares the **max** version in `schema_migrations` against the **max** version on disk — it will not catch a collision as long as the highest version number still matches, so a colliding migration can pass that check and still fail during `migrate()` itself.
+
+**Fix**:
+
+#### 1. Check for existing collisions before adding a new migration
+
+```bash
+cd backend/src/db/migrations
+ls | sed -E 's/\.(up|down)\.sql$//' | sed -E 's/^(V[0-9]+)__.*/\1/' | sort | uniq -c | sort -rn | awk '$1>1'
+```
+
+#### 2. Always pick the next unused number
+
+```bash
+ls backend/src/db/migrations/*.up.sql | sed -E 's#.*/V([0-9]+)__.*#\1#' | sort -n | tail -1
+```
+Use that number **+ 1** for your new migration, and re-run this check immediately before opening your PR — someone else's migration may have landed on `main` in the meantime.
+
+#### 3. If your PR collides with one already merged to `main`
+
+Rebase and rename your migration files (both `.up.sql` and `.down.sql`) to the next free version number rather than keeping the duplicate — do not rely on alphabetical tie-breaking to "sort it out".
+
+#### 4. If a collision has already been applied to a shared database
+
+Inspect `schema_migrations` to see which of the colliding files actually ran and in what order, then reconcile manually:
+```bash
+psql "$DATABASE_URL" -c "SELECT name, version, applied_at FROM schema_migrations ORDER BY applied_at;"
+```
+
+**Related Files**:
+- `backend/src/db/migrate.js`
+- `backend/src/db/migrations/`
+
+---
+
 ### Redis Connection Refused
 
 **Symptom**:
@@ -762,6 +883,77 @@ curl -X POST https://api.pinata.cloud/pinning/pinFileToIPFS \
 
 ---
 
+### CSRF 403 Errors When Calling the API From a Script
+
+**Symptom**:
+```
+403 Forbidden
+{"error":"invalid csrf token"}
+```
+Happens when calling a state-mutating endpoint (`POST`/`PUT`/`PATCH`/`DELETE`) with `curl`, Postman, or a Node script against a cookie-authenticated session, but never when the same call is made from the actual frontend in a browser.
+
+**Cause**:
+
+`backend/src/middleware/csrf.js` implements the double-submit cookie pattern via the `csrf-csrf` package:
+
+1. The client must first call `GET /api/auth/csrf-token`, which sets an HMAC-signed, non-`HttpOnly` `csrf-token` cookie and also returns the token in the JSON body.
+2. Every subsequent state-mutating request must echo that token back in the `X-CSRF-Token` header (checked case-insensitively as `x-csrf-token`, with `x-xsrf-token` accepted as a legacy alias).
+3. `shouldSkipCsrf()` only bypasses this for: safe methods (`GET`/`HEAD`/`OPTIONS`), the `/api/auth/*` bootstrap routes, health/metrics/docs endpoints, `/api/public/*` and `/api/developer/*` (which authenticate via `X-API-Key` instead of cookies), and `Authorization: Bearer` requests that carry **no** `token`/`refreshToken` cookie.
+
+A script that logs in via `POST /api/auth/login` (which sets `token`/`refreshToken` cookies) and then replays that cookie jar against a plain endpoint like `POST /api/jobs` — without also fetching and forwarding the CSRF token — is exactly the case this middleware is designed to reject. That is a legitimate 403, not a bug.
+
+**Fix**:
+
+#### 1. Fetch a CSRF token and keep the cookie jar
+
+```bash
+# Persist cookies across requests
+curl -c cookies.txt -b cookies.txt http://localhost:4000/api/auth/csrf-token
+```
+Note the `csrfToken` field in the JSON response.
+
+#### 2. Send the token back on every mutating request
+
+```bash
+curl -c cookies.txt -b cookies.txt \
+  -X POST http://localhost:4000/api/jobs \
+  -H "X-CSRF-Token: <token from step 1>" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "..."}'
+```
+
+#### 3. In a Node/JS script
+
+```javascript
+const { token } = await fetch(`${API_URL}/api/auth/csrf-token`, { credentials: 'include' })
+  .then(r => r.json());
+
+await fetch(`${API_URL}/api/jobs`, {
+  method: 'POST',
+  credentials: 'include', // send the cookie jar
+  headers: {
+    'Content-Type': 'application/json',
+    'X-CSRF-Token': token,
+  },
+  body: JSON.stringify({ title: '...' }),
+});
+```
+
+#### 4. Prefer API-key auth for pure scripting/integration use cases
+
+If you're writing a script or service integration rather than driving the cookie-based session a browser would use, use the `/api/developer/*` or `/api/public/*` endpoints with an `X-API-Key` header instead — `shouldSkipCsrf()` exempts these paths entirely since API keys aren't vulnerable to cross-site request forgery the way cookies are.
+
+#### 5. Re-fetch the token after login/logout
+
+The CSRF token is bound to the session via `getSessionIdentifier()` (keyed off the `refreshToken` cookie), so a token fetched before login (or before a token refresh rotates `refreshToken`) will be rejected afterward. Always fetch a fresh CSRF token immediately before the mutating call, or immediately after any auth state change.
+
+**Related Files**:
+- `backend/src/middleware/csrf.js`
+- `backend/src/testUtils/csrfTestHelpers.js` (reference implementation used by the backend's own integration tests)
+- `docs/auth-flow.md`
+
+---
+
 ## CI/CD Issues
 
 ### Workflow Failures (Missing Secrets)
@@ -1004,4 +1196,4 @@ If this guide doesn't resolve your issue:
 
 ---
 
-**Last Updated**: 2026-05-28
+**Last Updated**: 2026-08-24


### PR DESCRIPTION
## Summary

Closes #1197
Closes #1200
Closes #1202
Closes #1196

Four related docs/CI issues resolved together, all grounded in the actual current source tree (`contracts/marketpay-contract/src/lib.rs`, `contracts/arbitrator-registry/src/lib.rs`, `backend/`, `frontend/`) rather than assumptions.

### #1197 — `docs/architecture.md`
The old diagram and job-lifecycle section only showed `create_escrow`/`start_work`/`release_escrow`/`refund_escrow`. Redrawn against the real system:
- System diagram and job lifecycle now reflect the full contract surface (71 public entrypoints in `marketpay-contract`, plus the separate `arbitrator-registry` contract) — milestones, sealed-bid auctions, dispute bonds, arbitration cases, DAO governance, job boosts, deliverable oracle, certificates, ratings, multi-sig admin/freeze.
- Corrected the funds-flow description: the frontend builds and signs Soroban transactions directly via Freighter and submits them straight to Soroban RPC/Horizon — the Express backend never custodies escrowed funds. It's a REST/GraphQL API + PostgreSQL-backed Horizon indexer/cache, with one narrow exception: a service-keypair-signed path used only for automated timeout refunds and recurring-escrow ticks.
- Added a components breakdown (frontend, backend, contracts, infra/deploy) and noted `packages/backend`/`packages/client` are unwired legacy/prototype code, not part of the live build.

### #1200 — `docs/contract-api-reference.md`
Regenerated from the current `lib.rs` sources. Previously missing/undocumented:
- Milestones (`release_milestone`, `reject_milestone`)
- Sealed-bid budget commitment and freelancer bid auctions (`commit_budget`/`reveal_budget`, `submit_bid_commitment`/`close_bidding`/`reveal_bid`)
- Dispute bonds (`set_dispute_bond`, `get_dispute_bond*`, bonded `raise_dispute`/`resolve_dispute` flow)
- Arbitration cases (`resolve_arbitration`) — including an explicit note that case-creation/vote-submission entrypoints referenced by error codes 7007–7013 don't exist yet, a real gap in the current contract
- Multi-sig admin/freeze (`freeze_contract`, `unfreeze_contract`, `add_admin`, `set_unfreeze_threshold`)
- Timeout extensions, on-chain messaging, deliverable-hash oracle, certificates, ratings
- The separate `arbitrator-registry` contract's full API (register/deregister/DAO-driven registration, staking)
- A corrected events table (removed two fabricated events, added the ~12 real ones found via source grep) and the full error-code reference, with a note that several `panic!()` strings in `lib.rs` aren't reflected in `errors.rs`'s `error_code_from_panic` reverse-mapping.

### #1202 — `docs/troubleshooting.md`
Added the three failure modes named in the issue, each grounded in this repo's actual tooling:
- **npm ci peer-dependency errors** — tied to `frontend/package.json`'s React/Storybook version pinning and the historical `react-dom@19`/`storybook@10` drift mentioned in #1196.
- **Migration version collisions** — `backend/src/db/migrations/` currently has *ten* different `V22__*.up.sql` files (plus smaller collisions at V3/V5/V6/V10/V12/V13/V17/V19/V20/V21); documented why `backend/src/db/migrate.js`'s alphabetical tie-break ordering makes this a real correctness risk, not just a cosmetic issue.
- **CSRF 403s when calling the API from a script** — walked through `backend/src/middleware/csrf.js`'s double-submit cookie pattern and exactly what a `curl`/Node script needs to do (fetch `/api/auth/csrf-token`, keep the cookie jar, echo `X-CSRF-Token`) versus using the API-key-authenticated `/api/developer/*` routes instead.

### #1196 — `.github/dependabot.yml`
The file was removed (last seen disabled via `open-pull-requests-limit: 0` in commit `b1da30a`, then deleted). Reintroduced, scoped per ecosystem actually present in this repo:
- `npm` for `/frontend`, `/backend`, and `/` (root tooling)
- `cargo` for `/contracts/marketpay-contract` and `/contracts/arbitrator-registry`
- `github-actions` for the workflows in `.github/workflows/`

Each ecosystem gets: weekly schedule, a `minor-patch` group for version updates, a separate `security` group for security-only updates, major versions excluded from automated PRs (reviewed manually, one at a time — the exact failure mode #1196 describes, e.g. `react-dom@19` alongside `react@18`), a per-ecosystem `open-pull-requests-limit` cap, and `dependencies`/ecosystem labels plus the existing assignee convention from the prior config.

## Test plan

- [x] Verified current `.github/dependabot.yml` is absent and confirmed its removal history via `git log --all -- .github/dependabot.yml`
- [x] Verified the migration-collision claim: `ls backend/src/db/migrations/*.up.sql | sed -E 's#.*/V([0-9]+)__.*#\1#' | sort -n | uniq -c` shows real duplicates
- [x] Verified the CSRF flow against the actual `backend/src/middleware/csrf.js` implementation
- [x] Cross-checked every documented contract function signature against `contracts/marketpay-contract/src/lib.rs` and `contracts/arbitrator-registry/src/lib.rs` (71 + 13 public entrypoints respectively)
- [x] `.github/dependabot.yml` is valid YAML (v2 schema, matches Dependabot's documented `groups`/`applies-to` syntax)
- Docs-only + CI-config-only change — no application code touched, no build/test impact expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)