### PR TITLE
test(services): extend webhookService unit tests

### DIFF
--- a/backend/src/services/webhookService.test.js
+++ b/backend/src/services/webhookService.test.js
@@ -1,5 +1,21 @@
 "use strict";
 
+/**
+ * src/services/webhookService.test.js
+ *
+ * Unit tests for the outbound webhook service:
+ *   - buildSignature               — deterministic HMAC-SHA256 signatures
+ *   - registerWebhook              — inserts the webhook row
+ *   - deliverSingleWebhook         — success on first attempt, records delivery
+ *     attempts (INSERT INTO webhook_deliveries), retries then succeeds/fails
+ *   - deliverEscrowWebhooks        — fan-out across registered webhooks,
+ *     short-circuits empty recipient lists
+ *
+ * The internal helpers listWebhooksForEvent and recordWebhookDeliveryAttempt
+ * are exercised through these exported entry points. axios is mocked so no
+ * network I/O happens; the DB pool is a shared jest.fn().
+ */
+
 const mockQuery = jest.fn();
 const mockPost = jest.fn();
 
@@ -11,12 +27,27 @@ jest.mock("axios", () => ({
   post: (...args) => mockPost(...args),
 }));
 
+const crypto = require("crypto");
 const {
   buildSignature,
   registerWebhook,
   deliverSingleWebhook,
   deliverEscrowWebhooks,
+  MAX_RETRIES,
 } = require("./webhookService");
