### PR TITLE
fix(db): verify V6 migration prefix is unique (#1067)

### DIFF
--- a/backend/src/db/migrationValidation.test.js
+++ b/backend/src/db/migrationValidation.test.js
@@ -90,6 +90,13 @@ describe("assertUniqueVersions()", () => {
       ])
     ).toThrow(/Duplicate migration version V1/);
   });
+
+  it("V6 migration prefix is used by exactly one migration (issue #1067)", () => {
+    const migrations = loadMigrationPairs();
+    const v6 = migrations.filter((m) => m.version === 6);
+    expect(v6).toHaveLength(1);
+    expect(v6[0].name).toBe("V6__private_message_nonce_unique");
+  });
 });
 
 describe("getCurrentMigrationVersion()", () => {


### PR DESCRIPTION
Closes #1067

## What

Adds a targeted regression test verifying that the V6 migration prefix is used by exactly one migration file (\V6__private_message_nonce_unique\), preventing future duplication.

## Why

The V6 prefix was previously shared by three unrelated migrations (\V6__job_recommendations_index\, \V6__onchain_message_fields\, \V6__saved_searches\). Commit \d0fe57\ renumbered them to V8, V9, and V10 respectively, but no regression test existed to prevent duplicates from being reintroduced.

## Verification

- \ssertUniqueVersions()\ test suite: 3 passed, 9 skipped (Postgres-dependent)
- V6 uniqueness test: **passed**