### PR TITLE
docs: clarify frontend contract error handling

### DIFF
--- a/docs/contract-errors.md
+++ b/docs/contract-errors.md
@@ -188,6 +188,40 @@ the corresponding `panic!` message, and a human-readable description.
 
 ---
 
+## Frontend Error-Handling Contract
+
+`frontend/lib/contractErrors.ts` is the frontend boundary between raw Soroban
+failures and user-facing messages. Keep these behaviors stable when adding or
+changing contract errors:
+
+1. **Normalize the wrapper first.** `getContractErrorCode()` removes the
+   `Error: ` and `HostError: ` prefixes, then recognizes both
+   `Error(Contract, #N)` and `Error(Contract, #N): <panic message>` forms.
+2. **Use `UNKNOWN` for code-only failures.** A Soroban error-table number is
+   not the application error enum, so `Error(Contract, #N)` maps to code `0`
+   rather than guessing a specific operation failure.
+3. **Prefer a localized message when a panic is known.**
+   `getContractErrorMessage()` selects `en`, `es`, or `fr`; unsupported locales
+   fall back to English. The unknown error has a locale-specific generic
+   message, while an unmapped numeric code gets an explicit diagnostic.
+4. **Preserve diagnostic text when parsing fails.** `parseContractError()`
+   returns the original raw error if neither the simulation wrapper nor the
+   panic message matches a known contract error. This prevents useful provider
+   diagnostics from being discarded.
+
+When adding a new contract error, update all three message maps and the
+`PANIC_TO_CODE` map together. Also update the canonical Rust error reference
+above and verify the frontend typecheck before opening a PR.
+
+### Examples
+
+| Input | Result |
+|-------|--------|
+| `Error(Contract, #1)` | Generic localized contract message |
+| `Error(Contract, #1): Escrow not found` | Escrow-not-found message |
+| `Soroban simulation failed: Bidding is closed` | Bidding-closed message |
+| `Provider unavailable` | Original provider diagnostic |
+
 ## Usage in Frontend
 
 ```typescript


### PR DESCRIPTION


## Summary
- Documents how the frontend normalizes Soroban error wrappers before mapping them.
- Explains why code-only contract failures use UNKNOWN instead of guessing an application error.
- Records locale fallback behavior and preservation of unmapped provider diagnostics.
- Adds examples and maintenance guidance for keeping the Rust and frontend error references synchronized.

## Scope
This PR is documentation-only. The original TypeScript implementation fix is already present upstream in commit 786d1bf; no duplicate implementation changes are made.

## Testing
- npm run type-check — passed.
- npm run lint — passed with existing warnings.
- git diff --check — passed.

## Files changed
- docs/contract-errors.md — documents the frontend contract-error handling behavior related to #1107.

Closes #1107