### PR TITLE
Closes #1153

### DIFF
--- a/backend/src/routes/ratings.test.js
+++ b/backend/src/routes/ratings.test.js
@@ -1,0 +1,322 @@
+"use strict";
+
+/**
+ * src/routes/ratings.test.js
+ *
+ * Route-level test suite for /api/ratings endpoints.
+ * Covers:
+ *   - POST /api/ratings (submit a rating) — guarded by verifyJWT
+ *   - GET /api/ratings/:publicKey (list ratings for a user) — public
+ *
+ * The DB pool is replaced with the shared pgMock. The ratingService is
+ * mocked at the module level so tests stay deterministic. CSRF is a
+ * passthrough in jest.setup.js, so a dummy "X-CSRF-Token" header is
+ * sufficient for mutating requests.
+ */
+
+jest.mock("../db/pool", () => {
+  const { createPgMock } = require("../testUtils/pgMock");
+  return createPgMock();
+});
+
+jest.mock("../services/ratingService", () => ({
+  createRating: jest.fn(),
+  getRatingsForUser: jest.fn(),
+}));
+
+const pool = require("../db/pool");
+const jwt = require("jsonwebtoken");
+const express = require("express");
+const request = require("supertest");
+const { JWT_SECRET } = require("../middleware/auth");
+const { defaultJobRow } = require("../testUtils/pgMock");
+const { createRating, getRatingsForUser } = require("../services/ratingService");
+const ratingRoutes = require("./ratings");
+
+// ── Minimal Express test app ─────────────────────────────────────────────────
+
+const app = express();
+app.use(express.json());
+app.use("/api/ratings", ratingRoutes);
+
+app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+  const status = err.statusCode || err.status || 500;
+  res.status(status).json({ error: err.message, code: err.code || "INTERNAL_ERROR" });
+});
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const RATER_ADDRESS = "G" + "A".repeat(55);
+const RATED_ADDRESS = "G" + "B".repeat(55);
+const OTHER_ADDRESS = "G" + "C".repeat(55);
+const JOB_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+function makeToken(publicKey = RATER_ADDRESS) {
+  return jwt.sign({ publicKey }, JWT_SECRET, { expiresIn: "1h" });
+}
+
+/** Seed a completed job where RATER_ADDRESS is the client and RATED_ADDRESS is the freelancer */
+function seedCompletedJob() {
+  const job = defaultJobRow({
+    id: JOB_ID,
+    status: "completed",
+    client_address: RATER_ADDRESS,
+    freelancer_address: RATED_ADDRESS,
+  });
+  pool.jobs.set(JOB_ID, job);
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe("Ratings Route Suite (/api/ratings)", () => {
+  beforeEach(() => {
+    pool.reset();
+    jest.clearAllMocks();
+  });
+
+  // ===========================================================================
+  // 1. POST /api/ratings — submit a rating (guarded by verifyJWT)
+  // ===========================================================================
+  describe("POST /api/ratings", () => {
+    const validBody = {
+      jobId: JOB_ID,
+      ratedAddress: RATED_ADDRESS,
+      stars: 5,
+      review: "Excellent work — delivered on time",
+    };
+
+    it("201 — happy path: submits a rating for a completed job", async () => {
+      seedCompletedJob();
+
+      const mockRating = {
+        id: "rating-1",
+        job_id: JOB_ID,
+        rater_address: RATER_ADDRESS,
+        rated_address: RATED_ADDRESS,
+        stars: 5,
+        review: "Excellent work — delivered on time",
+      };
+      createRating.mockResolvedValue(mockRating);
+
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send(validBody);
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual(mockRating);
+      expect(createRating).toHaveBeenCalledWith({
+        jobId: JOB_ID,
+        raterAddress: RATER_ADDRESS,
+        ratedAddress: RATED_ADDRESS,
+        stars: 5,
+        review: "Excellent work — delivered on time",
+      });
+    });
+
+    it("401 — rejects when no JWT is supplied", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("X-CSRF-Token", "dummy-token")
+        .send(validBody);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toMatch(/Unauthorized/);
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(createRating).not.toHaveBeenCalled();
+    });
+
+    it("401 — rejects an invalid / malformed JWT", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", "Bearer not.a.valid.jwt")
+        .set("X-CSRF-Token", "dummy-token")
+        .send(validBody);
+
+      expect(res.status).toBe(401);
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(createRating).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects when jobId is missing", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ ratedAddress: RATED_ADDRESS, stars: 5 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("jobId, ratedAddress and stars are required");
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects when ratedAddress is missing", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ jobId: JOB_ID, stars: 5 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("jobId, ratedAddress and stars are required");
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects when stars is missing", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ jobId: JOB_ID, ratedAddress: RATED_ADDRESS });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("jobId, ratedAddress and stars are required");
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects when stars is above 5", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ ...validBody, stars: 6 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("stars must be an integer between 1 and 5");
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects when stars is below 1", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ ...validBody, stars: 0 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("stars must be an integer between 1 and 5");
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects when stars is not a valid number", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ ...validBody, stars: "abc" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("stars must be an integer between 1 and 5");
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects when review exceeds 200 characters", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ ...validBody, review: "a".repeat(201) });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("review must be 200 characters or fewer");
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects self-rating", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ ...validBody, ratedAddress: RATER_ADDRESS });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Cannot rate yourself");
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("404 — rejects when job does not exist", async () => {
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send({ ...validBody, jobId: "nonexistent-job-id" });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("Job not found");
+      expect(createRating).not.toHaveBeenCalled();
+    });
+
+    it("400 — rejects when job is not completed", async () => {
+      const job = defaultJobRow({
+        id: JOB_ID,
+        status: "open",
+        client_address: RATER_ADDRESS,
+        freelancer_address: RATED_ADDRESS,
+      });
+      pool.jobs.set(JOB_ID, job);
+
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send(validBody);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Job must be completed before rating");
+      expect(createRating).not.toHaveBeenCalled();
+    });
+
+    it("403 — rejects when rater is not a job participant", async () => {
+      const job = defaultJobRow({
+        id: JOB_ID,
+        status: "completed",
+        client_address: OTHER_ADDRESS,
+        freelancer_address: RATED_ADDRESS,
+      });
+      pool.jobs.set(JOB_ID, job);
+
+      const res = await request(app)
+        .post("/api/ratings")
+        .set("Authorization", `Bearer ${makeToken()}`)
+        .set("X-CSRF-Token", "dummy-token")
+        .send(validBody);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("Only job participants can submit a rating");
+      expect(createRating).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // 2. GET /api/ratings/:publicKey — list ratings for a user (public)
+  // ===========================================================================
+  describe("GET /api/ratings/:publicKey", () => {
+    it("200 — returns ratings for a user", async () => {
+      const mockRatings = [
+        { id: "rating-1", job_id: JOB_ID, rated_address: RATED_ADDRESS, stars: 5 },
+        { id: "rating-2", job_id: "job-other", rated_address: RATED_ADDRESS, stars: 4 },
+      ];
+      getRatingsForUser.mockResolvedValue(mockRatings);
+
+      const res = await request(app).get(`/api/ratings/${RATED_ADDRESS}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual(mockRatings);
+      expect(getRatingsForUser).toHaveBeenCalledWith(RATED_ADDRESS);
+    });
+
+    it("200 — returns empty array when user has no ratings", async () => {
+      getRatingsForUser.mockResolvedValue([]);
+
+      const res = await request(app).get(`/api/ratings/${RATED_ADDRESS}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual([]);
+      expect(getRatingsForUser).toHaveBeenCalledWith(RATED_ADDRESS);
+    });
+  });
+});

--- a/backend/src/routes/verification.test.js
+++ b/backend/src/routes/verification.test.js
@@ -1,0 +1,239 @@
+"use strict";
+
+/**
+ * src/routes/verification.test.js
+ *
+ * Route-level test suite for /api/verification endpoints.
+ *
+ * Focuses on the Email Verification representative flow end-to-end:
+ *   - POST /api/verification/email (initiate email verification)
+ *   - POST /api/verification/email/confirm (confirm verification token)
+ *   - GET /api/verification/:publicKey (query user verification status)
+ *
+ * Findings on auth & guards (Step 1):
+ *   - None of the verification endpoints (/email, /email/confirm, /:publicKey)
+ *     are protected with authentication middleware (such as authenticateToken).
+ *   - They are public bootstrap routes, allowing users to request and confirm
+ *     verification links without requiring pre-existing authentication credentials.
+ *   - As a result, 401/403 auth rejection test cases are omitted for these routes.
+ *
+ * Finding on GET /:publicKey response shape (Step 1):
+ *   - When no verification record exists for a publicKey, the endpoint returns
+ *     HTTP 200 with default status:
+ *     { success: true, data: { emailVerified: false, phoneVerified: false, idVerified: false } }
+ *     (not a 404 status).
+ */
+
+// Scale rate limiting before requiring route modules
+process.env.RATE_LIMIT_SCALE = "1000";
+
+jest.mock("../db/pool", () => {
+  const { createPgMock } = require("../testUtils/pgMock");
+  return createPgMock();
+});
+
+const crypto = require("crypto");
+const express = require("express");
+const request = require("supertest");
+const pool = require("../db/pool");
+const verificationRoutes = require("./verification");
+
+// Setup minimal Express test application
+const app = express();
+app.use(express.json());
+app.use("/api/verification", verificationRoutes);
+
+// Structured error handler
+app.use((err, req, res, _next) => {
+  const status = err.statusCode || err.status || 500;
+  res.status(status).json({
+    error: err.message,
+    code: err.code || "INTERNAL_ERROR",
+  });
+});
+
+const VALID_PUBLIC_KEY = "G" + "A".repeat(55);
+const UNVERIFIED_PUBLIC_KEY = "G" + "B".repeat(55);
+const VALID_EMAIL = "developer@example.com";
+
+describe("Verification Route Suite (/api/verification)", () => {
+  beforeEach(() => {
+    pool.reset();
+    jest.clearAllMocks();
+  });
+
+  // =========================================================================
+  // 1. POST /api/verification/email
+  // =========================================================================
+  describe("POST /api/verification/email", () => {
+    it("200 — happy path: sends verification email with valid email and publicKey", async () => {
+      const res = await request(app)
+        .post("/api/verification/email")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({
+          email: VALID_EMAIL,
+          publicKey: VALID_PUBLIC_KEY,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        message: "Verification email sent",
+      });
+    });
+
+    it("400 — validation failure: rejects when email is missing", async () => {
+      const res = await request(app)
+        .post("/api/verification/email")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({
+          publicKey: VALID_PUBLIC_KEY,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Email and publicKey required");
+    });
+
+    it("400 — validation failure: rejects when publicKey is missing", async () => {
+      const res = await request(app)
+        .post("/api/verification/email")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({
+          email: VALID_EMAIL,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Email and publicKey required");
+    });
+
+    it("400 — validation failure: rejects empty request body", async () => {
+      const res = await request(app)
+        .post("/api/verification/email")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Email and publicKey required");
+    });
+  });
+
+  // =========================================================================
+  // 2. POST /api/verification/email/confirm
+  // =========================================================================
+  describe("POST /api/verification/email/confirm", () => {
+    it("200 — happy path: confirms verification with a valid token and updates status", async () => {
+      const TEST_TOKEN = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90";
+      jest
+        .spyOn(crypto, "randomBytes")
+        .mockReturnValueOnce(Buffer.from(TEST_TOKEN, "hex"));
+
+      // 1. Initiate email verification to register the token in memory
+      const initRes = await request(app)
+        .post("/api/verification/email")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({
+          email: "confirmed-user@example.com",
+          publicKey: VALID_PUBLIC_KEY,
+        });
+      expect(initRes.status).toBe(200);
+
+      // 2. Confirm verification with the minted token
+      const confirmRes = await request(app)
+        .post("/api/verification/email/confirm")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({
+          token: TEST_TOKEN,
+        });
+
+      expect(confirmRes.status).toBe(200);
+      expect(confirmRes.body).toEqual({
+        success: true,
+        message: "Email verified successfully",
+      });
+
+      // 3. Verify that GET /api/verification/:publicKey reflects updated status
+      const statusRes = await request(app).get(`/api/verification/${VALID_PUBLIC_KEY}`);
+      expect(statusRes.status).toBe(200);
+      expect(statusRes.body.success).toBe(true);
+      expect(statusRes.body.data).toMatchObject({
+        emailVerified: true,
+        phoneVerified: false,
+        idVerified: false,
+        email: "confirmed-user@example.com",
+      });
+      expect(statusRes.body.data.verifiedAt).toBeDefined();
+    });
+
+    it("400 — confirmation failure: rejects non-existent or invalid token (not-found token path)", async () => {
+      const res = await request(app)
+        .post("/api/verification/email/confirm")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({
+          token: "non-existent-token-value-12345",
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Invalid or expired token");
+    });
+
+    it("400 — confirmation failure: rejects when token is missing from body", async () => {
+      const res = await request(app)
+        .post("/api/verification/email/confirm")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Invalid or expired token");
+    });
+
+    it("400 — confirmation failure: rejects already consumed token (single-use enforcement)", async () => {
+      const SINGLE_USE_TOKEN = "f1e2d3c4b5a60718293a4b5c6d7e8f90f1e2d3c4b5a60718293a4b5c6d7e8f90";
+      jest
+        .spyOn(crypto, "randomBytes")
+        .mockReturnValueOnce(Buffer.from(SINGLE_USE_TOKEN, "hex"));
+
+      // Initiate
+      await request(app)
+        .post("/api/verification/email")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({
+          email: "single-use@example.com",
+          publicKey: VALID_PUBLIC_KEY,
+        });
+
+      // First confirmation succeeds
+      const firstConfirm = await request(app)
+        .post("/api/verification/email/confirm")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({ token: SINGLE_USE_TOKEN });
+      expect(firstConfirm.status).toBe(200);
+
+      // Second confirmation fails because token was deleted upon first use
+      const secondConfirm = await request(app)
+        .post("/api/verification/email/confirm")
+        .set("X-CSRF-Token", "dummy-csrf-token")
+        .send({ token: SINGLE_USE_TOKEN });
+      expect(secondConfirm.status).toBe(400);
+      expect(secondConfirm.body.error).toBe("Invalid or expired token");
+    });
+  });
+
+  // =========================================================================
+  // 3. GET /api/verification/:publicKey
+  // =========================================================================
+  describe("GET /api/verification/:publicKey", () => {
+    it("200 — not-found path: returns default unverified status when publicKey has no record", async () => {
+      const res = await request(app).get(`/api/verification/${UNVERIFIED_PUBLIC_KEY}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        data: {
+          emailVerified: false,
+          phoneVerified: false,
+          idVerified: false,
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds `backend/src/routes/ratings.test.js`, covering both endpoints in `backend/src/routes/ratings.js` (which previously had no test file):

- `POST /api/ratings` — happy path (201), auth rejection (401 for missing/malformed JWT), validation failures (400 for missing fields, invalid stars, review length, self-rating), not-found (404 for nonexistent job), and forbidden (403 for non-participant rater).
- `GET /api/ratings/:publicKey` — happy path with and without existing ratings.

Uses the repo's existing `src/testUtils/pgMock.js` pattern to mock the pool, and mocks `ratingService` directly where it performs transactions via `pool.connect()`. No changes to `ratings.js` were needed — it was testable as written.

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #1153

## Testing
- [ ] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [x] Docs updated if needed

Ran `backend/src/routes/ratings.test.js` in isolation — 16/16 tests pass. Ran the full backend test suite with and without the new file to confirm no regressions; failure counts differ only due to pre-existing flaky/timeout-based test suites already present in the baseline (unrelated to this change). Lint passes with 0 errors introduced.

## Screenshots (if UI change)
N/A — backend test-only change, no UI or Testnet interaction.
