### PR TITLE
fix(test): stabilize Rising Talent tier assertion in profileService.t…

### DIFF
--- a/backend/src/services/profileService.test.js
+++ b/backend/src/services/profileService.test.js
@@ -17,6 +17,9 @@ const {
 
 describe("profileService", () => {
   const publicKey = "GABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABC";
+  // Rising Talent requires account age < 90 days — keep this relative so the
+  // assertion stays stable as the calendar moves forward.
+  const recentCreatedAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -145,14 +148,14 @@ describe("profileService", () => {
         total_earned_xlm: "150.0000000",
         avg_rating: "4.80",
         rating_count: 2,
-        created_at: "2026-04-23T00:00:00.000Z",
-        updated_at: "2026-04-23T00:00:00.000Z",
+        created_at: recentCreatedAt,
+        updated_at: recentCreatedAt,
       };
       pool.query
         .mockResolvedValueOnce({ rows: [profileRow] })
         .mockResolvedValueOnce({
           rows: [{
-            created_at: profileRow.created_at,
+            created_at: recentCreatedAt,
             completed_jobs: 3,
             total_jobs: 3,
             total_earned_xlm: "150.0000000",


### PR DESCRIPTION
## Description

### Summary
Fixes a flaky/time-dependent test failure in `profileService.test.js`. The issue's overall title implicates a repo-wide CSRF root cause (113 failures across 23 suites), but this specific suite's failure is unrelated to CSRF — it's a unit test with a mocked pool and no HTTP layer, so CSRF doesn't apply here. The actual cause is a hardcoded date that aged past the tier-eligibility threshold.

### Root Cause
- The "Rising Talent" tier requires account age **< 90 days**.
- The test used a hardcoded `created_at: "2026-04-23"`, which is now ~123 days old as of August 2026.
- As a result, the test expected `"Rising Talent"` but the service correctly returned `"Newcomer"` — the test itself had gone stale, not the underlying logic.

### Fix
Replaced the hardcoded date with a relative date (30 days ago), so the assertion stays valid regardless of when the test runs:

```javascript
const recentCreatedAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
```

### CSRF Helper Note (for maintainer context)
The repo-wide CSRF helper requested in the parent issue already exists on `main` at `backend/src/testUtils/csrfTestHelpers.js`:
- `fetchCsrf(app)` — fetches a CSRF token/cookie pair from `/api/auth/csrf-token`.
- `applyCsrf(req, csrf)` — applies the cookie and `X-CSRF-Token` header to supertest requests.
- Already in use in HTTP-based route tests (e.g. `aiScorer.test.js`).

No new CSRF helper was needed for this specific fix, since `profileService.test.js` doesn't make HTTP requests.

### Verification
- `npx jest src/services/profileService.test.js` passes with the date fix applied.



### Related Issue
Closes #1085