### PR TITLE
fix: remove dead build step from e2e workflow and delete unused cleanupTriggeredAlerts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,11 +42,6 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Build frontend
-        run: npm run build
-        env:
-          SKIP_API_CALLS: "true"
-
       - name: Run E2E tests (chromium)
         run: npx playwright test tests/e2e/freelancer-onboarding.spec.ts tests/e2e/full-marketplace-flow.spec.ts --project=chromium
 

--- a/backend/src/services/priceAlertService.js
+++ b/backend/src/services/priceAlertService.js
@@ -143,17 +143,6 @@ async function deletePriceAlert(alertId, userAddress) {
   return true;
 }
 
-/**
- * Delete all triggered one-time alerts for a user (cleanup).
- * @param {string} userAddress - Stellar public key
- */
-async function cleanupTriggeredAlerts(userAddress) {
-  await pool.query(
-    "DELETE FROM price_alerts WHERE user_address = $1 AND triggered = TRUE AND one_time = TRUE",
-    [userAddress]
-  );
-}
-
 function throwBadRequest(message) {
   const e = new Error(message);
   e.status = 400;

--- a/backend/src/services/priceAlertService.test.js
+++ b/backend/src/services/priceAlertService.test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({ query: jest.fn() }));
+jest.mock("./notificationService", () => ({ createInAppNotification: jest.fn().mockResolvedValue({}) }));
+
+const pool = require("../db/pool");
+const { PriceAlertService } = require("./priceAlertService");
+
+const VALID_ADDRESS = "GABCDEFGHIJKLMNOPQRSTUVWXYZ123456789ABCDEFGHIJKLMNOPQRSTU";
+
+describe("PriceAlertService.runOnce", () => {
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ stellar: { usd: 0.15 } }),
+    });
+    service = new PriceAlertService({ broadcast: jest.fn(), sendEmail: jest.fn() });
+  });
+
+  test("cleans up stale triggered one-time alerts after each poll", async () => {
+    // No legacy prefs, no active alerts — we just want the cleanup query to fire
+    pool.query
+      .mockResolvedValueOnce({ rows: [] }) // SELECT price_alert_preferences
+      .mockResolvedValueOnce({ rows: [] }) // SELECT price_alerts WHERE triggered = FALSE
+      .mockResolvedValueOnce({ rowCount: 0 }); // DELETE cleanup
+
+    await service.runOnce();
+
+    const calls = pool.query.mock.calls.map((c) => c[0]);
+    const cleanupCall = calls.find(
+      (sql) =>
+        /DELETE FROM price_alerts/i.test(sql) &&
+        /triggered = TRUE/i.test(sql) &&
+        /one_time = TRUE/i.test(sql) &&
+        /triggered_at/i.test(sql)
+    );
+    expect(cleanupCall).toBeDefined();
+  });
+
+  test("marks a triggered alert and notifies the user", async () => {
+    const alert = {
+      id: "alert-1",
+      user_address: VALID_ADDRESS,
+      condition: "above",
+      threshold: "0.10",
+      one_time: true,
+      triggered: false,
+    };
+
+    pool.query
+      .mockResolvedValueOnce({ rows: [] })         // legacy prefs
+      .mockResolvedValueOnce({ rows: [alert] })    // active alerts
+      .mockResolvedValueOnce({ rowCount: 1 })      // UPDATE triggered = TRUE
+      .mockResolvedValueOnce({ rowCount: 1 })      // DELETE one-time alert
+      .mockResolvedValueOnce({ rowCount: 0 });     // bulk cleanup
+
+    await service.runOnce();
+
+    const updateCall = pool.query.mock.calls.find(
+      (c) => /UPDATE price_alerts SET triggered = TRUE/i.test(c[0]) && c[1][0] === alert.id
+    );
+    expect(updateCall).toBeDefined();
+  });
+});


### PR DESCRIPTION
Two dead code issues:

  dropped the npm run build step before Playwright. 
  Playwright starts its own dev server in CI via webServer config, 
  so the build output was never used.

 priceAlertService.js: removed `cleanupTriggeredAlerts, defined 
  but never called. runOnce already handles this cleanup after every 
  poll, and handleNewAlertTrigger deletes one-time alerts on trigger.

Added tests to guard the cleanup path in runOnce.

Closes #1185 
