### PR TITLE
fix(backend, frontend): implement escrow extensions & fix TypeScript errors

### DIFF
--- a/backend/src/routes/escrow.js
+++ b/backend/src/routes/escrow.js
@@ -28,6 +28,8 @@ const {
   releaseMilestone,
   rejectMilestone,
   disputeMilestone,
+  requestEscrowExtension,
+  approveEscrowExtension,
 
   verifyFreelancerAccount,
 } = require("../services/escrowService");
@@ -525,6 +527,70 @@ router.post("/verify-freelancer", escrowActionRateLimiter, async (req, res, next
     await verifyFreelancerAccount(freelancerAddress);
 
     res.json({ success: true, data: { freelancerAddress, exists: true } });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * POST /api/escrow/:jobId/extend
+ * Request an on-chain escrow timeout extension by mutual consent.
+ * The caller must be the client or freelancer.
+ */
+router.post("/:jobId/extend", escrowActionRateLimiter, async (req, res, next) => {
+  try {
+    const { jobId } = req.params;
+    const { requestedBy, newTimeoutLedger, contractTxHash } = req.body;
+
+    if (!requestedBy || !/^G[A-Z0-9]{55}$/.test(requestedBy)) {
+      const e = new Error("Invalid wallet address");
+      e.status = 400;
+      throw e;
+    }
+
+    if (
+      newTimeoutLedger === undefined ||
+      newTimeoutLedger === null ||
+      !Number.isInteger(Number(newTimeoutLedger)) ||
+      Number(newTimeoutLedger) <= 0
+    ) {
+      const e = new Error("newTimeoutLedger must be a positive integer");
+      e.status = 400;
+      throw e;
+    }
+
+    const result = await requestEscrowExtension(
+      jobId,
+      requestedBy,
+      Number(newTimeoutLedger),
+      contractTxHash,
+    );
+
+    res.status(201).json(result);
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * POST /api/escrow/:jobId/extend/approve
+ * Approve a pending escrow timeout extension request.
+ * The caller must be the party that did NOT request the extension.
+ */
+router.post("/:jobId/extend/approve", escrowActionRateLimiter, async (req, res, next) => {
+  try {
+    const { jobId } = req.params;
+    const { approvedBy, contractTxHash } = req.body;
+
+    if (!approvedBy || !/^G[A-Z0-9]{55}$/.test(approvedBy)) {
+      const e = new Error("Invalid wallet address");
+      e.status = 400;
+      throw e;
+    }
+
+    const result = await approveEscrowExtension(jobId, approvedBy, contractTxHash);
+
+    res.json(result);
   } catch (e) {
     next(e);
   }

--- a/backend/src/routes/escrow.test.js
+++ b/backend/src/routes/escrow.test.js
@@ -53,6 +53,8 @@ jest.mock("../services/escrowService", () => ({
   rejectMilestone: jest.fn(),
   disputeMilestone: jest.fn(),
   verifyFreelancerAccount: jest.fn(),
+  requestEscrowExtension: jest.fn(),
+  approveEscrowExtension: jest.fn(),
 }));
 
 jest.mock("../services/recurringEscrowService", () => ({
@@ -72,6 +74,8 @@ const {
   rejectMilestone,
   disputeMilestone,
   verifyFreelancerAccount,
+  requestEscrowExtension,
+  approveEscrowExtension,
 } = require("../services/escrowService");
 const {
   createRecurringEscrow,
@@ -685,6 +689,112 @@ describe("Escrow Route Suite (/api/escrow)", () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe("freelancerAddress is required");
+    });
+  });
+
+  // =========================================================================
+  // 13. POST /api/escrow/:jobId/extend
+  // =========================================================================
+  describe("POST /api/escrow/:jobId/extend", () => {
+    it("201 — requests escrow extension successfully", async () => {
+      requestEscrowExtension.mockResolvedValue({
+        success: true,
+        extension: {
+          id: 1,
+          job_id: JOB_ID,
+          requested_by: CLIENT_ADDRESS,
+          new_timeout_ledger: 2000,
+          status: "pending",
+        },
+      });
+
+      const res = await request(app)
+        .post(`/api/escrow/${JOB_ID}/extend`)
+        .send({
+          requestedBy: CLIENT_ADDRESS,
+          newTimeoutLedger: 2000,
+          contractTxHash: "tx-extend-1",
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.extension.new_timeout_ledger).toBe(2000);
+      expect(requestEscrowExtension).toHaveBeenCalledWith(
+        JOB_ID,
+        CLIENT_ADDRESS,
+        2000,
+        "tx-extend-1",
+      );
+    });
+
+    it("400 — rejects when requestedBy is invalid format", async () => {
+      const res = await request(app)
+        .post(`/api/escrow/${JOB_ID}/extend`)
+        .send({
+          requestedBy: "INVALID_WALLET",
+          newTimeoutLedger: 2000,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Invalid wallet address");
+    });
+
+    it("400 — rejects when newTimeoutLedger is missing or non-positive", async () => {
+      const res = await request(app)
+        .post(`/api/escrow/${JOB_ID}/extend`)
+        .send({
+          requestedBy: CLIENT_ADDRESS,
+          newTimeoutLedger: 0,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("newTimeoutLedger must be a positive integer");
+    });
+  });
+
+  // =========================================================================
+  // 14. POST /api/escrow/:jobId/extend/approve
+  // =========================================================================
+  describe("POST /api/escrow/:jobId/extend/approve", () => {
+    it("200 — approves escrow extension successfully", async () => {
+      approveEscrowExtension.mockResolvedValue({
+        success: true,
+        extension: {
+          id: 1,
+          job_id: JOB_ID,
+          requested_by: CLIENT_ADDRESS,
+          approved_by: FREELANCER_ADDRESS,
+          new_timeout_ledger: 2000,
+          status: "approved",
+        },
+      });
+
+      const res = await request(app)
+        .post(`/api/escrow/${JOB_ID}/extend/approve`)
+        .send({
+          approvedBy: FREELANCER_ADDRESS,
+          contractTxHash: "tx-approve-1",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.extension.status).toBe("approved");
+      expect(approveEscrowExtension).toHaveBeenCalledWith(
+        JOB_ID,
+        FREELANCER_ADDRESS,
+        "tx-approve-1",
+      );
+    });
+
+    it("400 — rejects when approvedBy is invalid format", async () => {
+      const res = await request(app)
+        .post(`/api/escrow/${JOB_ID}/extend/approve`)
+        .send({
+          approvedBy: "NOT_AN_ADDRESS",
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Invalid wallet address");
     });
   });
 });

--- a/backend/src/services/escrowService.js
+++ b/backend/src/services/escrowService.js
@@ -740,6 +740,146 @@ async function submitDeliverableHash(jobId, freelancerAddress, hashHex) {
   return { success: true, submission: rows[0] };
 }
 
+async function requestEscrowExtension(jobId, requestedBy, newTimeoutLedger, contractTxHash) {
+  const job = await getJob(jobId);
+  if (job.clientAddress !== requestedBy && job.freelancerAddress !== requestedBy) {
+    const e = new Error("Only the client or freelancer can request an extension");
+    e.status = 403;
+    throw e;
+  }
+
+  const { rows: pending } = await pool.query(
+    "SELECT status FROM escrow_extensions WHERE job_id = $1 AND status = 'pending'",
+    [jobId],
+  );
+  if (pending.length > 0) {
+    const e = new Error("A pending extension request already exists for this escrow");
+    e.status = 400;
+    throw e;
+  }
+
+  const { rows: escrowRows } = await pool.query(
+    "SELECT status, timeout_ledger FROM escrows WHERE job_id = $1",
+    [jobId],
+  );
+  if (!escrowRows.length) {
+    const e = new Error("No escrow found for this job");
+    e.status = 404;
+    throw e;
+  }
+
+  const escrow = escrowRows[0];
+  if (escrow.status !== "funded" && escrow.status !== "in_progress" && escrow.status !== "locked") {
+    const e = new Error("Extension is only allowed while escrow is funded or in progress");
+    e.status = 400;
+    throw e;
+  }
+
+  const currentLedger = escrow.timeout_ledger || 0;
+  if (newTimeoutLedger <= currentLedger) {
+    const e = new Error("New timeout ledger must be greater than the current timeout");
+    e.status = 400;
+    throw e;
+  }
+
+  const txInfo = await verifyOnChainTransaction(contractTxHash);
+  const txHash = contractTxHash || `offchain-${Date.now()}`;
+
+  await logContractInteraction({
+    functionName: "request_extension",
+    callerAddress: requestedBy,
+    jobId,
+    txHash,
+    ledgerSequence: txInfo ? txInfo.ledgerSequence : undefined,
+    feeCharged: txInfo ? txInfo.feeCharged : undefined,
+    eventData: txInfo ? txInfo.eventData : undefined,
+  });
+
+  const { rows } = await pool.query(
+    `INSERT INTO escrow_extensions (job_id, requested_by, new_timeout_ledger, status, created_at, updated_at)
+     VALUES ($1, $2, $3, 'pending', NOW(), NOW())
+     RETURNING *`,
+    [jobId, requestedBy, newTimeoutLedger],
+  );
+
+  return { success: true, extension: rows[0] };
+}
+
+async function approveEscrowExtension(jobId, approvedBy, contractTxHash) {
+  const job = await getJob(jobId);
+
+  const { rows: pendingRows } = await pool.query(
+    "SELECT * FROM escrow_extensions WHERE job_id = $1 AND status = 'pending'",
+    [jobId],
+  );
+  if (!pendingRows.length) {
+    const e = new Error("No pending extension request for this job");
+    e.status = 404;
+    throw e;
+  }
+
+  const extension = pendingRows[0];
+
+  if (extension.requested_by === approvedBy) {
+    const e = new Error("Cannot approve your own extension request");
+    e.status = 403;
+    throw e;
+  }
+
+  if (job.clientAddress !== approvedBy && job.freelancerAddress !== approvedBy) {
+    const e = new Error("Only the client or freelancer can approve an extension");
+    e.status = 403;
+    throw e;
+  }
+
+  const { rows: escrowRows } = await pool.query(
+    "SELECT status FROM escrows WHERE job_id = $1",
+    [jobId],
+  );
+  if (!escrowRows.length) {
+    const e = new Error("No escrow found for this job");
+    e.status = 404;
+    throw e;
+  }
+
+  const escrow = escrowRows[0];
+  if (escrow.status !== "funded" && escrow.status !== "in_progress" && escrow.status !== "locked") {
+    const e = new Error("Extension is only allowed while escrow is funded or in progress");
+    e.status = 400;
+    throw e;
+  }
+
+  const txInfo = await verifyOnChainTransaction(contractTxHash);
+  const txHash = contractTxHash || `offchain-${Date.now()}`;
+
+  await logContractInteraction({
+    functionName: "approve_extension",
+    callerAddress: approvedBy,
+    jobId,
+    txHash,
+    ledgerSequence: txInfo ? txInfo.ledgerSequence : undefined,
+    feeCharged: txInfo ? txInfo.feeCharged : undefined,
+    eventData: txInfo ? txInfo.eventData : undefined,
+  });
+
+  const { rows } = await pool.query(
+    `UPDATE escrow_extensions
+     SET status = 'approved', approved_by = $2, approved_at = NOW(), updated_at = NOW()
+     WHERE id = $1
+     RETURNING *`,
+    [extension.id, approvedBy],
+  );
+
+  await pool.query(
+    `UPDATE escrows
+     SET timeout_ledger = $2, updated_at = NOW()
+     WHERE job_id = $1`,
+    [jobId, extension.new_timeout_ledger],
+  );
+
+  return { success: true, extension: rows[0] };
+}
+
 module.exports = {
   releaseFunds,
   refundClient,
@@ -754,6 +894,8 @@ module.exports = {
   resolveLedgerTimestamp,
   startEscrowTimeoutChecker,
   submitDeliverableHash,
+  requestEscrowExtension,
+  approveEscrowExtension,
 
   verifyFreelancerAccount,
   ESCROW_TIMEOUT_DAYS,

--- a/backend/src/services/escrowService.test.js
+++ b/backend/src/services/escrowService.test.js
@@ -51,6 +51,8 @@ const {
   disputeMilestone,
   getEscrow,
   verifyFreelancerAccount,
+  requestEscrowExtension,
+  approveEscrowExtension,
   ESCROW_TIMEOUT_DAYS,
 } = require("./escrowService");
 
@@ -374,6 +376,169 @@ describe("escrowService", () => {
       await expect(verifyFreelancerAccount(FREELANCER_ADDRESS)).rejects.toThrow(
         "Failed to verify freelancer account on Stellar network",
       );
+    });
+  });
+
+  describe("requestEscrowExtension", () => {
+    it("requests extension successfully by client", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({ rows: [] }) // no pending extension
+        .mockResolvedValueOnce({ rows: [{ status: "funded", timeout_ledger: 1000 }] }) // escrow
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, job_id: JOB_ID, requested_by: CLIENT_ADDRESS, new_timeout_ledger: 2000, status: "pending" }],
+        });
+
+      const result = await requestEscrowExtension(JOB_ID, CLIENT_ADDRESS, 2000, TX_HASH);
+
+      expect(result.success).toBe(true);
+      expect(result.extension.new_timeout_ledger).toBe(2000);
+      expect(result.extension.status).toBe("pending");
+    });
+
+    it("requests extension successfully by freelancer", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ status: "in_progress", timeout_ledger: 1000 }] })
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, job_id: JOB_ID, requested_by: FREELANCER_ADDRESS, new_timeout_ledger: 3000, status: "pending" }],
+        });
+
+      const result = await requestEscrowExtension(JOB_ID, FREELANCER_ADDRESS, 3000);
+
+      expect(result.success).toBe(true);
+      expect(result.extension.requested_by).toBe(FREELANCER_ADDRESS);
+    });
+
+    it("rejects extension request by non-participant", async () => {
+      getJob.mockResolvedValue(makeJob());
+
+      await expect(
+        requestEscrowExtension(JOB_ID, OTHER_ADDRESS, 2000),
+      ).rejects.toMatchObject({ message: "Only the client or freelancer can request an extension", status: 403 });
+    });
+
+    it("rejects when a pending extension request already exists", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({ rows: [{ status: "pending" }] });
+
+      await expect(
+        requestEscrowExtension(JOB_ID, CLIENT_ADDRESS, 2000),
+      ).rejects.toMatchObject({ message: "A pending extension request already exists for this escrow", status: 400 });
+    });
+
+    it("rejects when escrow not found", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await expect(
+        requestEscrowExtension(JOB_ID, CLIENT_ADDRESS, 2000),
+      ).rejects.toMatchObject({ message: "No escrow found for this job", status: 404 });
+    });
+
+    it("rejects when escrow is not funded or in progress", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ status: "completed", timeout_ledger: 1000 }] });
+
+      await expect(
+        requestEscrowExtension(JOB_ID, CLIENT_ADDRESS, 2000),
+      ).rejects.toMatchObject({ message: "Extension is only allowed while escrow is funded or in progress", status: 400 });
+    });
+
+    it("rejects when new timeout ledger is not greater than current timeout", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ status: "funded", timeout_ledger: 2000 }] });
+
+      await expect(
+        requestEscrowExtension(JOB_ID, CLIENT_ADDRESS, 1500),
+      ).rejects.toMatchObject({ message: "New timeout ledger must be greater than the current timeout", status: 400 });
+    });
+  });
+
+  describe("approveEscrowExtension", () => {
+    it("approves extension successfully by counterparty", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, job_id: JOB_ID, requested_by: CLIENT_ADDRESS, new_timeout_ledger: 2500, status: "pending" }],
+        })
+        .mockResolvedValueOnce({ rows: [{ status: "funded" }] })
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, job_id: JOB_ID, requested_by: CLIENT_ADDRESS, approved_by: FREELANCER_ADDRESS, new_timeout_ledger: 2500, status: "approved" }],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // update escrows timeout_ledger
+
+      const result = await approveEscrowExtension(JOB_ID, FREELANCER_ADDRESS, TX_HASH);
+
+      expect(result.success).toBe(true);
+      expect(result.extension.status).toBe("approved");
+      expect(result.extension.approved_by).toBe(FREELANCER_ADDRESS);
+    });
+
+    it("rejects approval by the same party who requested it", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, job_id: JOB_ID, requested_by: CLIENT_ADDRESS, new_timeout_ledger: 2500, status: "pending" }],
+        });
+
+      await expect(
+        approveEscrowExtension(JOB_ID, CLIENT_ADDRESS),
+      ).rejects.toMatchObject({ message: "Cannot approve your own extension request", status: 403 });
+    });
+
+    it("rejects approval by non-participant", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, job_id: JOB_ID, requested_by: CLIENT_ADDRESS, new_timeout_ledger: 2500, status: "pending" }],
+        });
+
+      await expect(
+        approveEscrowExtension(JOB_ID, OTHER_ADDRESS),
+      ).rejects.toMatchObject({ message: "Only the client or freelancer can approve an extension", status: 403 });
+    });
+
+    it("rejects approval when no pending request exists", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({ rows: [] });
+
+      await expect(
+        approveEscrowExtension(JOB_ID, FREELANCER_ADDRESS),
+      ).rejects.toMatchObject({ message: "No pending extension request for this job", status: 404 });
+    });
+
+    it("rejects approval when escrow is not funded or in progress", async () => {
+      getJob.mockResolvedValue(makeJob());
+      mockQuery
+        .mockReset()
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, job_id: JOB_ID, requested_by: CLIENT_ADDRESS, new_timeout_ledger: 2500, status: "pending" }],
+        })
+        .mockResolvedValueOnce({ rows: [{ status: "completed" }] });
+
+      await expect(
+        approveEscrowExtension(JOB_ID, FREELANCER_ADDRESS),
+      ).rejects.toMatchObject({ message: "Extension is only allowed while escrow is funded or in progress", status: 400 });
     });
   });
 });

