### PR TITLE
fix(security): pin nanoid to patched 3.3.18 to close high advisory

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -66,7 +66,8 @@
     "overrides": {
         "bull": {
             "uuid": "^11.1.1"
-        }
+        },
+        "nanoid": "^3.3.18"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
Closes #1162.

`npm audit` in `backend/` flagged nanoid's high-severity advisories:
- [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) — custom generators loop indefinitely with a negative size (patched in 3.3.16)
- [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators loop indefinitely when size is zero (patched in 3.3.18)

nanoid is not a direct dependency — it's pulled in transitively only via `postcss` (`postcss -> nanoid@^3.3.16`), which itself sits outside backend's production dependency tree.

**Investigation:** a from-scratch `npm ci` + `npm audit --omit=dev --audit-level=high` (the exact command the Security workflow gates on) already comes back clean today. Tracing the lockfile, the immediately preceding commit (882c4d5, an unrelated `bull`/`uuid` override) caused npm to regenerate `package-lock.json` and incidentally re-resolve nanoid from 3.3.16 → 3.3.18 as a side effect — so the advisory was already resolved, just by accident rather than intent.

**Fix:** pin nanoid explicitly via `overrides` in `backend/package.json` (same pattern as the existing `bull`/`uuid` override), so a future lockfile regeneration can't silently drop back to a vulnerable 3.x nanoid. `package-lock.json` has no diff since the resolved version was already correct.

No audit-exception entry is needed — a fully patched version exists and is installed, so there's no residual risk to document as accepted.

## Test plan
- [x] `npm ci` from a clean `node_modules` in `backend/`
- [x] `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities (matches CI's blocking gate)
- [x] `npm audit --audit-level=moderate` → only pre-existing, unrelated moderate `qs`/`typed-rest-client` findings remain (non-blocking, gated at `high`)