### PR TITLE
docs(db): align migration headers for renumbered V22 and V23 scripts

### DIFF
--- a/backend/src/db/migrations/V22__add_updated_at_triggers.down.sql
+++ b/backend/src/db/migrations/V22__add_updated_at_triggers.down.sql
@@ -1,4 +1,4 @@
--- V13__add_updated_at_triggers.down.sql
+-- V22__add_updated_at_triggers.down.sql
 
 DO $$
 DECLARE

--- a/backend/src/db/migrations/V22__add_updated_at_triggers.up.sql
+++ b/backend/src/db/migrations/V22__add_updated_at_triggers.up.sql
@@ -1,4 +1,4 @@
--- V13__add_updated_at_triggers.up.sql
+-- V22__add_updated_at_triggers.up.sql
 
 -- 1. Create the trigger function
 CREATE OR REPLACE FUNCTION set_updated_at()

--- a/backend/src/db/migrations/V23__api_key_rotation.down.sql
+++ b/backend/src/db/migrations/V23__api_key_rotation.down.sql
@@ -1,3 +1,4 @@
+-- V23__api_key_rotation.down.sql
 ALTER TABLE api_keys
   DROP COLUMN IF EXISTS rotating_key_hash,
   DROP COLUMN IF EXISTS rotating_at,

--- a/backend/src/db/migrations/V23__api_key_rotation.up.sql
+++ b/backend/src/db/migrations/V23__api_key_rotation.up.sql
@@ -1,3 +1,4 @@
+-- V23__api_key_rotation.up.sql
 ALTER TABLE api_keys
   ADD COLUMN IF NOT EXISTS rotating_key_hash TEXT,
   ADD COLUMN IF NOT EXISTS rotating_at TIMESTAMPTZ,


### PR DESCRIPTION
## Summary

- Updated SQL comment headers in [`V22__add_updated_at_triggers.up.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V22__add_updated_at_triggers.up.sql) and [`V22__add_updated_at_triggers.down.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V22__add_updated_at_triggers.down.sql) from legacy `V13` references to `V22`.
- Added standardized version headers to [`V23__api_key_rotation.up.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V23__api_key_rotation.up.sql) and [`V23__api_key_rotation.down.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V23__api_key_rotation.down.sql).
- Verified that all migrations (`V13__milestone_escrow`, `V22__add_updated_at_triggers`, and `V23__api_key_rotation`) load sequentially with distinct version numbers across [`backend/src/db/migrations.test.js`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations.test.js) and [`backend/src/db/migrationValidation.test.js`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrationValidation.test.js).

## Why

Three separate migrations originally shared the `V13` prefix (`milestone_escrow`, `add_updated_at_triggers`, and `api_key_rotation`). Following the migration renumbering to `V13`, `V22`, and `V23`, residual header comments referencing `V13` in the `V22` scripts created confusion during schema inspection and audit tracking.

## Implementation

- Updated SQL header comments in `backend/src/db/migrations/V22__add_updated_at_triggers.up.sql` and `down.sql`.
- Added explicit version header comments to `backend/src/db/migrations/V23__api_key_rotation.up.sql` and `down.sql`.

## Testing

- `npm --prefix backend run test:unit src/db/migrations.test.js` — 3 passed, 0 failed.
- `npm --prefix backend run test:unit src/db/migrationValidation.test.js` — 11 passed, 0 failed.
- `npm --prefix backend run lint` — passed with 0 errors.

## Scope / Risk

- SQL comments only.
- Zero runtime schema changes; no risk to active database state.

## Issue

Closes #1065
