### PR TITLE
docs: verify #1171 unbalanced braces — no fix needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WebSocket Double-Connect**: Fixed an issue causing duplicate WebSocket connection attempts. (#894)
 - **Pagination Cursor**: Resolved a bug causing pagination cursors to become stale. (#894)
 - **Earnings Chart**: Addressed display and rendering bugs in the freelancer earnings chart. (#894)
+- **Unbalanced Braces in Contract**: Verified and confirmed that `lib.rs` brace nesting is correct — issue could not be reproduced. (#1171)
 
 
 ## [1.0.0] - 2026-07-01


### PR DESCRIPTION
Closes #1171

### What
Issue #1171 reported two extra closing braces in `contracts/marketpay-contract/src/lib.rs`, claiming the crate does not build and functions after line 3072 sit outside the `impl` block.

### Verification
All checks pass on the current branch:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 62 passed, 0 failed

### Conclusion
The issue cannot be reproduced. The brace nesting in `lib.rs` is correct — `get_evidence_cids` (line 3061) is inside `impl MarketPayContract`, and the impl block closes cleanly at line 3067. No code change is required.

### Change
Added a changelog entry under `[Unreleased] > Fixed` documenting the verification.