### PR TITLE
fix(db): verify V10 migration prefix is unique (#1068)

### DIFF
--- a/backend/src/db/migrationValidation.test.js
+++ b/backend/src/db/migrationValidation.test.js
@@ -95,6 +95,13 @@ describe("assertUniqueVersions()", () => {
     expect(v6).toHaveLength(1);
     expect(v6[0].name).toBe("V6__private_message_nonce_unique");
   });
+
+  it("V10 migration prefix is used by exactly one migration (issue #1068)", () => {
+    const migrations = loadMigrationPairs();
+    const v10 = migrations.filter((m) => m.version === 10);
+    expect(v10).toHaveLength(1);
+    expect(v10[0].name).toBe("V10__saved_searches");
+  });
 });
 
 describe("getCurrentMigrationVersion()", () => {


### PR DESCRIPTION
Closes #1068

## What

Adds a targeted regression test verifying that the V10 migration prefix is used by exactly one migration file (\V10__saved_searches\), preventing future duplication.

## Why

The V10 prefix was previously shared by two unrelated migrations (\V10__in_app_notifications\ and \V10__sealed_bid_commitments\). Commit \d0fe57\ renumbered them to V14 and V15 respectively, but no regression test existed to prevent duplicates from being reintroduced.

## Verification

- \ssertUniqueVersions()\ test suite: 3 passed, 9 skipped (Postgres-dependent)
- V10 uniqueness test: **passed**