### PR TITLE
 Add CSRF_SECRET to required environment variables

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,6 +14,7 @@ codebase is listed, along with its type, default, required status, and example.
 |---|---|---|---|---|---|
 | `DATABASE_URL` | `string` | — | PostgreSQL connection string used by the API and migrations. | Must be a valid PostgreSQL URL. Startup crashes if unset (`requireEnv`). | `postgresql://user:pass@localhost:5432/marketpay` |
 | `JWT_SECRET` | `string` | — | Signing key for auth tokens. | Must be a non-empty string. Startup crashes if unset (`process.exit(1)` in `auth.js`). | `4c9d0f7d6f4f4c0f8d1b3b...` |
+| `CSRF_SECRET` | `string` | `JWT_SECRET` (dev) / — (prod) | HMAC secret for signing `csrf-token` double-submit cookies. | **Required in production** — startup crashes if unset (`process.exit(1)` in `csrf.js`). Falls back to `JWT_SECRET` in dev/CI only. | `random-hmac-secret` |
 
 ### Network & Stellar
 


### PR DESCRIPTION
CSRF_SECRET is required in production (middleware/csrf.js calls process.exit(1) when NODE_ENV=production and it is unset), but was missing from the "Required" table in docs/environment-variables.md.

Added it alongside DATABASE_URL and JWT_SECRET. Audited every requireEnv() and process.exit(1) call in the backend against the docs — all are now covered.

closes#1204

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #1204 

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
