### PR TITLE
fix: drop dead build step and handle all-skipped tests in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,16 +42,11 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Build frontend
-        run: npm run build
-        env:
-          SKIP_API_CALLS: "true"
-
       - name: Run E2E tests (chromium)
-        run: npx playwright test tests/e2e/freelancer-onboarding.spec.ts tests/e2e/full-marketplace-flow.spec.ts --project=chromium
+        run: npx playwright test tests/e2e/freelancer-onboarding.spec.ts tests/e2e/full-marketplace-flow.spec.ts --project=chromium --pass-with-no-tests
 
       - name: Run E2E tests (chromium-dark)
-        run: npx playwright test tests/e2e/freelancer-onboarding.spec.ts tests/e2e/full-marketplace-flow.spec.ts --project=chromium-dark
+        run: npx playwright test tests/e2e/freelancer-onboarding.spec.ts tests/e2e/full-marketplace-flow.spec.ts --project=chromium-dark --pass-with-no-tests
 
       - name: Upload Playwright report on failure
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Two issues in e2e.yml:

- Removed npm run build before Playwright. The playwright webServer
  config already starts npm run dev in CI, so the build output was
  never served, just wasted CI time.

- Added --pass-with-no-tests to both Playwright steps. Both spec files
  are currently all test.skip pending backend integration. Without this
  flag Playwright exits non-zero when it finds zero tests to run
  
  Closes #1187  