### PR TITLE
fix(frontend): resolve TypeScript errors in FeeEstimationModal (#1112)

### DIFF
--- a/frontend/components/FeeEstimationModal.tsx
+++ b/frontend/components/FeeEstimationModal.tsx
@@ -143,6 +143,28 @@ export default function FeeEstimationModal({
         </dl>
       )}
 
+      {estimate && (
+        <div className="mb-4">
+          <label className="text-xs text-amber-700 block mb-1">
+            Max fee multiplier: {maxFeeMultiplier.toFixed(1)}×
+          </label>
+          <input
+            type="range"
+            min={1}
+            max={3}
+            step={0.5}
+            value={maxFeeMultiplier}
+            onChange={(e) => setMaxFeeMultiplier(Number(e.target.value))}
+            className="w-full accent-amber-500"
+          />
+          {maxFeeUsd != null && (
+            <p className="text-xs text-amber-700 mt-1">
+              Max fee: {maxFeeXlm} XLM ≈ \ USD
+            </p>
+          )}
+        </div>
+      )}
+
       {insufficient && (
         <p className="text-red-400 text-xs mb-3">
           Insufficient balance — top up XLM and try again.


### PR DESCRIPTION
 Description
Fixes 2 TypeScript errors in `FeeEstimationModal.tsx` where `maxFeeMultiplier` and `maxFeeUsd` were declared but never used.

 Changes
- Added fee multiplier slider (1×–3×) that uses `maxFeeMultiplier` and `setMaxFeeMultiplier`
- Added max fee display showing `maxFeeXlm` and `maxFeeUsd`
- Both previously-unused variables are now wired into the UI

Closes #1112