### PR TITLE
test: fix websocket chaos suite and harden ws lifecycle (#1088)

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -587,6 +587,7 @@ wsServer.on("connection", async (ws, request) => {
       realtimeClients.delete(ws);
       setWebsocketConnections("realtime", realtimeClients.size);
       if (userAddress) {
+        userLastSeen.set(userAddress, new Date());
         const sockets = userClients.get(userAddress);
         if (sockets) {
           sockets.delete(ws);
@@ -679,19 +680,23 @@ wsServer.on("connection", async (ws, request) => {
 
     ws.on("close", async () => {
       clients.delete(ws);
-      refreshWsMetrics();
-      const freshSession = await loadScopeSession(sessionId);
-      if (!freshSession) return;
-      const nextCursors = { ...(freshSession.cursors || {}) };
-      delete nextCursors[participantId];
-      await upsertScopeSession(sessionId, {
-        content: freshSession.content || "",
-        cursors: nextCursors,
-        finalized: freshSession.finalized,
-        finalizedHash: freshSession.finalized_hash || null,
-        finalizedPayload: freshSession.finalized_payload || null,
-      });
       if (!clients.size) scopeSessionClients.delete(sessionId);
+      refreshWsMetrics();
+      try {
+        const freshSession = await loadScopeSession(sessionId);
+        if (!freshSession) return;
+        const nextCursors = { ...(freshSession.cursors || {}) };
+        delete nextCursors[participantId];
+        await upsertScopeSession(sessionId, {
+          content: freshSession.content || "",
+          cursors: nextCursors,
+          finalized: freshSession.finalized,
+          finalizedHash: freshSession.finalized_hash || null,
+          finalizedPayload: freshSession.finalized_payload || null,
+        });
+      } catch {
+        /* ignore close cleanup errors */
+      }
     });
   }
 });
@@ -1034,24 +1039,16 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 // Expose WebSocket internals for testing
-app._ws = {
-  server,
-  wsServer,
-  realtimeClients,
-  userClients,
-  userLastSeen,
-  scopeSessionClients,
-  broadcastRealtime,
-  broadcastToUser,
-};
-
-app.startEscrowTimeoutChecker = startEscrowTimeoutChecker;
-
-// Expose WebSocket internals for tests
 app._ws = wsServer;
 app._ws.server = server;
+app._ws.wsServer = wsServer;
 app._ws.realtimeClients = realtimeClients;
 app._ws.userClients = userClients;
+app._ws.userLastSeen = userLastSeen;
 app._ws.scopeSessionClients = scopeSessionClients;
+app._ws.broadcastRealtime = broadcastRealtime;
+app._ws.broadcastToUser = broadcastToUser;
+
+app.startEscrowTimeoutChecker = startEscrowTimeoutChecker;
 
 module.exports = app;

--- a/backend/src/services/websocket.chaos.test.js
+++ b/backend/src/services/websocket.chaos.test.js
@@ -1,7 +1,7 @@
 /**
  * src/services/websocket.chaos.test.js
  *
- * Issue #888 — Chaos/reconnection resilience tests for the WebSocket server.
+ * Issue #888 / #1088 — Chaos/reconnection resilience tests for the WebSocket server.
  *
  * Covers:
  *   1. Random connection kills x10  →  verify client reconnects every time
@@ -137,19 +137,32 @@ function userToken(userAddress) {
   return jwt.sign({ publicKey: userAddress }, process.env.JWT_SECRET);
 }
 
+let port;
+const openClients = new Set();
+
 /**
  * Create a new WS client, wire up message capture, and attach helpers.
  */
-function wsConnect(userAddress, { port, path = "/ws/realtime" } = {}) {
+function wsConnect(userAddress, { port: portArg, path = "/ws/realtime" } = {}) {
+  const targetPort = portArg || port;
   const sep = path.includes("?") ? "&" : "?";
   const token = userAddress ? `${sep}token=${userToken(userAddress)}` : "";
-  const ws = new WsClient(`ws://localhost:${port}${path}${token}`);
+  const ws = new WsClient(`ws://localhost:${targetPort}${path}${token}`);
+  openClients.add(ws);
+  ws.on("close", () => openClients.delete(ws));
+  ws.on("error", () => {
+    // ignore intentional connection kills
+  });
   const messages = [];
   const messageCallbacks = [];
   ws.on("message", (data) => {
-    const parsed = JSON.parse(data.toString());
-    messages.push(parsed);
-    messageCallbacks.forEach((cb) => cb(parsed));
+    try {
+      const parsed = JSON.parse(data.toString());
+      messages.push(parsed);
+      messageCallbacks.forEach((cb) => cb(parsed));
+    } catch (_err) {
+      // non-JSON message
+    }
   });
   ws._messages = messages;
   ws._waitForMessage = (filter, timeoutMs = 500) => {
@@ -161,9 +174,12 @@ function wsConnect(userAddress, { port, path = "/ws/realtime" } = {}) {
         if (idx !== -1) messageCallbacks.splice(idx, 1);
         reject(new Error("Timed out waiting for WebSocket message"));
       }, timeoutMs);
+      if (typeof timer.unref === "function") timer.unref();
       const onMsg = (msg) => {
         if (filter(msg)) {
           clearTimeout(timer);
+          const idx = messageCallbacks.indexOf(onMsg);
+          if (idx !== -1) messageCallbacks.splice(idx, 1);
           resolve(msg);
         }
       };
@@ -201,28 +217,81 @@ function seededShuffle(arr, seed) {
 // ── Test Suite ────────────────────────────────────────────────────────────
 
 describe("WebSocket chaos & reconnection resilience (#888)", () => {
-  let port;
   let server;
 
   beforeAll(async () => {
     server = app._ws.server;
-    // bootstrap() already called server.listen() — just wait for readiness
-    await new Promise((resolve) => {
-      if (server.listening) return resolve();
-      server.once("listening", resolve);
-    });
+    // bootstrap() is skipped in NODE_ENV=test — bind an ephemeral port ourselves.
+    if (!server.listening) {
+      await new Promise((resolve) => server.listen(0, resolve));
+    }
     port = server.address().port;
   }, 10_000);
 
   afterAll(() => {
-    server.close();
+    for (const ws of openClients) {
+      try {
+        ws.terminate();
+      } catch (_err) {
+        // ignore
+      }
+    }
+    openClients.clear();
+    for (const ws of app._ws.realtimeClients) {
+      try {
+        ws.terminate();
+      } catch (_err) {
+        // ignore
+      }
+    }
+    for (const set of app._ws.userClients.values()) {
+      for (const ws of set) {
+        try {
+          ws.terminate();
+        } catch (_err) {
+          // ignore
+        }
+      }
+    }
+    for (const set of app._ws.scopeSessionClients.values()) {
+      for (const ws of set) {
+        try {
+          ws.terminate();
+        } catch (_err) {
+          // ignore
+        }
+      }
+    }
+    if (server) {
+      if (typeof server.closeAllConnections === "function") {
+        try {
+          server.closeAllConnections();
+        } catch (_err) {
+          // ignore
+        }
+      }
+      try {
+        server.close();
+      } catch (_err) {
+        // ignore
+      }
+    }
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    for (const ws of openClients) {
+      try {
+        ws.terminate();
+      } catch (_err) {
+        // ignore
+      }
+    }
+    openClients.clear();
     app._ws.userClients.clear();
     app._ws.realtimeClients.clear();
     app._ws.scopeSessionClients.clear();
+    if (app._ws.userLastSeen) app._ws.userLastSeen.clear();
   });
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -297,7 +366,7 @@ describe("WebSocket chaos & reconnection resilience (#888)", () => {
       await ws1._waitForMessage((m) => m.event === "connected", 1_000);
 
       // Send several messages via the server's own broadcast
-      const broadcast = app.locals.broadcastRealtime;
+      const broadcast = app.locals.broadcastRealtime || app._ws.broadcastRealtime;
       const sentPayloads = [];
       for (let i = 0; i < 5; i++) {
         const payload = { id: i, text: `pre-kill-${i}`, ts: Date.now() };
@@ -348,7 +417,7 @@ describe("WebSocket chaos & reconnection resilience (#888)", () => {
     });
 
     test("no duplicate messages received after reconnection", async () => {
-      const broadcast = app.locals.broadcastRealtime;
+      const broadcast = app.locals.broadcastRealtime || app._ws.broadcastRealtime;
 
       // First connect
       const ws1 = wsConnect(TEST_USER_A, { port });
@@ -523,6 +592,7 @@ describe("WebSocket chaos & reconnection resilience (#888)", () => {
         timings.push(elapsed);
 
         ws2.close();
+        await new Promise((r) => setTimeout(r, 15));
       }
 
       // Build a useful failure message

--- a/backend/src/services/websocket.test.js
+++ b/backend/src/services/websocket.test.js
@@ -9,7 +9,7 @@ const TEST_USER_1 = "GAXJ4S6F7W2K3H5N8D9P0Q2R4T6V8W1Z3X5C7V9B2N4M6P8R0T2V4X6Z8";
 const TEST_USER_2 = "GBYJ4S6F7W2K3H5N8D9P0Q2R4T6V8W1Z3X5C7V9B2N4M6P8R0T2V4X6Z9";
 
 // ── Prevent process.exit from killing the test runner ─────────────────────
-const realExit = process.exit;
+const _realExit = process.exit;
 process.exit = jest.fn((code) => {
   const err = new Error(`process.exit called with ${code}`);
   Error.captureStackTrace(err, process.exit);
@@ -122,6 +122,7 @@ describe("WebSocket real-time notification delivery", () => {
     jest.clearAllMocks();
     app._ws.userClients.clear();
     app._ws.realtimeClients.clear();
+    if (app._ws.userLastSeen) app._ws.userLastSeen.clear();
   });
 
   function wsConnect(userAddress) {


### PR DESCRIPTION
## Summary

## Related Issue
Closes #1088


Fixes failing tests in `src/services/websocket.chaos.test.js` and hardens server-side WebSocket lifecycle and session management:
- **Test Server Startup**: Binds an ephemeral port (`server.listen(0)`) in `beforeAll` if not already listening, preventing timeouts in `NODE_ENV=test` where `bootstrap()` is skipped.
- **Port Resolution & Shadowing**: Resolves `targetPort = portArg || port` in `wsConnect` to prevent `ws://localhost:undefined` connection errors.
- **Unhandled Socket Errors**: Attaches `ws.on("error", () => {})` to all chaos test clients to handle abrupt socket terminations cleanly without unhandled `ECONNRESET` exceptions.
- **Deterministic Teardown**: Tracks all client socket instances in `openClients` and forcibly terminates remaining sockets in `afterEach` and `afterAll` to eliminate hanging handles and memory leaks.
- **Disconnect Tracking & Scope Session Cleanup**: Updates `server.js` to record disconnect timestamps in `userLastSeen` on socket close (for accurate notification replay upon reconnect) and ensures scope session in-memory maps are immediately pruned when active clients reach zero.

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change


## Testing
- [x] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [ ] Docs updated if needed

### Verification Steps Executed:
1. `cd backend && npx jest src/services/websocket.chaos.test.js --forceExit` — **9/9 tests passed** (10x chaos kills, in-flight message delivery & deduplication, dead connection cleanup, reconnection timing < 3s).
2. `cd backend && npx jest src/services/websocket.test.js --forceExit` — **5/5 tests passed** (real-time notification delivery, offline replay, broadcast isolation, connection limits, and CSRF integration).
3. `cd backend && npx jest __tests__/scope.websocket.test.js --forceExit` — **4/4 tests passed** (collaborative session initialization, real-time updates, and document finalization).
4. `cd backend && npx eslint src/services/websocket.chaos.test.js src/services/websocket.test.js src/server.js` — **0 errors, 0 warnings**.

## Screenshots (if UI change)
N/A (backend & test suite changes only)
