### PR TITLE
fix(test): add proper CSRF handling and cache isolation to contributo…

### DIFF
--- a/backend/jest.setup.js
+++ b/backend/jest.setup.js
@@ -18,11 +18,3 @@ process.env.CONTRACT_ID =
   "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 process.env.STELLAR_NETWORK = process.env.STELLAR_NETWORK || "testnet";
 
-// Mock CSRF protection in tests to allow hardcoded tokens
-jest.mock("./src/middleware/csrf", () => {
-  const actual = jest.requireActual("./src/middleware/csrf");
-  return {
-    ...actual,
-    doubleCsrfProtection: (req, res, next) => next(), // Skip CSRF validation in tests
-  };
-});

--- a/backend/src/routes/contributors.test.js
+++ b/backend/src/routes/contributors.test.js
@@ -21,16 +21,29 @@ jest.mock("../db/pool", () => {
   };
 });
 
-// axios may or may not be in node_modules, so use { virtual: true } to
-// avoid module-resolution failures.
-jest.mock(
-  "axios",
-  () => ({
-    get: jest.fn(),
-  }),
-  { virtual: true },
-);
+// Mock axios so tests control GitHub API responses.
+jest.mock("axios", () => ({
+  default: { create: jest.fn() },
+  get: jest.fn(),
+}));
 const axios = require("axios");
+
+// Mock stellar-sdk to avoid its axios dependency chain and network calls.
+jest.mock("@stellar/stellar-sdk", () => ({
+  Horizon: jest.fn(),
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  Keypair: { fromSecret: jest.fn(), fromPublicKey: jest.fn() },
+  TransactionBuilder: jest.fn(),
+  Account: jest.fn(),
+  Contract: jest.fn(),
+  nativeToScVal: jest.fn(),
+  scValToNative: jest.fn(),
+  Address: jest.fn(),
+  rpc: { Server: jest.fn() },
+  xdr: {},
+  Utils: { readChallengeTx: jest.fn(), verifyChallengeTxSigners: jest.fn() },
+  SorobanRpc: { Server: jest.fn() },
+}));
 
 jest.mock("../services/indexerService", () =>
   jest.fn().mockImplementation(() => ({ start: jest.fn() })),
@@ -49,6 +62,7 @@ jest.mock("../routes/notifications", () => {
 });
 
 const pool = require("../db/pool");
+const { fetchCsrf, applyCsrf } = require("../testUtils/csrfTestHelpers");
 const app = require("../server");
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
@@ -88,14 +102,31 @@ function computeScore(jobs, xlm, prs) {
 // ─── Suite ─────────────────────────────────────────────────────────────────
 
 describe("GET /api/contributors", () => {
-  // Bust the module-scoped contributorCache after each test so test
-  // isolation is preserved (cache must not leak between tests).
-  afterEach(async () => {
-    await request(app).post("/api/contributors/refresh");
-  });
+  // Monotonically advance fake time by 25 h each test so the module-scoped
+  // contributorCache (1 h TTL) and GitHub sub-cache (24 h TTL) are always
+  // stale at the start of every test.  Within a single test Date.now()
+  // returns the same value, so the caching-behaviour test still works.
+  let fakeTime;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    fakeTime = (fakeTime ?? Date.now()) + 25 * 60 * 60 * 1000;
+    jest.spyOn(Date, "now").mockReturnValue(fakeTime);
+    pool.query.mockResolvedValue({ rows: [] });
+    pool.connect.mockResolvedValue({
+      query: pool.query,
+      release: jest.fn(),
+    });
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    axios.get.mockResolvedValue({ data: [] });
+    pool.query.mockResolvedValue({ rows: [] });
+    await applyCsrf(
+      request(app).post("/api/contributors/refresh"),
+      await fetchCsrf(app),
+    );
   });
 
   // ── Score computation ─────────────────────────────────────────────────
@@ -465,6 +496,11 @@ describe("GET /api/contributors", () => {
 describe("POST /api/contributors/refresh", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    pool.query.mockResolvedValue({ rows: [] });
+    pool.connect.mockResolvedValue({
+      query: pool.query,
+      release: jest.fn(),
+    });
   });
 
   it("refreshes cache and returns fresh data", async () => {
@@ -482,7 +518,7 @@ describe("POST /api/contributors/refresh", () => {
       ],
     });
 
-    const res = await request(app).post("/api/contributors/refresh");
+    const res = await applyCsrf(request(app).post("/api/contributors/refresh"), await fetchCsrf(app));
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.message).toBe("Cache refreshed");


### PR DESCRIPTION


closes #1079

## fix(test): add proper CSRF handling to contributors.test.js 

### Problem

`jest.setup.js` contained a global CSRF mock that completely bypassed the `doubleCsrfProtection` middleware — it was a no-op `(req, res, next) => next()`. This meant no test ever exercised real CSRF validation.

The `contributors.test.js` suite was also broken independently of that mock:

- A `{ virtual: true }` axios mock didn't intercept real `require("axios")` calls from `@stellar/stellar-sdk`, causing `_axios.default.create is not a function`.
- `POST /api/contributors/refresh` never sent a CSRF token, so it would `401` once real middleware was restored.
- The module-scoped `contributorCache` leaked between tests — the `afterEach` refresh repopulated it with a fresh timestamp, making the next `GET` return stale cached data.

### Solution

**`jest.setup.js`** — Removed the global CSRF mock. Tests now use the existing `fetchCsrf` / `applyCsrf` helpers from `src/testUtils/csrfTestHelpers.js` to obtain and send real CSRF tokens, just like a browser client would.

**`contributors.test.js`** — Three fixes:

1. **Axios mock**: Removed `{ virtual: true }` so the mock replaces the real `node_modules/axios` for all consumers. Added `default: { create: jest.fn() }` so `@stellar/stellar-sdk`'s `horizon_axios_client` doesn't crash.
2. **Stellar-SDK mock**: Added a full `jest.mock("@stellar/stellar-sdk", ...)` to block its axios dependency chain and network calls entirely.
3. **Cache isolation**: Instead of fighting the cache with refresh calls that themselves re-populate it, the suite now uses a monotonic `Date.now()` spy — each `beforeEach` advances fake time by 25 hours (exceeding both the 1-hour main TTL and 24-hour GitHub sub-cache TTL). Within a single test the spy returns a fixed value, so the caching-behaviour test still works correctly. An `afterEach` refresh (with CSRF tokens) resets `_githubData` to prevent fallback leakage on the GitHub-API-failure test.

### Result

All 16/16 contributors tests pass. The CSRF token flow now matches production: fetch token via `GET /api/auth/csrf-token`, send via header on mutating requests.

### Files changed

| File |
|---|
| `backend/jest.setup.js` |
| `backend/src/routes/contributors.test.js` |


- [x] Global CSRF bypass removed — tests now exercise real middleware
- [x] Axios/Stellar-SDK mocking fixed so tests run in isolation without network calls
- [x] Cache isolation fixed between tests
- [x] All 16 tests in the suite passing
- [x] No new test infrastructure introduced — reuses existing shared helpers