### PR TITLE
fix(test): assert rateLimiter 429 body.error field

### DIFF
--- a/backend/src/middleware/rateLimiter.test.js
+++ b/backend/src/middleware/rateLimiter.test.js
@@ -44,7 +44,8 @@ describe("rate limiter IP handling", () => {
       .set("X-Forwarded-For", "10.0.0.99");
 
     expect(blocked.status).toBe(429);
-    expect(blocked.body.message).toMatch(/too many requests/i);
+    // createRateLimiter handler returns `{ error }`, not `{ message }`.
+    expect(blocked.body.error).toMatch(/too many requests/i);
   });
 
   it("uses a consistent key for the same connection when headers are spoofed", async () => {


### PR DESCRIPTION
The suite failed because createRateLimiter returns { error }, not { message }. Align the assertion with the middleware response so src/middleware/rateLimiter.test.js passes.

Closes #1076 
## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract 

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed


