### PR TITLE
docs(db): align migration headers and documentation for renumbered V1…

### DIFF
--- a/backend/src/db/migrations/V18__full_text_search_idempotency_metrics.down.sql
+++ b/backend/src/db/migrations/V18__full_text_search_idempotency_metrics.down.sql
@@ -1,4 +1,4 @@
--- Rollback V12: #553, #559, #561
+-- Rollback V18: #553, #559, #561
 
 -- Issue #561: platform_metrics
 DROP TABLE IF EXISTS platform_metrics CASCADE;

--- a/backend/src/db/migrations/V19__job_archiving.down.sql
+++ b/backend/src/db/migrations/V19__job_archiving.down.sql
@@ -1,6 +1,6 @@
--- V12__job_archiving.down.sql
+-- V19__job_archiving.down.sql
 --
--- Reverses V12__job_archiving.up.sql.
+-- Reverses V19__job_archiving.up.sql.
 --
 -- WARNING: This rollback does NOT restore rows that have already been moved to
 -- the archive tables. It only drops the archiving infrastructure. If you need

--- a/backend/src/db/migrations/V19__job_archiving.up.sql
+++ b/backend/src/db/migrations/V19__job_archiving.up.sql
@@ -1,4 +1,4 @@
--- V12__job_archiving.up.sql
+-- V19__job_archiving.up.sql
 --
 -- Data Archiving Strategy for Old Completed Jobs
 --

--- a/docs/data-archiving.md
+++ b/docs/data-archiving.md
@@ -222,7 +222,7 @@ COMMIT;
 To drop the archiving infrastructure entirely, run the down-migration:
 
 ```bash
-psql $DATABASE_URL -f backend/src/db/migrations/V12__job_archiving.down.sql
+psql $DATABASE_URL -f backend/src/db/migrations/V19__job_archiving.down.sql
 ```
 
 ---

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -718,16 +718,53 @@ Migrations follow a Flyway-style `V{n}__{description}.{up|down}.sql` naming conv
 |---------|-------------|
 | V1 | Initial schema — profiles, jobs, applications, escrows, ratings, messages |
 | V2 | Admin 2FA, job drafts |
-| V3 | Contract events, indexer state, skill certificates |
-| V4 | Developer API keys, audit trail, frozen wallets |
-| V5 | Weekly digest fields on profiles |
-| V6 | Job recommendations index, on-chain message fields |
-| V7 | Job search filter composite indexes |
-| V9 | Milestone escrow JSONB columns |
-| V10 | In-app notifications table, sealed-bid commitment columns |
-| V11 | Query optimization composite indexes |
-| V12 | Profile field encryption (pgp_sym_encrypt), full-text search, idempotency metrics |
-| V13 | `updated_at` triggers on all tables, API key rotation |
-| V14 | Normalized `job_skills` table |
+| V3 | Contract events and indexer state |
+| V4 | Skill certificates |
+| V5 | Developer API keys and audit trail |
+| V6 | Private message nonce uniqueness |
+| V7 | Weekly digest fields |
+| V8 | Job recommendations index |
+| V9 | On-chain message fields |
+| V10 | Saved searches |
+| V11 | Job search filter indexes |
+| V12 | DAO governance |
+| V13 | Milestone escrow |
+| V14 | In-app notifications |
+| V15 | Sealed bid commitments |
+| V16 | Query optimization indexes |
+| V17 | Add idempotency keys |
+| V18 | Full-text search and idempotency metrics |
+| V19 | Data archiving strategy and stored procedures |
+| V20 | Profile field encryption |
+| V21 | Full-text search additions |
+| V22 | `updated_at` triggers on all tables |
+| V23 | API key rotation |
+| V24 | Normalized `job_skills` table |
+| V25 | `jobs_skills` GIN index |
+| V26 | Status subscriptions |
+| V27 | Message attachments |
+| V28 | GDPR deletion support |
+| V29 | WebSocket event queue |
+| V30 | Job category taxonomy |
+| V31 | API key usage minute rate tracking |
+| V32 | Escrow extensions |
+| V33 | TF-IDF vocabulary |
+| V34 | Deliverable submissions |
+| V35 | Recurring escrow |
+| V36 | Job timeline |
+| V37 | Proposal templates |
+| V38 | Add GitHub username to profiles |
+| V39 | Admin user moderation and audit log |
+| V40 | App-level encryption |
+| V41 | Audit log table |
+| V42 | Contract audit log enrichment |
+| V43 | Escrow webhooks |
+| V44 | Price alerts |
+| V45 | Project assessments |
+| V46 | Soft delete jobs |
+| V47 | Time entry milestone index |
+| V48 | Missing foreign key and index optimizations |
+| V49 | NFT certificates |
 
 The schema is applied idempotently (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`). No destructive changes are made to existing data by default.
+


### PR DESCRIPTION
## Summary

- Updated SQL comment headers in [`V18__full_text_search_idempotency_metrics.down.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V18__full_text_search_idempotency_metrics.down.sql), [`V19__job_archiving.up.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V19__job_archiving.up.sql), and [`V19__job_archiving.down.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V19__job_archiving.down.sql) to accurately reflect their assigned version numbers rather than legacy `V12` prefixes.
- Corrected down-migration script references in [`docs/data-archiving.md`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/docs/data-archiving.md) from `V12__job_archiving.down.sql` to `V19__job_archiving.down.sql`.
- Updated the comprehensive migrations table in [`docs/database-schema.md`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/docs/database-schema.md) to document all 49 sequential migrations (`V1` to `V49`) with unique, strictly increasing version numbers and matching descriptions.

## Why

Multiple migrations originally shared the `V12` prefix (such as `dao_governance`, `job_archiving`, `full_text_search_idempotency_metrics`, and `jobs_skills_gin_index`). Following the migration renumbering to unique sequential prefixes (`V12`, `V18`, `V19`, `V25`), residual `V12` header comments and outdated references in the documentation caused ambiguity regarding migration rollback commands and schema lineage.

## Implementation

- Updated SQL headers in:
  - `backend/src/db/migrations/V18__full_text_search_idempotency_metrics.down.sql`
  - `backend/src/db/migrations/V19__job_archiving.up.sql`
  - `backend/src/db/migrations/V19__job_archiving.down.sql`
- Updated rollback CLI commands in `docs/data-archiving.md`.
- Expanded the migration index table in `docs/database-schema.md` to cover `V1` through `V49`.

## Testing

- `npm --prefix backend run test:unit src/db/migrations.test.js` — 3 passed, 0 failed.
- `npm --prefix backend run test:unit src/db/migrationValidation.test.js` — 11 passed, 0 failed.
- `npm --prefix backend run lint` — passed with 0 errors.

## Scope / Risk

- SQL comments and documentation files only.
- Zero runtime schema modifications; no risk to active database state.

## Issue

Closes #1064