+
+const USER_ADDRESS = "G" + "A".repeat(55);
+const WEBHOOK_URL = "https://example.com/webhook";
+const SECRET = "super-secret-123";
+
+const WEBHOOK_ROW = {
+  id: "webhook-1",
+  user_address: USER_ADDRESS,
+  url: WEBHOOK_URL,
+  events: ["escrow_created", "escrow_released"],
+  secret: SECRET,
+  created_at: "2026-08-01T00:00:00.000Z",
+};
 
 describe("webhookService", () => {
   beforeEach(() => {
@@ -25,77 +56,203 @@ describe("webhookService", () => {
     mockPost.mockReset();
   });
 
-  it("registers a webhook", async () => {
-    const row = {
-      id: "webhook-1",
-      user_address: "GTEST",
-      url: "https://example.com/webhook",
-      events: ["escrow_released"],
-      created_at: new Date().toISOString(),
-    };
-    mockQuery.mockResolvedValueOnce({ rows: [row] });
+  // =========================================================================
+  // buildSignature
+  // =========================================================================
+  describe("buildSignature", () => {
+    it("builds a deterministic HMAC-SHA256 signature", () => {
+      const payload = JSON.stringify({ hello: "world" });
+      const signature = buildSignature("secret", payload);
 
-    const result = await registerWebhook({
-      userAddress: "GTEST",
-      url: row.url,
-      events: row.events,
-      secret: "supersecret",
+      expect(signature).toHaveLength(64);
+      expect(signature).toMatch(/^[a-f0-9]+$/);
+      // Deterministic: the same inputs always produce the same signature.
+      expect(buildSignature("secret", payload)).toBe(signature);
+      // And it matches a reference HMAC computed with the same secret.
+      const expected = crypto
+        .createHmac("sha256", "secret")
+        .update(payload)
+        .digest("hex");
+      expect(signature).toBe(expected);
     });
 
-    expect(result).toEqual(row);
+    it("changes when the secret or the payload changes", () => {
+      const payload = JSON.stringify({ event: "escrow_released" });
+      const signature = buildSignature(SECRET, payload);
+
+      expect(buildSignature("another-secret-123", payload)).not.toBe(signature);
+      expect(buildSignature(SECRET, JSON.stringify({ event: "refund_issued" }))).not.toBe(
+        signature,
+      );
+    });
   });
 
-  it("builds a deterministic HMAC-SHA256 signature", () => {
-    const signature = buildSignature("secret", JSON.stringify({ hello: "world" }));
-    expect(signature).toHaveLength(64);
-    expect(signature).toMatch(/^[a-f0-9]+$/);
-  });
-
-  it("retries failed deliveries and records each attempt", async () => {
-    mockPost
-      .mockRejectedValueOnce(new Error("network 1"))
-      .mockRejectedValueOnce(new Error("network 2"))
-      .mockResolvedValueOnce({ status: 202 });
-    mockQuery.mockResolvedValue({ rows: [{}] });
-
-    const result = await deliverSingleWebhook(
-      {
+  // =========================================================================
+  // registerWebhook
+  // =========================================================================
+  describe("registerWebhook", () => {
+    it("registers a webhook", async () => {
+      const row = {
         id: "webhook-1",
+        user_address: "GTEST",
         url: "https://example.com/webhook",
+        events: ["escrow_released"],
+        created_at: new Date().toISOString(),
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [row] });
+
+      const result = await registerWebhook({
+        userAddress: "GTEST",
+        url: row.url,
+        events: row.events,
         secret: "supersecret",
-      },
-      "escrow_released",
-      { event: "escrow_released", jobId: "job-1" },
-    );
+      });
 
-    expect(result.success).toBe(true);
-    expect(mockPost).toHaveBeenCalledTimes(3);
-    expect(mockQuery).toHaveBeenCalledTimes(3);
-  });
-
-  it("delivers escrow events to subscribed webhooks", async () => {
-    mockQuery
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: "webhook-1",
-            user_address: "GTEST",
-            url: "https://example.com/webhook",
-            events: ["escrow_released"],
-            secret: "supersecret",
-          },
-        ],
-      })
-      .mockResolvedValue({ rows: [{}] });
-    mockPost.mockResolvedValue({ status: 200 });
-
-    const result = await deliverEscrowWebhooks({
-      eventType: "escrow_released",
-      userAddresses: ["GTEST"],
-      payload: { event: "escrow_released", jobId: "job-1" },
+      expect(result).toEqual(row);
     });
 
-    expect(result.deliveries).toHaveLength(1);
-    expect(result.deliveries[0].success).toBe(true);
+    it("inserts the webhook with the expected columns and parameters", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [WEBHOOK_ROW] });
+
+      const result = await registerWebhook({
+        userAddress: USER_ADDRESS,
+        url: WEBHOOK_URL,
+        events: ["escrow_created"],
+        secret: SECRET,
+      });
+
+      expect(result).toEqual(WEBHOOK_ROW);
+      const [sql, params] = mockQuery.mock.calls[0];
+      expect(sql).toMatch(/INSERT INTO webhooks/);
+      expect(params).toEqual([USER_ADDRESS, WEBHOOK_URL, ["escrow_created"], SECRET]);
+    });
+  });
+
+  // =========================================================================
+  // deliverSingleWebhook
+  // =========================================================================
+  describe("deliverSingleWebhook", () => {
+    it("delivers on the first attempt with an HMAC signature header", async () => {
+      mockPost.mockResolvedValue({ status: 200 });
+      mockQuery.mockResolvedValue({ rows: [{ id: "delivery-1" }] });
+      const payload = { event: "escrow_released", jobId: "job-1" };
+
+      const result = await deliverSingleWebhook(WEBHOOK_ROW, "escrow_released", payload);
+
+      expect(result.success).toBe(true);
+      expect(result.attempts).toHaveLength(1);
+      expect(mockPost).toHaveBeenCalledTimes(1);
+      const [url, body, config] = mockPost.mock.calls[0];
+      expect(url).toBe(WEBHOOK_URL);
+      expect(body).toEqual(payload);
+      expect(config.headers["Content-Type"]).toBe("application/json");
+      expect(config.headers["X-Webhook-Signature"]).toBe(
+        buildSignature(SECRET, JSON.stringify(payload)),
+      );
+      // The delivery attempt is persisted with a JSON-stringified payload.
+      const [sql, params] = mockQuery.mock.calls[0];
+      expect(sql).toMatch(/INSERT INTO webhook_deliveries/);
+      expect(params).toContain("webhook-1");
+      expect(params).toContain("escrow_released");
+      expect(params).toContain(JSON.stringify(payload));
+      expect(params).toContain(200);
+    });
+
+    it("retries failed deliveries and records each attempt", async () => {
+      mockPost
+        .mockRejectedValueOnce(new Error("network 1"))
+        .mockRejectedValueOnce(new Error("network 2"))
+        .mockResolvedValueOnce({ status: 202 });
+      mockQuery.mockResolvedValue({ rows: [{}] });
+
+      const result = await deliverSingleWebhook(
+        {
+          id: "webhook-1",
+          url: "https://example.com/webhook",
+          secret: "supersecret",
+        },
+        "escrow_released",
+        { event: "escrow_released", jobId: "job-1" },
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockPost).toHaveBeenCalledTimes(3);
+      expect(mockQuery).toHaveBeenCalledTimes(3);
+    });
+
+    it("reports failure after exhausting all attempts", async () => {
+      mockPost.mockRejectedValue(new Error("connection refused"));
+      // Echo the status param back so each recorded attempt reflects it.
+      mockQuery.mockImplementation(async (sql, params) => ({
+        rows: [{ id: `delivery-${params[3]}`, status: params[4] }],
+      }));
+
+      const result = await deliverSingleWebhook(
+        WEBHOOK_ROW,
+        "escrow_released",
+        { event: "escrow_released", jobId: "job-1" },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.attempts).toHaveLength(MAX_RETRIES);
+      expect(mockPost).toHaveBeenCalledTimes(MAX_RETRIES);
+      expect(result.attempts[result.attempts.length - 1].status).toBe("failed");
+    });
+  });
+
+  // =========================================================================
+  // deliverEscrowWebhooks
+  // =========================================================================
+  describe("deliverEscrowWebhooks", () => {
+    it("returns no deliveries without querying when no user addresses are given", async () => {
+      const result = await deliverEscrowWebhooks({
+        eventType: "escrow_released",
+        userAddresses: [],
+        payload: { jobId: "job-1" },
+      });
+
+      expect(result.deliveries).toEqual([]);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("returns no deliveries when the user has no matching webhooks", async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      const result = await deliverEscrowWebhooks({
+        eventType: "escrow_released",
+        userAddresses: [USER_ADDRESS],
+        payload: { jobId: "job-1" },
+      });
+
+      expect(result.deliveries).toEqual([]);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("delivers escrow events to subscribed webhooks", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: "webhook-1",
+              user_address: "GTEST",
+              url: "https://example.com/webhook",
+              events: ["escrow_released"],
+              secret: "supersecret",
+            },
+          ],
+        })
+        .mockResolvedValue({ rows: [{}] });
+      mockPost.mockResolvedValue({ status: 200 });
+
+      const result = await deliverEscrowWebhooks({
+        eventType: "escrow_released",
+        userAddresses: ["GTEST"],
+        payload: { event: "escrow_released", jobId: "job-1" },
+      });
+
+      expect(result.deliveries).toHaveLength(1);
+      expect(result.deliveries[0].success).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Follow-up hardening PR — no open issue; complements #1327 (route tests for `webhooks.js`) by covering the service layer it calls.

## 1. Linked Issue
No issue number — this extends the existing `backend/src/services/webhookService.test.js` (which had only 4 smoke tests) with full unit coverage for the outbound webhook pipeline.

## 2. Problem Statement (The Bug)
`webhookService` is the engine behind `POST /api/webhooks` and every escrow webhook delivery, yet its test file only covered 4 happy paths. Critical behaviour was untested: HMAC signature correctness against a reference computation, the exact `INSERT INTO webhooks` parameters, the `X-Webhook-Signature` header sent on delivery, delivery-attempt persistence (`INSERT INTO webhook_deliveries` with a JSON-stringified payload), exhaustion of retries when the endpoint is down, and the empty-recipient short-circuit in `deliverEscrowWebhooks`. A local patch cannot fix this: the gap is fundamental (no coverage of the retry/failure contract), and only exercising the exported entry points closes it.

## 3. Solution Comparison and Decision
- **Option A — Test only through the route suite (#1327):** the route mocks `registerWebhook`, so the service's delivery/retry/signature behaviour stays uncovered. Rejected: route tests and service tests test different layers.
- **Option B — Rewrite the existing test file from scratch:** discards the 4 existing passing tests and churns review. Rejected: preserves existing coverage.
- **Option C (chosen) — Extend the existing file:** keep the original 4 tests verbatim (restructured into `describe` blocks) and add targeted tests for signatures, persistence, retry exhaustion, and short-circuits. axios is mocked so no network I/O happens; the pool is a shared `jest.fn()` (same pattern as before and as `escrowService.test.js`).

## 4. The Change (Code modifications)
`backend/src/services/webhookService.test.js`: 4 tests → 10 tests.

| Entry point | New / extended coverage |
| --- | --- |
| `buildSignature` | deterministic HMAC-SHA256 hex, matches reference `crypto.createHmac` output, changes when secret/payload change |
| `registerWebhook` | asserts the `INSERT INTO webhooks` SQL and exact parameter array |
| `deliverSingleWebhook` | first-attempt success with `X-Webhook-Signature` + `Content-Type` headers; delivery attempt persisted with JSON payload; **failure exhaustion** (success `false`, `MAX_RETRIES` attempts, last status `failed`) |
| `deliverEscrowWebhooks` | empty-recipient short-circuit (no DB query, no POSTs), no-matching-webhook case, fan-out to subscribers |

Key assertion for the signature header sent on delivery:

```js
expect(config.headers["X-Webhook-Signature"]).toBe(
  buildSignature(SECRET, JSON.stringify(payload)),
);
```

## 5. Compatibility Note (On INTERFACE_VERSION)
No interface version exists or is modified — this PR only changes a test file. No service, route, or middleware code is touched.

## 6. Incidental Fixes
- The existing "builds a deterministic HMAC-SHA256 signature" test only checked format (length/hex); it now also pins the value against a reference HMAC computation and proves inputs changes alter the output.
- Confirmed the internal helpers `listWebhooksForEvent` / `recordWebhookDeliveryAttempt` are exercised through the exported entry points rather than adding exports purely for tests (keeps the production module untouched).

## 7. Testing (Proving it works)
Key test names:
- `buildSignature — builds a deterministic HMAC-SHA256 signature` (length, hex, determinism, reference HMAC)
- `registerWebhook — inserts the webhook with the expected columns and parameters`
- `deliverSingleWebhook — delivers on the first attempt with an HMAC signature header`
- `deliverSingleWebhook — reports failure after exhausting all attempts`
- `deliverEscrowWebhooks — returns no deliveries without querying when no user addresses are given`

Before: `npx jest src/services/webhookService.test.js` → 4 tests.
After: `npx jest src/services/webhookService.test.js` → **1 suite passed, 10 tests passed**; `npx eslint` clean.

Pre-existing failures: none introduced. The suite runs in CI's unit step which currently reports unrelated pre-existing failures with `continue-on-error` (jest/axios ESM interop with @stellar/stellar-sdk, pool-mock gaps).

## 8. Additional Notes (Note on the first commit / Scope)
Single commit: `test(services): add unit tests for webhookService`. Scope is strictly the one test file — no production code modified.