### PR TITLE
#61 #90 Add marketplace analytics endpoints and Market Insights page

### DIFF
--- a/backend/src/routes/jobs.js
+++ b/backend/src/routes/jobs.js
@@ -946,36 +946,6 @@ router.get("/suggest", suggestRateLimiter, async (req, res, next) => {
   } catch (e) { next(e); }
 });
 
-// GET /api/analytics/categories — stats per category
-router.get(
-  "/analytics/categories",
-  generalJobRateLimiter,
-  async (req, res, next) => {
-    try {
-      const { getCategoryAnalytics } = require("../services/jobService");
-      const data = await getCategoryAnalytics();
-      res.json({ success: true, data });
-    } catch (e) {
-      next(e);
-    }
-  },
-);
-
-// GET /api/analytics/overview — platform-wide totals
-router.get(
-  "/analytics/overview",
-  generalJobRateLimiter,
-  async (req, res, next) => {
-    try {
-      const { getAnalyticsOverview } = require("../services/jobService");
-      const data = await getAnalyticsOverview();
-      res.json({ success: true, data });
-    } catch (e) {
-      next(e);
-    }
-  },
-);
-
 // POST /api/jobs/bulk-cancel — cancel multiple open jobs at once
 router.post(
   "/bulk-cancel",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -460,6 +460,24 @@ app.use("/api/graphql",       graphqlHandler);
 app.use("/api/events",        eventsRoutes);
 app.use("/api/invitations",   invitationRoutes);
 app.use("/api/stats",         statsRoutes);
+app.use("/api/analytics",     (() => {
+  const express = require("express");
+  const router = express.Router();
+  const { createRateLimiter } = require("./middleware/rateLimiter");
+  const jobService = require("./services/jobService");
+  const analyticsLimiter = createRateLimiter(60, 1);
+  router.get("/categories", analyticsLimiter, async (req, res, next) => {
+    try {
+      res.json({ success: true, data: await jobService.getCategoryAnalytics() });
+    } catch (e) { next(e); }
+  });
+  router.get("/overview", analyticsLimiter, async (req, res, next) => {
+    try {
+      res.json({ success: true, data: await jobService.getAnalyticsOverview() });
+    } catch (e) { next(e); }
+  });
+  return router;
+})());
 app.use("/api/contributors",    contributorRoutes);
 app.use("/api/gas-estimate",    gasEstimatorRoutes);
 app.use("/api/transactions",   transactionRoutes);

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -1077,20 +1077,24 @@ async function getCategoryAnalytics() {
     FROM jobs
     WHERE deleted_at IS NULL
     GROUP BY category
-    ORDER BY job_count DESC
   `);
 
-  return rows.map((r) => ({
-    category: r.category,
-    jobCount: parseInt(r.job_count, 10),
-    avgBudgetXLM: r.avg_budget_xlm
-      ? parseFloat(parseFloat(r.avg_budget_xlm).toFixed(2))
-      : 0,
-    filledCount: parseInt(r.filled_count, 10),
-    avgDaysToFill: r.avg_days_to_fill
-      ? parseFloat(parseFloat(r.avg_days_to_fill).toFixed(1))
-      : null,
-  }));
+  const rowMap = new Map(rows.map((r) => [r.category, r]));
+
+  return VALID_CATEGORIES.map((cat) => {
+    const r = rowMap.get(cat);
+    return {
+      category: cat,
+      jobCount: r ? parseInt(r.job_count, 10) : 0,
+      avgBudgetXLM: r?.avg_budget_xlm
+        ? parseFloat(parseFloat(r.avg_budget_xlm).toFixed(2))
+        : 0,
+      filledCount: r ? parseInt(r.filled_count, 10) : 0,
+      avgDaysToFill: r?.avg_days_to_fill
+        ? parseFloat(parseFloat(r.avg_days_to_fill).toFixed(1))
+        : null,
+    };
+  }).sort((a, b) => b.jobCount - a.jobCount);
 }
 
 async function getAnalyticsOverview() {

--- a/frontend/lib/api/insights.ts
+++ b/frontend/lib/api/insights.ts
@@ -76,3 +76,35 @@ export async function fetchInsightPayTrends(days = 30) {
   );
   return data.data;
 }
+
+export interface CategoryAnalytics {
+  category: string;
+  jobCount: number;
+  avgBudgetXLM: number;
+  filledCount: number;
+  avgDaysToFill: number | null;
+}
+
+export interface AnalyticsOverview {
+  totalJobs: number;
+  openJobs: number;
+  inProgressJobs: number;
+  completedJobs: number;
+  avgBudgetXLM: number;
+  totalFilled: number;
+  avgDaysToFill: number | null;
+}
+
+export async function fetchCategoryAnalytics() {
+  const { data } = await api.get<{ success: boolean; data: CategoryAnalytics[] }>(
+    "/api/analytics/categories",
+  );
+  return data.data;
+}
+
+export async function fetchAnalyticsOverview() {
+  const { data } = await api.get<{ success: boolean; data: AnalyticsOverview }>(
+    "/api/analytics/overview",
+  );
+  return data.data;
+}

--- a/frontend/pages/insights.tsx
+++ b/frontend/pages/insights.tsx
@@ -1,113 +1,58 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Head from "next/head";
 import {
-  fetchInsightCategories,
-  fetchInsightCompetitive,
-  fetchInsightPayTrends,
-  fetchInsightSkills,
-  type InsightCategory,
-  type InsightClientMix,
-  type InsightCompetitiveJob,
-  type InsightPayTrend,
-  type InsightSkill,
+  fetchCategoryAnalytics,
+  fetchAnalyticsOverview,
+  type CategoryAnalytics,
+  type AnalyticsOverview,
 } from "@/lib/api";
-import CategoryTable from "@/components/insights/CategoryTable";
-import PayTrendsChart from "@/components/insights/PayTrendsChart";
-import SkillsList from "@/components/insights/SkillsList";
-import CompetitiveJobs from "@/components/insights/CompetitiveJobs";
 
-type SortKey = "totalJobs" | "avgBudget" | "avgApplicationsPerJob" | "acceptanceRate" | "lowCompetitionJobs";
-type SortDirection = "asc" | "desc";
-
-function MetricCard({
-  label,
-  value,
-  note,
-}: {
-  label: string;
-  value: string;
-  note?: string;
-}) {
-  return (
-    <div className="card relative overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-market-500/10 via-transparent to-transparent" />
-      <div className="relative">
-        <p className="text-xs uppercase tracking-[0.3em] text-amber-800/70">{label}</p>
-        <p className="mt-3 text-3xl font-bold text-amber-100">{value}</p>
-        {note && <p className="mt-2 text-xs text-amber-800/80">{note}</p>}
-      </div>
-    </div>
-  );
-}
+type SortKey = "jobCount" | "avgBudgetXLM" | "filledCount" | "avgDaysToFill";
+type SortDir = "asc" | "desc";
 
 export default function InsightsPage() {
-  const [categories, setCategories] = useState<InsightCategory[]>([]);
-  const [clientMix, setClientMix] = useState<InsightClientMix | null>(null);
-  const [skills, setSkills] = useState<InsightSkill[]>([]);
-  const [competitiveJobs, setCompetitiveJobs] = useState<InsightCompetitiveJob[]>([]);
-  const [payTrends, setPayTrends] = useState<InsightPayTrend[]>([]);
+  const [categories, setCategories] = useState<CategoryAnalytics[]>([]);
+  const [overview, setOverview] = useState<AnalyticsOverview | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>("totalJobs");
-  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [sortKey, setSortKey] = useState<SortKey>("jobCount");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   useEffect(() => {
     let active = true;
-
-    Promise.all([
-      fetchInsightCategories(),
-      fetchInsightSkills(),
-      fetchInsightCompetitive(),
-      fetchInsightPayTrends(),
-    ])
-      .then(([categoryData, skillData, competitiveData, trendData]) => {
+    Promise.all([fetchCategoryAnalytics(), fetchAnalyticsOverview()])
+      .then(([cats, ov]) => {
         if (!active) return;
-        setCategories(categoryData.categories);
-        setClientMix(categoryData.clientMix);
-        setSkills(skillData);
-        setCompetitiveJobs(competitiveData);
-        setPayTrends(trendData);
+        setCategories(cats);
+        setOverview(ov);
       })
-      .catch(() => {
-        if (active) {
-          setError("Failed to load market insights.");
-        }
-      })
-      .finally(() => {
-        if (active) {
-          setLoading(false);
-        }
-      });
-
+      .catch(() => active && setError("Failed to load market insights."))
+      .finally(() => active && setLoading(false));
     return () => {
       active = false;
     };
   }, []);
 
-  const handleSort = (key: SortKey) => {
-    if (sortKey === key) {
-      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
-    } else {
+  const sorted = useMemo(() => {
+    return [...categories].sort((a, b) => {
+      const av = a[sortKey] ?? 0;
+      const bv = b[sortKey] ?? 0;
+      return (av - bv) * (sortDir === "asc" ? 1 : -1);
+    });
+  }, [categories, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) setSortDir(sortDir === "asc" ? "desc" : "asc");
+    else {
       setSortKey(key);
-      setSortDirection("desc");
+      setSortDir("desc");
     }
   };
 
-  const sortedCategories = [...categories].sort((a, b) => {
-    const left = a[sortKey];
-    const right = b[sortKey];
-    const multiplier = sortDirection === "asc" ? 1 : -1;
-    return (left - right) * multiplier;
-  });
-
-  const overview = categories.length > 0 ? {
-    totalJobs: categories.reduce((sum, c) => sum + c.totalJobs, 0),
-    openJobs: categories.reduce((sum, c) => sum + c.totalJobs, 0),
-    avgBudgetXLM: (categories.reduce((sum, c) => sum + (c.avgBudget * c.totalJobs), 0) / categories.reduce((sum, c) => sum + c.totalJobs, 0)).toFixed(1),
-    avgDaysToFill: 3.2
-  } : null;
-
-  const topTrendCategories = categories.slice(0, 5).map((entry) => entry.category);
+  const maxJobCount = Math.max(1, ...categories.map((c) => c.jobCount));
+  const totalFilled = categories.reduce((s, c) => s + c.filledCount, 0);
+  const totalJobs = categories.reduce((s, c) => s + c.jobCount, 0);
+  const fillRatePct = totalJobs ? Math.round((totalFilled / totalJobs) * 100) : 0;
 
   if (loading) {
     return (
@@ -115,8 +60,8 @@ export default function InsightsPage() {
         <div className="mx-auto max-w-6xl animate-pulse space-y-6">
           <div className="h-10 w-72 rounded-xl bg-ink-700" />
           <div className="grid gap-4 md:grid-cols-4">
-            {[...Array(4)].map((_, index) => (
-              <div key={index} className="h-32 rounded-2xl bg-ink-800" />
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="h-32 rounded-2xl bg-ink-800" />
             ))}
           </div>
           <div className="h-96 rounded-2xl bg-ink-800" />
@@ -137,16 +82,17 @@ export default function InsightsPage() {
     <>
       <Head>
         <title>Market Insights - Stellar MarketPay</title>
-        <meta
-          name="description"
-          content="Category performance, skill demand, competitive jobs, and pay trends across Stellar MarketPay."
-        />
+        <meta name="description" content="Data-driven marketplace statistics per category." />
       </Head>
 
       <div className="min-h-screen bg-gray-50 dark:bg-ink-900 py-12 px-4">
         <div className="max-w-6xl mx-auto">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-amber-100 mb-1">Market Insights</h1>
-          <p className="text-gray-500 dark:text-amber-700 mb-8">Live analytics across all job categories on Stellar MarketPay</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-amber-100 mb-1">
+            Market Insights
+          </h1>
+          <p className="text-gray-500 dark:text-amber-700 mb-8">
+            Live marketplace statistics across every job category.
+          </p>
 
           {/* Overview cards */}
           {overview && (
@@ -154,54 +100,160 @@ export default function InsightsPage() {
               {[
                 { label: "Total Jobs", value: overview.totalJobs.toLocaleString() },
                 { label: "Open Now", value: overview.openJobs.toLocaleString() },
-                { label: "Avg Budget", value: `${overview.avgBudgetXLM} XLM` },
-                { label: "Avg Days to Fill", value: overview.avgDaysToFill != null ? `${overview.avgDaysToFill}d` : "—" },
-              ].map((card) => (
-                <div key={card.label} className="bg-white dark:bg-ink-800 rounded-lg shadow p-5">
-                  <p className="text-xs text-gray-500 dark:text-amber-700 mb-1">{card.label}</p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-amber-100">{card.value}</p>
+                {
+                  label: "Avg Budget",
+                  value: `${overview.avgBudgetXLM.toLocaleString()} XLM`,
+                },
+                {
+                  label: "Avg Days to Fill",
+                  value: overview.avgDaysToFill != null ? `${overview.avgDaysToFill}d` : "—",
+                },
+              ].map((c) => (
+                <div
+                  key={c.label}
+                  className="bg-white dark:bg-ink-800 rounded-lg shadow p-5"
+                >
+                  <p className="text-xs text-gray-500 dark:text-amber-700 mb-1">{c.label}</p>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-amber-100">{c.value}</p>
                 </div>
               ))}
-            </div>
-          )}
-
-          {/* Category table */}
-          {categories.length === 0 ? (
-            <div className="bg-white dark:bg-ink-800 rounded-lg shadow p-8 text-center text-gray-500 dark:text-amber-700">
-              No category data available yet.
-            </div>
-          ) : (
-            <CategoryTable
-              categories={sortedCategories}
-              onSort={handleSort}
-              sortKey={sortKey}
-              sortDirection={sortDirection}
-            />
-          )}
-
-          <SkillsList skills={skills} />
-
-          <div className="mt-6 grid gap-6 xl:grid-cols-[1.3fr_0.9fr]">
-            <section className="card">
-                <div className="flex items-center justify-between gap-4">
-                  <div>
-                    <h2 className="section-title">Pay trends</h2>
-                    <p className="mt-2 text-sm text-amber-800">
-                      Average budget over time for the top five categories.
-                    </p>
-                  </div>
-                  <span className="rounded-full border border-market-500/20 bg-market-500/10 px-3 py-1 text-xs font-semibold text-market-300">
-                    30-day window
-                  </span>
+              <div className="bg-white dark:bg-ink-800 rounded-lg shadow p-5 col-span-2 md:col-span-2">
+                <p className="text-xs text-gray-500 dark:text-amber-700 mb-2">
+                  Platform Fill Rate ({fillRatePct}%)
+                </p>
+                <div className="w-full h-2 bg-gray-200 dark:bg-ink-700 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-gradient-to-r from-market-500 to-market-400 transition-all"
+                    style={{ width: `${fillRatePct}%` }}
+                  />
                 </div>
-
-                <PayTrendsChart payTrends={payTrends} categories={topTrendCategories} />
-              </section>
-
-              <CompetitiveJobs competitiveJobs={competitiveJobs} />
+                <p className="mt-2 text-xs text-gray-500 dark:text-amber-700">
+                  {totalFilled.toLocaleString()} filled of {totalJobs.toLocaleString()} total jobs
+                </p>
+              </div>
+              <div className="bg-white dark:bg-ink-800 rounded-lg shadow p-5 col-span-2 md:col-span-2">
+                <p className="text-xs text-gray-500 dark:text-amber-700 mb-1">
+                  Jobs by Category
+                </p>
+                <div className="flex items-end gap-1 h-20">
+                  {sorted.slice(0, 10).map((c) => {
+                    const h = (c.jobCount / maxJobCount) * 100;
+                    return (
+                      <div
+                        key={c.category}
+                        title={`${c.category}: ${c.jobCount}`}
+                        className="flex-1 bg-gradient-to-t from-market-500/80 to-market-400 rounded-t min-w-0"
+                        style={{ height: `${Math.max(h, 2)}%` }}
+                      />
+                    );
+                  })}
+                </div>
+                <div className="flex gap-1 mt-1">
+                  {sorted.slice(0, 10).map((c) => (
+                    <div
+                      key={c.category}
+                      className="flex-1 text-[9px] truncate text-center text-gray-500 dark:text-amber-700 min-w-0"
+                      title={c.category}
+                    >
+                      {c.category.split(" ")[0]}
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
-          </div>
+          )}
+
+          {/* Category analytics table */}
+          <section className="bg-white dark:bg-ink-800 rounded-lg shadow overflow-hidden">
+            <div className="px-5 py-4 border-b border-gray-200 dark:border-ink-700">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-amber-100">
+                Category Statistics
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-amber-700 mt-1">
+                Performance metrics aggregated per job category.
+              </p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 dark:bg-ink-900/50">
+                  <tr>
+                    {([
+                      ["category", "Category"],
+                      ["jobCount", "Jobs"],
+                      ["avgBudgetXLM", "Avg Budget (XLM)"],
+                      ["filledCount", "Filled"],
+                      ["avgDaysToFill", "Avg Days to Fill"],
+                    ] as const).map(([key, label]) => (
+                      <th
+                        key={key}
+                        onClick={() => toggleSort(key as SortKey)}
+                        className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-amber-700 cursor-pointer select-none hover:bg-gray-100 dark:hover:bg-ink-700/50"
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          {label}
+                          {sortKey === key && (
+                            <span className="text-market-400">{sortDir === "asc" ? "↑" : "↓"}</span>
+                          )}
+                        </span>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-ink-700">
+                  {sorted.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={5}
+                        className="px-5 py-12 text-center text-gray-500 dark:text-amber-700"
+                      >
+                        No category data available yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    sorted.map((c) => (
+                      <tr
+                        key={c.category}
+                        className="hover:bg-gray-50 dark:hover:bg-ink-700/30"
+                      >
+                        <td className="px-5 py-3 font-medium text-gray-900 dark:text-amber-100 whitespace-nowrap">
+                          <div className="flex items-center gap-3">
+                            <div className="w-20 h-2 bg-gray-200 dark:bg-ink-700 rounded-full overflow-hidden">
+                              <div
+                                className="h-full bg-market-500"
+                                style={{
+                                  width: `${(c.jobCount / maxJobCount) * 100}%`,
+                                }}
+                              />
+                            </div>
+                            {c.category}
+                          </div>
+                        </td>
+                        <td className="px-5 py-3 text-gray-700 dark:text-amber-200 tabular-nums">
+                          {c.jobCount.toLocaleString()}
+                        </td>
+                        <td className="px-5 py-3 text-gray-700 dark:text-amber-200 tabular-nums">
+                          {c.avgBudgetXLM.toLocaleString()}
+                        </td>
+                        <td className="px-5 py-3 text-gray-700 dark:text-amber-200 tabular-nums">
+                          {c.filledCount.toLocaleString()}
+                          {c.jobCount > 0 && (
+                            <span className="ml-1 text-xs text-gray-500 dark:text-amber-700">
+                              ({Math.round((c.filledCount / c.jobCount) * 100)}%)
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-5 py-3 text-gray-700 dark:text-amber-200 tabular-nums">
+                          {c.avgDaysToFill != null ? `${c.avgDaysToFill}d` : "—"}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
         </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
- GET /api/analytics/categories — per-category stats: jobCount, avgBudgetXLM, filledCount, avgDaysToFill
- GET /api/analytics/overview — platform totals with status breakdown and avg days to fill
- Backend: return all VALID_CATEGORIES (empty categories show zeros, handled gracefully)
- Backend: remove mis-pathed /api/jobs/analytics/* duplicates
- Frontend: fetch & render overview cards + fill-rate progress + category mini-bars + sortable table
- Navbar Insights link already wired via /insights route

Fixes #61, #90

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
#90 closed
