### PR TITLE
fix: pass accepted bid amount to escrow update

### DIFF
--- a/backend/src/routes/jobs.js
+++ b/backend/src/routes/jobs.js
@@ -559,7 +559,15 @@ router.patch(
   async (req, res, next) => {
     try {
       const { escrowContractId } = validate(updateEscrowSchema, req.body);
-      const job = await updateJobEscrowId(req.params.id, escrowContractId);
+      const pool = require("../db/pool");
+      const { rows: acceptedApplications } = await pool.query(
+        "SELECT bid_amount FROM applications WHERE job_id = $1 AND status = 'accepted' LIMIT 1",
+        [req.params.id],
+      );
+      const options = acceptedApplications.length
+        ? { amount: acceptedApplications[0].bid_amount }
+        : {};
+      const job = await updateJobEscrowId(req.params.id, escrowContractId, options);
       await logContractInteraction({
         functionName: "create_escrow",
         callerAddress: req.user.publicKey,

--- a/backend/src/services/jobService.test.js
+++ b/backend/src/services/jobService.test.js
@@ -466,6 +466,27 @@ describe("jobService", () => {
       expect(updated.escrowContractId).toBe("CONTRACT123");
     });
 
+    it("uses an explicit escrow amount when provided", async () => {
+      const job = await createJob({
+        title: "Escrow amount test job",
+        description: "Description format that is long enough to pass validation.",
+        budget: "100",
+        category: "Frontend Development",
+        clientAddress: validClientAddress,
+        currency: "XLM",
+      });
+
+      const updated = await updateJobEscrowId(job.id, "CONTRACT123", { amount: "75.5000000" });
+
+      expect(updated.escrowContractId).toBe("CONTRACT123");
+      const escrowInsert = pool.query.mock.calls.find(([sql]) =>
+        sql.includes("INSERT INTO escrows"),
+      );
+      expect(escrowInsert[1]).toEqual(
+        expect.arrayContaining(["75.5000000"]),
+      );
+    });
+
     it("rejects invalid escrow contract ID", async () => {
       await expect(updateJobEscrowId("job-1", "")).rejects.toThrow("Invalid escrow contract ID");
     });


### PR DESCRIPTION


## Summary
- Looks up the accepted application when escrow is recorded.
- Passes the accepted bid amount to updateJobEscrowId so escrow uses the agreed price instead of the original budget.
- Preserves budget fallback when no application has been accepted.

## Scope
Does not touch frontend TypeScript errors, escrow fallback behavior, or unrelated application flows.

## Testing
- npm run lint — passed with existing warnings.
- npm test -- --runInBand src/services/jobService.test.js — focused tests passed; Jest exits non-zero because existing coverage thresholds are evaluated for untested services.
- npx jest --selectProjects unit --forceExit — pre-existing failures remain, including sanitize-html ESM parsing and database/environment-dependent tests.

## Files changed
- backend/src/routes/jobs.js — forwards the accepted bid amount during escrow recording.
- backend/src/services/jobService.test.js — verifies explicit escrow amounts are honored.

Closes #1130