### PR TITLE
fix(test): mock health dependencies in migrationValidation.test.js (#…

### DIFF
--- a/backend/src/db/migrationValidation.test.js
+++ b/backend/src/db/migrationValidation.test.js
@@ -46,9 +46,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  if (hasPostgres) {
-    await pool.end();
-  }
+  await pool.end();
 });
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -195,6 +193,34 @@ describe("validateMigrationVersion()", () => {
 });
 
 describe("Health endpoint – migrationVersion field", () => {
+  let fetchSpy;
+  let poolSpy;
+  const cacheService = require("../services/cacheService");
+  const originalCachePing = cacheService.ping;
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        _embedded: { records: [{ sequence: 12345678 }] },
+      }),
+    });
+    poolSpy = jest.spyOn(pool, "query").mockResolvedValue({
+      rows: [{ "?column?": 1 }],
+    });
+    cacheService.ping = jest.fn().mockResolvedValue("up");
+  });
+
+  afterAll(() => {
+    fetchSpy?.mockRestore();
+    poolSpy?.mockRestore();
+    if (originalCachePing) {
+      cacheService.ping = originalCachePing;
+    } else {
+      delete cacheService.ping;
+    }
+  });
+
   it("returns migrationVersion in the health response", async () => {
     const express = require("express");
     const supertest = require("supertest");


### PR DESCRIPTION
## Summary
Fixes the failing `src/db/migrationValidation.test.js` test suite by:
- Mocking external health check dependencies (`global.fetch` for Stellar Horizon, `pool.query` for Postgres, and `cacheService.ping` for Redis) during the `Health endpoint – migrationVersion field` tests to eliminate live network/db timeouts.
- Ensuring `await pool.end()` is always executed in `afterAll` to cleanly close any open pg connections and prevent open handles/hanging test runners when running without a live Postgres instance.

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #1075

## Testing
- [x] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [ ] Docs updated if needed

All unit tests in `backend/src/db/migrationValidation.test.js` (12/12) and `backend/__tests__/health.test.js` (5/5) pass cleanly without timeouts or open handles. Backend lint checks pass with 0 errors.

## Screenshots (if UI change)
N/A (backend test suite fix)