--- a/backend/src/testUtils/pgMock.js
+++ b/backend/src/testUtils/pgMock.js
@@ -123,6 +123,20 @@ function defaultEscrowRow(overrides = {}) {
   };
 }
 
+function defaultEscrowExtensionRow(overrides = {}) {
+  return {
+    id: overrides.id || 1,
+    job_id: overrides.job_id || "job-1",
+    requested_by: overrides.requested_by || "G" + "A".repeat(55),
+    new_timeout_ledger: overrides.new_timeout_ledger || 1000,
+    status: overrides.status || "pending",
+    approved_by: overrides.approved_by || null,
+    approved_at: overrides.approved_at || null,
+    created_at: overrides.created_at || new Date().toISOString(),
+    updated_at: overrides.updated_at || new Date().toISOString(),
+  };
+}
+
 function defaultOnboardingRow(overrides = {}) {
   return {
     public_key: overrides.public_key || "G" + "A".repeat(55),
@@ -174,6 +188,7 @@ function createPgMock() {
   const daoArbitrators = new Map();
   const apiKeys = new Map();
   const escrows = new Map();
+  const escrowExtensions = new Map();
   const onboardingProgress = new Map();
   const timelineEvents = [];
 
@@ -417,6 +432,43 @@ function createPgMock() {
         [...escrows.values()].find((e) => e.job_id === params[0]) ||
         escrows.get(params[0]);
       return { rows: escrow ? [escrow] : [] };
+    }
+
+    // ─── Escrow Extensions Queries ─────────────────────────────────────────
+    if (text.startsWith("INSERT INTO escrow_extensions")) {
+      const id = escrowExtensions.size + 1;
+      const row = defaultEscrowExtensionRow({
+        id,
+        job_id: params[0],
+        requested_by: params[1],
+        new_timeout_ledger: params[2],
+        status: "pending",
+      });
+      escrowExtensions.set(id, row);
+      return { rows: [row], rowCount: 1 };
+    }
+
+    if (text.includes("FROM escrow_extensions")) {
+      let list = [...escrowExtensions.values()];
+      if (text.includes("job_id = $1")) {
+        list = list.filter((e) => e.job_id === params[0]);
+      }
+      if (text.includes("status = 'pending'")) {
+        list = list.filter((e) => e.status === "pending");
+      }
+      return { rows: list };
+    }
+
+    if (text.startsWith("UPDATE escrow_extensions")) {
+      const ext = escrowExtensions.get(params[0]) || [...escrowExtensions.values()].find((e) => e.id === params[0]);
+      if (ext) {
+        ext.status = "approved";
+        ext.approved_by = params[1];
+        ext.approved_at = new Date().toISOString();
+        ext.updated_at = new Date().toISOString();
+        return { rows: [ext], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
     }
 
     // ─── Specific UPDATE jobs ────────────────────────────────────────────
@@ -1203,6 +1255,7 @@ function createPgMock() {
     daoArbitrators.clear();
     apiKeys.clear();
     escrows.clear();
+    escrowExtensions.clear();
     onboardingProgress.clear();
     timelineEvents.length = 0;
     query.mockClear();
@@ -1220,6 +1273,7 @@ function createPgMock() {
     daoArbitrators,
     apiKeys,
     escrows,
+    escrowExtensions,
     onboardingProgress,
     reset,
     end: jest.fn(),
@@ -1238,5 +1292,6 @@ module.exports = {
   defaultDaoArbitratorRow,
   defaultApiKeyRow,
   defaultEscrowRow,
+  defaultEscrowExtensionRow,
   defaultOnboardingRow,
 };

--- a/frontend/__tests__/snapshots/staticComponents.snap.test.tsx
+++ b/frontend/__tests__/snapshots/staticComponents.snap.test.tsx
@@ -51,7 +51,7 @@ import FeeEstimationModal from "@/components/FeeEstimationModal";
 
 const mockTransaction = {} as import("@stellar/stellar-sdk").Transaction;
 
-const noop = jest.fn();
+const noop: any = jest.fn();
 
 describe("static component snapshots", () => {
   describe("Spinner", () => {

--- a/frontend/stories/NotificationBell.stories.tsx
+++ b/frontend/stories/NotificationBell.stories.tsx
@@ -1,3 +1,4 @@
+declare const jest: any;
 import { Meta, StoryObj } from "@storybook/react";
 import NotificationBell from "@/components/NotificationBell";
 import { fetchNotifications } from "@/lib/api";


### PR DESCRIPTION
## Summary of Changes

This PR resolves three issues (#1124, #1122, and #1127):

### 1. Escrow Extension Endpoints & Services (Closes #1127)
- **Backend Services (`backend/src/services/escrowService.js`)**:
  - Implemented `requestEscrowExtension(jobId, requestedBy, newTimeoutLedger, contractTxHash)`: Validates that the requester is the client or freelancer, verifies escrow is funded/in progress and new timeout is strictly greater than the current timeout ledger, prevents duplicate pending requests, logs contract audit interaction, and records the pending extension in `escrow_extensions`.
  - Implemented `approveEscrowExtension(jobId, approvedBy, contractTxHash)`: Validates the approver is a job participant and ensures that the approver is **not** the requester (enforces mutual consent), transitions the extension status to `approved`, updates `escrows.timeout_ledger`, and logs the contract interaction.
  - Exported both functions from `escrowService.js`.
- **Backend Routes (`backend/src/routes/escrow.js`)**:
  - Restored `POST /api/escrow/:jobId/extend` with rate limiting and input validation for wallet address and positive integer ledger timeout.
  - Restored `POST /api/escrow/:jobId/extend/approve` with rate limiting and input validation for wallet address.
- **Testing & Mocks (`backend/src/testUtils/pgMock.js`, `backend/src/services/escrowService.test.js`, `backend/src/routes/escrow.test.js`)**:
  - Added mock storage and query handlers for `escrow_extensions` table in `pgMock.js`.
  - Added unit test suites covering success and error conditions (unauthorized requester/approver, self-approval attempt, non-existent pending request, invalid ledger timeouts, and non-funded escrows).
  - Added route test suites for both endpoints.

### 2. Frontend Static Component Snapshot TypeScript Fix (Closes #1124)
- Fixed callback parameter type compatibility in `frontend/__tests__/snapshots/staticComponents.snap.test.tsx` by typing `noop` mock as `any` (`const noop: any = jest.fn();`) to support both 0-arg callbacks and callbacks with arguments (such as `(updated: Job) => void` for `ExtendJobModal`).

### 3. Frontend Storybook TypeScript Fix (Closes #1122)
- Added `declare const jest: any;` in `frontend/stories/NotificationBell.stories.tsx` to fix TypeScript compilation in the Storybook environment where `jest` is used for mocking `fetchNotifications`.

---

Closes #1124
Closes #1122
Closes #1127