### PR TITLE
feat(security): add gitleaks pre-commit hook and allowlist configuration

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -32,6 +32,9 @@ title = "Stellar MarketPay Gitleaks Configuration"
   # could never match a connection-string pattern.
   regexTarget = "line"
   regexes = [
+    '''G[A-Z2-7]{55}''',
+    '''TEST_SECRET_KEY_.*''',
+    '''S[A-Z2-7]{55}testmock.*''',
     '''postgresql://test:test@localhost:\d+/\w+''',
     '''postgresql://postgres:postgres@localhost:\d+/\w+''',
     '''ci-test-[a-z-]*(secret|key)[a-z0-9-]*''',

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -33,7 +33,8 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   fi
 fi
 
-gitleaks detect --source . --config .gitleaks.toml --verbose --no-git --staged
+# Run gitleaks on staged files
+gitleaks protect -v --staged --config .gitleaks.toml
 gitleaks_status=$?
 
 if [ "$gitleaks_status" -ne 0 ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,25 @@ Stellar MarketPay is a decentralized freelance marketplace built on the Stellar 
 
 ## Prerequisites
 
-| Tool             | Minimum Version | Notes                                                                  |
+### Secrets Scanning (Gitleaks)
+
+We use [Gitleaks](https://github.com/gitleaks/gitleaks) in our `husky` pre-commit hook to prevent accidental commits of API keys, Stellar secret keys, and other sensitive information.
+
+**Installation:**
+You must install gitleaks locally for the pre-commit hook to work effectively.
+
+- **macOS (Homebrew):**
+  ```bash
+  brew install gitleaks
+  ```
+- **Linux/Windows (Go):**
+  ```bash
+  go install github.com/gitleaks/gitleaks/v8@latest
+  ```
+
+*Note: If gitleaks detects a false positive, you can configure exceptions in the `.gitleaks.toml` file under the `[allowlist]` section.*
+
+### Required Tools
 | ---------------- | --------------- | ---------------------------------------------------------------------- |
 | Node.js          | 18.x            | [nodejs.org](https://nodejs.org)                                       |
 | npm              | 9.x             | Included with Node                                                     |


### PR DESCRIPTION
## Title
feat(security): add secrets scanning pre-commit hook with gitleaks 
Closes #822 

## Description
This PR introduces local pre-commit secret scanning via [Gitleaks](https://github.com/gitleaks/gitleaks) integrated into our Husky pre-commit hook. Catching secrets (such as API keys, Stellar private secret keys, and tokens) locally before they are committed provides immediate developer feedback and prevents credential leaks before code reaches remote branches or CI.

Closes #822

---

## Acceptance Criteria Verification

- [x] **Add gitleaks to the husky pre-commit hook**: `.husky/pre-commit` configured to run `gitleaks protect -v --staged --config .gitleaks.toml` on staged changes.
- [x] **Configure `.gitleaks.toml` with project-specific allow-list**: Added allow-list regex patterns for Stellar public key wallet addresses (`G[A-Z2-7]{55}`), test keys (`TEST_SECRET_KEY_.*`), and mock secret seeds (`S[A-Z2-7]{55}testmock.*`).
- [x] **Document how to install gitleaks in `CONTRIBUTING.md`**: Added a dedicated *Secrets Scanning (Gitleaks)* section under Prerequisites with installation instructions for Homebrew and Go.
- [x] **Faster local feedback**: Blocks commits containing un-allowlisted secret patterns prior to pushing to CI.

---

## Changes Made

- **`.husky/pre-commit`**: Integrated `gitleaks protect` to scan staged files with fallback instructions if Gitleaks is not installed locally.
- **`.gitleaks.toml`**: Expanded `[allowlist]` regexes to ignore false positives from public Stellar addresses and test fixture keys.
- **`CONTRIBUTING.md`**: Added Gitleaks installation instructions (`brew install gitleaks` / `go install ...`) and instructions for configuring false positive overrides.

---

