### PR TITLE
ci: add fuzz workflow running contract fuzz targets (#1174)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,55 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "contracts/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "contracts/**"
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_create_escrow
+          - fuzz_release_escrow
+          - fuzz_timeout_refund
+    defaults:
+      run:
+        working-directory: contracts/marketpay-contract/fuzz
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.rustup
+            contracts/marketpay-contract/fuzz/target
+          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('contracts/**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-fuzz-
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Fuzz ${{ matrix.target }} (60s)
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60


### PR DESCRIPTION
## Summary
Adds a fuzz.yml GitHub Actions workflow that actually runs the three existing Cobra fuzz targets under contracts/marketpay-contract/fuzz/fuzz_targets/ (fuzz_create_escrow, fuzz_release_escrow, fuzz_timeout_refund). Previously these harnesses were dead code — no workflow invoked them, so they never guarded a PR.
The workflow is path-filtered to contracts/**, runs each target for ~60s, and uses fail-fast: false so a crash in one target doesn't hide failures in the others.
- Triggers on push/pull_request when contracts/** changes
- Matrix job over the three fuzz targets with fail-fast: false
- Reuses existing CI conventions (actions/checkout@v4, dtolnay/rust-toolchain, actions/cache)
- Installs cargo-fuzz and runs cargo fuzz run <target> -- -max_total_time=60
- working-directory set to contracts/marketpay-contract/fuzz

## Type
- Bug fix
- New feature
- Documentation
- Refactor
- Smart contract change
Related Issue

Closes #1174

## Testing
- Tested locally on Testnet
- No TypeScript / Rust errors
- Docs updated if needed
Screenshots (if UI change)
N/A — CI workflow only, 