### PR TITLE
fix(routes): wire up admin API key usage stats endpoint (#1186)

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -857,6 +857,23 @@ router.get("/metrics/time-series", verifyJWT, requireAdminRole, requireAdmin2FA,
   }
 });
 
+// ── GET /api/admin/api-keys/usage — API key usage stats (Issue #452) ─────────
+router.get(
+  "/api-keys/usage",
+  verifyJWT,
+  requireAdminRole,
+  requireAdmin2FA,
+  async (req, res, next) => {
+    try {
+      const lookbackDays = Number(req.query.days) || 7;
+      const stats = await getApiKeyUsageStats(lookbackDays);
+      res.json({ success: true, data: stats });
+    } catch (e) {
+      next(e);
+    }
+  },
+);
+
 // ── GET /api/admin/reports/latest — download the most recent weekly PDF ───────
 router.get("/reports/latest", verifyJWT, requireAdminRole, requireAdmin2FA, async (req, res, next) => {
   try {

--- a/backend/src/routes/admin.test.js
+++ b/backend/src/routes/admin.test.js
@@ -1,0 +1,129 @@
+"use strict";
+
+/**
+ * src/routes/admin.test.js
+ *
+ * Route-level test suite for the admin API key usage endpoint (Issue #1186).
+ *
+ * Regression guard: `getApiKeyUsageStats` from developerService was imported
+ * by src/routes/admin.js but never wired to a route, so the admin "API Key
+ * Usage" dashboard (AdminApiKeyUsage.tsx, calls GET /api/admin/api-keys/usage)
+ * 404'd. This suite asserts the endpoint is mounted and delegates to the
+ * service — it fails if the route is disconnected again.
+ */
+
+jest.mock("../db/pool", () => {
+  const { createPgMock } = require("../testUtils/pgMock");
+  return createPgMock();
+});
+
+jest.mock("../middleware/auth", () => ({
+  verifyJWT: jest.fn((req, res, next) => {
+    req.user = { publicKey: "GADMIN", role: "admin" };
+    next();
+  }),
+  requireAdminRole: jest.fn((req, res, next) => next()),
+  requireAdmin2FA: jest.fn((req, res, next) => next()),
+}));
+
+jest.mock("../services/jobService", () => ({
+  updateJobStatus: jest.fn(),
+  listJobs: jest.fn(),
+}));
+
+jest.mock("../services/contractAuditService", () => ({
+  logContractInteraction: jest.fn(),
+}));
+
+jest.mock("../services/auditLogService", () => ({
+  listAuditLogs: jest.fn(),
+}));
+
+jest.mock("../services/developerService", () => ({
+  getApiKeyUsageStats: jest.fn(),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const adminRoutes = require("./admin");
+const { getApiKeyUsageStats } = require("../services/developerService");
+
+const app = express();
+app.use(express.json());
+app.use("/api/admin", adminRoutes);
+
+app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+  const status = err.statusCode || err.status || 500;
+  res.status(status).json({
+    error: err.message,
+    code: err.code || "INTERNAL_ERROR",
+  });
+});
+
+function usageStats(overrides = {}) {
+  return {
+    lookbackDays: 7,
+    keys: [
+      {
+        id: 1,
+        label: "staging-bot",
+        key_prefix: "mk_live_ab12",
+        requests_today: 42,
+        requests_last_hour: 7,
+        endpoint_breakdown: [
+          {
+            endpoint: "/api/public/jobs",
+            requests: 7,
+            lastMinute: "2026-08-26T10:00:00.000Z",
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("Admin Route Suite (/api/admin/api-keys/usage)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getApiKeyUsageStats.mockResolvedValue(usageStats());
+  });
+
+  it("200 — returns per-key usage stats from the developerService", async () => {
+    const res = await request(app).get("/api/admin/api-keys/usage");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(getApiKeyUsageStats).toHaveBeenCalledWith(7);
+    expect(res.body.data).toMatchObject({
+      lookbackDays: 7,
+      keys: [
+        {
+          id: 1,
+          label: "staging-bot",
+          requests_today: 42,
+          requests_last_hour: 7,
+        },
+      ],
+    });
+  });
+
+  it("200 — honors the days lookback query parameter", async () => {
+    const res = await request(app).get("/api/admin/api-keys/usage?days=30");
+
+    expect(res.status).toBe(200);
+    expect(getApiKeyUsageStats).toHaveBeenCalledWith(30);
+  });
+
+  it("500 — forwards service errors to the error handler", async () => {
+    getApiKeyUsageStats.mockRejectedValue(new Error("usage stats exploded"));
+
+    const res = await request(app).get("/api/admin/api-keys/usage");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({
+      error: "usage stats exploded",
+      code: "INTERNAL_ERROR",
+    });
+  });
+});


### PR DESCRIPTION
﻿## Overview

This PR fixes a dead-wiring regression in the backend: `getApiKeyUsageStats` from `developerService` was imported in `src/routes/admin.js` but never mounted, so the admin **API Key Usage** dashboard view was unreachable (every call to `GET /api/admin/api-keys/usage` 404'd while the frontend `AdminApiKeyUsage.tsx` widget was still calling it).

## Related Issue

Closes [#1186](https://github.com/Emmy123222/Stellar-MarketPay-/issues/1186)

## Changes

### Route wiring

- **[MODIFY]** `backend/src/routes/admin.js`
  - Restores `GET /api/admin/api-keys/usage` (protected by `verifyJWT` + `requireAdminRole` + `requireAdmin2FA`), delegating to `getApiKeyUsageStats` with the `days` lookback query param (default 7).
  - The route was accidentally dropped in `bf2f3b4` (weekly PDF report feature, #657) while the import, the frontend widget, and the API client were left behind.

### Regression test

- **[ADD]** `backend/src/routes/admin.test.js`
  - Route-level suite (3 tests) covering the happy path, the `days` lookback param, and error forwarding.
  - Verified to fail (404) when the route is disconnected, so it guards against re-disconnection.

## Verification Results

```
npm run lint
✅ 0 errors (getApiKeyUsageStats unused-vars warning in admin.js is gone)

npx jest src/routes/admin.test.js
✅ 3/3 passed

npx jest src/routes/admin.test.js src/tests/adminUserManagement.test.js src/routes/developer.test.js
✅ 44/44 passed
```

## Acceptance Criteria

| Criterion | Status |
| --- | --- |
| `getApiKeyUsageStats` is used (not dead wiring) in `src/routes/admin.js` | ✅ Wired to `GET /api/admin/api-keys/usage` |
| Admin API-key usage view is reachable | ✅ Endpoint returns 200 with usage stats |
| Test fails if disconnected again | ✅ Suite 404s when route removed |
