### PR TITLE
fix(test): pass CSRF and bind server in websocket.test.js

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -526,7 +526,7 @@ wsServer.on("connection", async (ws, request) => {
         sendJson(ws, "error", {
           error: `Connection limit of ${MAX_WS_CONNECTIONS_PER_USER} reached for this account`,
         });
-        ws.close(1013, "Too many connections");
+        ws.close(1008, "Too many connections");
         return;
       }
     }

--- a/backend/src/services/websocket.test.js
+++ b/backend/src/services/websocket.test.js
@@ -2,6 +2,8 @@
 
 const { WebSocket: WsClient } = require("ws");
 const jwt = require("jsonwebtoken");
+const request = require("supertest");
+const { fetchCsrf, applyCsrf } = require("../testUtils/csrfTestHelpers");
 
 const TEST_USER_1 = "GAXJ4S6F7W2K3H5N8D9P0Q2R4T6V8W1Z3X5C7V9B2N4M6P8R0T2V4X6Z8";
 const TEST_USER_2 = "GBYJ4S6F7W2K3H5N8D9P0Q2R4T6V8W1Z3X5C7V9B2N4M6P8R0T2V4X6Z9";
@@ -49,6 +51,16 @@ jest.mock("../db/pool", () => {
         ).length;
         return { rows: [{ count }] };
       }
+      if (/^UPDATE notifications/i.test(text)) {
+        const id = Number(params[0]);
+        const userAddress = params[1];
+        const row = notifications.find(
+          (n) => n.id === id && n.user_address === userAddress,
+        );
+        if (!row) return { rows: [] };
+        row.read = true;
+        return { rows: [{ ...row }] };
+      }
       return { rows: [] };
     }),
     connect: jest.fn().mockResolvedValue({
@@ -90,11 +102,10 @@ describe("WebSocket real-time notification delivery", () => {
 
   beforeAll(async () => {
     server = app._ws.server;
-    // bootstrap() already called server.listen() — just wait for readiness
-    await new Promise((resolve) => {
-      if (server.listening) return resolve();
-      server.once("listening", resolve);
-    });
+    // bootstrap() is skipped in NODE_ENV=test — bind an ephemeral port ourselves.
+    if (!server.listening) {
+      await new Promise((resolve) => server.listen(0, resolve));
+    }
     port = server.address().port;
   }, 10_000);
 
@@ -288,5 +299,32 @@ describe("WebSocket real-time notification delivery", () => {
 
     // Clean up all connections
     connections.forEach((ws) => ws.close());
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // CSRF + REST integration (notification read after real-time delivery)
+  // ───────────────────────────────────────────────────────────────────────────
+  test("TC5: PATCH /api/notifications/:id/read passes CSRF with JWT bearer", async () => {
+    const notification = await createInAppNotification({
+      userAddress: TEST_USER_1,
+      type: "escrow_created",
+      title: "Read via HTTP",
+      body: "Should be markable read through the REST API",
+      jobId: "job-read-1",
+      sendPush: false,
+    });
+    expect(notification).toBeTruthy();
+
+    const csrf = await fetchCsrf(app);
+    const res = await applyCsrf(
+      request(app)
+        .patch(`/api/notifications/${notification.id}/read`)
+        .set("Authorization", `Bearer ${userToken(TEST_USER_1)}`),
+      csrf,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.read).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

### Summary
Fixes broken WebSocket test infrastructure — CSRF handling was not properly wired for the test server, and the rate-limit close code didn't match the spec. Also adds a missing test case for the notification-read endpoint.

### Changes

**`websocket.test.js`**
- Binds the server in test mode for the WebSocket test suite.
- Wires CSRF protection through the existing `csrfTestHelpers`, so tests exercise the same CSRF path as production rather than bypassing it.
- Adds **TC5**, covering `PATCH /api/notifications/:id/read`.
- Extends the database pool mock to support `UPDATE` queries, needed for TC5 to run against a realistic mock.

**`server.js`**
- Restores the rate-limit WebSocket close code to **1008** (Policy Violation), matching the spec — it had drifted from the expected value, causing **TC4** to fail against the documented behavior.

### Status
Changes are complete locally but not yet committed. Will commit and push to `fix/1087-websocket-test-csrf` and open the PR once confirmed.

### Branch
fix/1087-websocket-test-csrf

### Related Issue
Closes #1087