### PR TITLE
docs(db): align migration headers for renumbered V31, V32, and V33 sc…

### DIFF
--- a/backend/src/db/migrations/V31__api_key_usage_minute.down.sql
+++ b/backend/src/db/migrations/V31__api_key_usage_minute.down.sql
@@ -1,3 +1,4 @@
+-- V31__api_key_usage_minute.down.sql
 DROP INDEX IF EXISTS idx_api_key_usage_minute_endpoint_time;
 DROP INDEX IF EXISTS idx_api_key_usage_minute_key_time;
 DROP TABLE IF EXISTS api_key_usage_minute;

--- a/backend/src/db/migrations/V31__api_key_usage_minute.up.sql
+++ b/backend/src/db/migrations/V31__api_key_usage_minute.up.sql
@@ -1,3 +1,4 @@
+-- V31__api_key_usage_minute.up.sql
 -- Per-minute API key usage breakdown for the issue #452 sliding window rate
 -- limiter. The daily aggregate table (`api_key_usage_daily` from V4) is kept
 -- untouched so existing admin dashboard widgets continue to work. The new

--- a/backend/src/db/migrations/V32__escrow_extensions.down.sql
+++ b/backend/src/db/migrations/V32__escrow_extensions.down.sql
@@ -1,2 +1,2 @@
--- V19: Rollback escrow_extensions table
+-- V32: Rollback escrow_extensions table
 DROP TABLE IF EXISTS escrow_extensions;

--- a/backend/src/db/migrations/V32__escrow_extensions.up.sql
+++ b/backend/src/db/migrations/V32__escrow_extensions.up.sql
@@ -1,4 +1,4 @@
--- V19: Escrow timeout extension by mutual consent
+-- V32: Escrow timeout extension by mutual consent
 -- Tracks pending and approved on-chain extension requests
 -- so the DB stays consistent with the Soroban contract state.
 

--- a/backend/src/db/migrations/V33__tfidf_vocabulary.down.sql
+++ b/backend/src/db/migrations/V33__tfidf_vocabulary.down.sql
@@ -1,2 +1,2 @@
--- V19__tfidf_vocabulary
+-- V33__tfidf_vocabulary.down.sql
 DROP TABLE IF EXISTS tfidf_vocabulary;

--- a/backend/src/db/migrations/V33__tfidf_vocabulary.up.sql
+++ b/backend/src/db/migrations/V33__tfidf_vocabulary.up.sql
@@ -1,4 +1,4 @@
--- V19__tfidf_vocabulary
+-- V33__tfidf_vocabulary.up.sql
 -- Stores the global term vocabulary and IDF weights for the job recommendation TF-IDF engine
 
 CREATE TABLE IF NOT EXISTS tfidf_vocabulary (


### PR DESCRIPTION
## Summary

- Updated SQL comment headers across the migrations renumbered from the former `V19` prefix:
  - Added standardized version headers to [`V31__api_key_usage_minute.up.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V31__api_key_usage_minute.up.sql) and [`V31__api_key_usage_minute.down.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V31__api_key_usage_minute.down.sql).
  - Updated legacy `V19` header comments in [`V32__escrow_extensions.up.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V32__escrow_extensions.up.sql) and [`V32__escrow_extensions.down.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V32__escrow_extensions.down.sql) to `V32`.
  - Updated legacy `V19` header comments in [`V33__tfidf_vocabulary.up.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V33__tfidf_vocabulary.up.sql) and [`V33__tfidf_vocabulary.down.sql`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations/V33__tfidf_vocabulary.down.sql) to `V33`.
- Verified that all migrations load in strict sequential order without collisions across [`backend/src/db/migrations.test.js`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrations.test.js) and [`backend/src/db/migrationValidation.test.js`](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/Stellar-MarketPay-/backend/src/db/migrationValidation.test.js).

## Why

Three separate migrations originally shared the `V19` prefix (`api_key_usage_minute`, `escrow_extensions`, and `tfidf_vocabulary`). Following their renumbering to unique sequential prefixes (`V31`, `V32`, and `V33`), residual `V19` comments in the `.up.sql` and `.down.sql` files created ambiguity during manual SQL auditing and schema verification.

## Implementation

- Updated SQL comment headers in:
  - `backend/src/db/migrations/V31__api_key_usage_minute.up.sql` and `down.sql`
  - `backend/src/db/migrations/V32__escrow_extensions.up.sql` and `down.sql`
  - `backend/src/db/migrations/V33__tfidf_vocabulary.up.sql` and `down.sql`

## Testing

- `npm --prefix backend run test:unit src/db/migrations.test.js` — 3 passed, 0 failed.
- `npm --prefix backend run test:unit src/db/migrationValidation.test.js` — 11 passed, 0 failed.
- `npm --prefix backend run lint` — passed with 0 errors.

## Scope / Risk

- SQL comments only.
- Zero runtime schema changes; no risk to active database state.

## Issue

Closes #1066
