### PR TITLE
chore(db): add migration version uniqueness verification script (#1070)

### DIFF
--- a/scripts/verify-migration-versions.sh
+++ b/scripts/verify-migration-versions.sh
@@ -1,0 +1,15 @@
+﻿#!/usr/bin/env bash
+# Verify no duplicate migration versions exist.
+set -euo pipefail
+
+cd "$(dirname "$0")/../backend/src/db/migrations"
+
+ls V*__*.up.sql | sed 's/__.*//' | sort | uniq -d > /tmp/duplicate_versions.txt
+
+if [ -s /tmp/duplicate_versions.txt ]; then
+  echo "ERROR: Duplicate migration versions found:"
+  cat /tmp/duplicate_versions.txt
+  exit 1
+else
+  echo "OK: All migration versions are unique."
+fi


### PR DESCRIPTION
 Description
Adds a verification script to detect duplicate migration versions.

V20 duplicate was already resolved — all migration versions V1 through V49 are unique. This script prevents future regressions.

 Changes
- Added `scripts/verify-migration-versions.sh`
- Script scans `backend/src/db/migrations/` for duplicate version prefixes
- Exits with error if duplicates found

Closes #1070